### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ environment to auto-fix code faster.
 - [Development](#development)
 - [Testing](#testing)
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/last9-last9-mcp-server).
+
 ## Quick Start (Hosted MCP)
 
 The fastest way to get started. No local binary, no tokens — authentication is


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/last9-last9-mcp-server)