### PR TITLE
fix: extract binary from tar.gz archive in npm postinstall script

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024-present Last9
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -309,11 +309,29 @@ Configure the Claude app to use the MCP server:
 4. Copy and paste the server config to your existing file, then save
 5. Restart Claude
 
+### If installed via Homebrew:
 ```json
 {
   "mcpServers": {
     "last9": {
       "command": "/opt/homebrew/bin/last9-mcp",
+      "env": {
+        "LAST9_BASE_URL": "<last9_otlp_host>",
+        "LAST9_AUTH_TOKEN": "<last9_otlp_auth_token>",
+        "LAST9_REFRESH_TOKEN": "<last9_write_refresh_token>"
+      }
+    }
+  }
+}
+```
+
+### If installed via NPM:
+```json
+{
+  "mcpServers": {
+    "last9": {
+      "command": "npx",
+      "args": ["-y", "@last9/mcp-server"],
       "env": {
         "LAST9_BASE_URL": "<last9_otlp_host>",
         "LAST9_AUTH_TOKEN": "<last9_otlp_auth_token>",
@@ -334,11 +352,29 @@ Configure Cursor to use the MCP server:
 4. Copy and paste the server config to your existing file, then save
 5. Restart Cursor
 
+### If installed via Homebrew:
 ```json
 {
   "mcpServers": {
     "last9": {
       "command": "/opt/homebrew/bin/last9-mcp",
+      "env": {
+        "LAST9_BASE_URL": "<last9_otlp_host>",
+        "LAST9_AUTH_TOKEN": "<last9_otlp_auth_token>",
+        "LAST9_REFRESH_TOKEN": "<last9_write_refresh_token>"
+      }
+    }
+  }
+}
+```
+
+### If installed via NPM:
+```json
+{
+  "mcpServers": {
+    "last9": {
+      "command": "npx",
+      "args": ["-y", "@last9/mcp-server"],
       "env": {
         "LAST9_BASE_URL": "<last9_otlp_host>",
         "LAST9_AUTH_TOKEN": "<last9_otlp_auth_token>",
@@ -359,11 +395,29 @@ Configure Windsurf to use the MCP server:
 4. Copy and paste the server config to your existing file, then save
 5. Restart Windsurf
 
+### If installed via Homebrew:
 ```json
 {
   "mcpServers": {
     "last9": {
       "command": "/opt/homebrew/bin/last9-mcp",
+      "env": {
+        "LAST9_BASE_URL": "<last9_otlp_host>",
+        "LAST9_AUTH_TOKEN": "<last9_otlp_auth_token>",
+        "LAST9_REFRESH_TOKEN": "<last9_write_refresh_token>"
+      }
+    }
+  }
+}
+```
+
+### If installed via NPM:
+```json
+{
+  "mcpServers": {
+    "last9": {
+      "command": "npx",
+      "args": ["-y", "@last9/mcp-server"],
       "env": {
         "LAST9_BASE_URL": "<last9_otlp_host>",
         "LAST9_AUTH_TOKEN": "<last9_otlp_auth_token>",
@@ -385,6 +439,7 @@ Configure Windsurf to use the MCP server:
 3. Copy and paste the server config to your existing file, then save
 4. Restart VS Code
 
+### If installed via Homebrew:
 ```json
 {
   "mcp": {
@@ -392,6 +447,26 @@ Configure Windsurf to use the MCP server:
       "last9": {
         "type": "stdio",
         "command": "/opt/homebrew/bin/last9-mcp",
+        "env": {
+          "LAST9_BASE_URL": "<last9_otlp_host>",
+          "LAST9_AUTH_TOKEN": "<last9_otlp_auth_token>",
+          "LAST9_REFRESH_TOKEN": "<last9_write_refresh_token>"
+        }
+      }
+    }
+  }
+}
+```
+
+### If installed via NPM:
+```json
+{
+  "mcp": {
+    "servers": {
+      "last9": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "@last9/mcp-server"],
         "env": {
           "LAST9_BASE_URL": "<last9_otlp_host>",
           "LAST9_AUTH_TOKEN": "<last9_otlp_auth_token>",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "claude"
   ],
   "author": "Last9",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/last9/last9-mcp-server/issues"
   },


### PR DESCRIPTION
- The download script was downloading tar.gz archives but not extracting them
- This caused the binary to be gzipped data instead of an executable
- Added proper archive extraction using tar/unzip based on platform
- Added temporary file handling with cleanup
- Updated README with npm configuration examples for all MCP clients

Fixes: npm package installation and npx execution