### PR TITLE
fix: improve error handling for physical index operations

### DIFF
--- a/internal/telemetry/logs/service_logs.go
+++ b/internal/telemetry/logs/service_logs.go
@@ -111,9 +111,7 @@ func NewGetServiceLogsHandler(client *http.Client, cfg models.Config) func(mcp.C
 
 		physicalIndex, err := utils.FetchPhysicalIndex(client, cfg, service, env)
 		if err != nil {
-			// Log the error but continue without index to maintain backward compatibility
-			fmt.Printf("Warning: failed to fetch physical index for service %s: %v\n", service, err)
-			physicalIndex = ""
+			return mcp.CallToolResult{}, fmt.Errorf("failed to fetch physical index: %w", err)
 		}
 
 		// Fetch raw logs using the existing logs API approach with physical index

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -563,7 +563,8 @@ func FetchPhysicalIndex(client *http.Client, cfg models.Config, serviceName, env
 	}
 
 	if len(physicalIndexResponse) == 0 {
-		return "", fmt.Errorf("no physical index found for service %s", serviceName)
+		// Continue without index if it is not available
+		return "", nil
 	}
 
 	// Extract the index name from the first result


### PR DESCRIPTION
- Remove warning fallback in service logs handler, return proper errors
- Allow graceful continuation when no physical index is found
- Maintain backward compatibility for services without indexes

🤖 Generated with [Claude Code](https://claude.ai/code)