### PR TITLE
Add per-query datasource selection to Prometheus tools

### DIFF
--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -74,12 +74,14 @@ type PromqlRangeQueryArgs struct {
 	StartTimeISO    string  `json:"start_time_iso,omitempty" jsonschema:"Start time in RFC3339/ISO8601 format (e.g. 2024-06-01T12:00:00Z). Optional when lookback_minutes is provided."`
 	EndTimeISO      string  `json:"end_time_iso,omitempty" jsonschema:"End time in RFC3339/ISO8601 format (e.g. 2024-06-01T13:00:00Z). Defaults to now when omitted."`
 	LookbackMinutes float64 `json:"lookback_minutes,omitempty" jsonschema:"Number of minutes to look back from now (default: 60, minimum: 1). Use for relative windows like last 30 minutes."`
+	Datasource      string  `json:"datasource,omitempty" jsonschema:"Name of the datasource to query. If omitted, uses the default configured datasource."`
 }
 
 type PromqlInstantQueryArgs struct {
 	Query           string  `json:"query" jsonschema:"PromQL query to execute (required)"`
 	TimeISO         string  `json:"time_iso,omitempty" jsonschema:"Evaluation time in RFC3339/ISO8601 format (e.g. 2024-06-01T12:00:00Z). If omitted, defaults to now or now-lookback_minutes."`
 	LookbackMinutes float64 `json:"lookback_minutes,omitempty" jsonschema:"Number of minutes to look back from now when time_iso is omitted (default: 0, minimum: 1)."`
+	Datasource      string  `json:"datasource,omitempty" jsonschema:"Name of the datasource to query. If omitted, uses the default configured datasource."`
 }
 
 type PromqlLabelValuesArgs struct {
@@ -88,6 +90,7 @@ type PromqlLabelValuesArgs struct {
 	StartTimeISO    string  `json:"start_time_iso,omitempty" jsonschema:"Start time in RFC3339/ISO8601 format (e.g. 2024-06-01T12:00:00Z). Optional when lookback_minutes is provided."`
 	EndTimeISO      string  `json:"end_time_iso,omitempty" jsonschema:"End time in RFC3339/ISO8601 format (e.g. 2024-06-01T13:00:00Z). Defaults to now when omitted."`
 	LookbackMinutes float64 `json:"lookback_minutes,omitempty" jsonschema:"Number of minutes to look back from now (default: 60, minimum: 1). Use for relative windows like last 30 minutes."`
+	Datasource      string  `json:"datasource,omitempty" jsonschema:"Name of the datasource to query. If omitted, uses the default configured datasource."`
 }
 
 type PromqlLabelsArgs struct {
@@ -95,6 +98,7 @@ type PromqlLabelsArgs struct {
 	StartTimeISO    string  `json:"start_time_iso,omitempty" jsonschema:"Start time in RFC3339/ISO8601 format (e.g. 2024-06-01T12:00:00Z). Optional when lookback_minutes is provided."`
 	EndTimeISO      string  `json:"end_time_iso,omitempty" jsonschema:"End time in RFC3339/ISO8601 format (e.g. 2024-06-01T13:00:00Z). Defaults to now when omitted."`
 	LookbackMinutes float64 `json:"lookback_minutes,omitempty" jsonschema:"Number of minutes to look back from now (default: 60, minimum: 1). Use for relative windows like last 30 minutes."`
+	Datasource      string  `json:"datasource,omitempty" jsonschema:"Name of the datasource to query. If omitted, uses the default configured datasource."`
 }
 
 func resolveTimeRange(startTimeISO, endTimeISO string, lookbackMinutes float64) (int64, int64, error) {
@@ -1800,6 +1804,23 @@ func NewServiceDependencyGraphHandler(client *http.Client, cfg models.Config) fu
 	}
 }
 
+// resolveDatasourceCfg returns a copy of cfg with Prometheus credentials overridden
+// to those of the named datasource. If datasourceName is empty the original cfg is
+// returned unchanged. Returns an error when the name is non-empty but not found.
+func resolveDatasourceCfg(cfg models.Config, datasourceName string) (models.Config, error) {
+	if datasourceName == "" {
+		return cfg, nil
+	}
+	ds, ok := cfg.ResolveDatasource(datasourceName)
+	if !ok {
+		return cfg, fmt.Errorf("datasource %q not found", datasourceName)
+	}
+	cfg.PrometheusReadURL = ds.ReadURL
+	cfg.PrometheusUsername = ds.Username
+	cfg.PrometheusPassword = ds.Password
+	return cfg, nil
+}
+
 const PromqlRangeQueryDetails = `
 	Perform a Prometheus range query to get metrics data.
 	This tool can be used to query Prometheus for metrics data over a specified time range.
@@ -1829,6 +1850,7 @@ const PromqlRangeQueryDetails = `
 	- lookback_minutes: (Optional) Number of minutes to look back from now. Defaults to 60.
 	- start_time_iso: (Optional) Start time of the time range in RFC3339/ISO8601 format (e.g. 2026-02-09T15:04:05Z). Overrides lookback when provided.
 	- end_time_iso: (Optional) End time of the time range in RFC3339/ISO8601 format (e.g. 2026-02-09T16:04:05Z). Defaults to current time.
+	- datasource: (Optional) Name of the datasource to query. If omitted, uses the default configured datasource.
 	`
 
 func NewPromqlRangeQueryHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, PromqlRangeQueryArgs) (*mcp.CallToolResult, any, error) {
@@ -1843,7 +1865,12 @@ func NewPromqlRangeQueryHandler(client *http.Client, cfg models.Config) func(con
 			return nil, nil, err
 		}
 
-		httpResp, err := utils.MakePromRangeAPIQuery(ctx, client, query, startTimeParam, endTimeParam, cfg)
+		queryCfg, err := resolveDatasourceCfg(cfg, args.Datasource)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		httpResp, err := utils.MakePromRangeAPIQuery(ctx, client, query, startTimeParam, endTimeParam, queryCfg)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1897,6 +1924,7 @@ const PromqlInstantQueryDetails = `
 	- query: (Required) The Prometheus query to execute.
 	- time_iso: (Optional) The point in time to query in RFC3339/ISO8601 format (e.g. 2026-02-09T15:04:05Z). Overrides lookback when provided.
 	- lookback_minutes: (Optional) Number of minutes to look back from now when time_iso is omitted.
+	- datasource: (Optional) Name of the datasource to query. If omitted, uses the default configured datasource.
 `
 
 func NewPromqlInstantQueryHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, PromqlInstantQueryArgs) (*mcp.CallToolResult, any, error) {
@@ -1911,7 +1939,12 @@ func NewPromqlInstantQueryHandler(client *http.Client, cfg models.Config) func(c
 			return nil, nil, err
 		}
 
-		httpResp, err := utils.MakePromInstantAPIQuery(ctx, client, query, timeParam, cfg)
+		queryCfg, err := resolveDatasourceCfg(cfg, args.Datasource)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		httpResp, err := utils.MakePromInstantAPIQuery(ctx, client, query, timeParam, queryCfg)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -2052,14 +2085,15 @@ const PromqlLabelValuesQueryDetails = `
 	It returns an array of values for the label.
 	Parameters:
 	- match_query: (Required) A valid promql filter query
-	- label: (Required) Name of the label to return values for 
+	- label: (Required) Name of the label to return values for
 	- lookback_minutes: (Optional) Number of minutes to look back from now. Defaults to 60.
 	- start_time_iso: (Optional) Start time of the time range in RFC3339/ISO8601 format (e.g. 2026-02-09T15:04:05Z). Overrides lookback when provided.
 	- end_time_iso: (Optional) End time of the time range in RFC3339/ISO8601 format (e.g. 2026-02-09T16:04:05Z). Defaults to current time.
+	- datasource: (Optional) Name of the datasource to query. If omitted, uses the default configured datasource.
 
 	match_query should be a well formed, valid promql query
 	It is enouraged to not use default
-	values of start_time and end_time and use values that are appropriate for the 
+	values of start_time and end_time and use values that are appropriate for the
 	use case
 `
 
@@ -2078,7 +2112,12 @@ func NewPromqlLabelValuesHandler(client *http.Client, cfg models.Config) func(co
 			return nil, nil, err
 		}
 
-		httpResp, err := utils.MakePromLabelValuesAPIQuery(ctx, client, label, query, startTimeParam, endTimeParam, cfg)
+		queryCfg, err := resolveDatasourceCfg(cfg, args.Datasource)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		httpResp, err := utils.MakePromLabelValuesAPIQuery(ctx, client, label, query, startTimeParam, endTimeParam, queryCfg)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -2116,10 +2155,11 @@ const PromqlLabelsQueryDetails = `
 	- lookback_minutes: (Optional) Number of minutes to look back from now. Defaults to 60.
 	- start_time_iso: (Optional) Start time of the time range in RFC3339/ISO8601 format (e.g. 2026-02-09T15:04:05Z). Overrides lookback when provided.
 	- end_time_iso: (Optional) End time of the time range in RFC3339/ISO8601 format (e.g. 2026-02-09T16:04:05Z). Defaults to current time.
+	- datasource: (Optional) Name of the datasource to query. If omitted, uses the default configured datasource.
 
 	match_query should be a well formed, valid promql query
 	It is enouraged to not use default
-	values of start_time and end_time and use values that are appropriate for the 
+	values of start_time and end_time and use values that are appropriate for the
 	use case
 `
 
@@ -2134,7 +2174,12 @@ func NewPromqlLabelsHandler(client *http.Client, cfg models.Config) func(context
 			return nil, nil, err
 		}
 
-		httpResp, err := utils.MakePromLabelsAPIQuery(ctx, client, query, startTimeParam, endTimeParam, cfg)
+		queryCfg, err := resolveDatasourceCfg(cfg, args.Datasource)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		httpResp, err := utils.MakePromLabelsAPIQuery(ctx, client, query, startTimeParam, endTimeParam, queryCfg)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -2156,6 +2201,47 @@ func NewPromqlLabelsHandler(client *http.Client, cfg models.Config) func(context
 				&mcp.TextContent{
 					Text: string(responseBodyBytes),
 				},
+			},
+		}, nil, nil
+	}
+}
+
+// ListDatasourcesArgs has no required parameters.
+type ListDatasourcesArgs struct{}
+
+const ListDatasourcesDescription = `
+	List all available datasources configured for this organization.
+	Use this tool to discover valid datasource names before passing them to
+	prometheus_range_query, prometheus_instant_query, prometheus_label_values,
+	or prometheus_labels via the datasource parameter.
+
+	Returns an array of objects, each with:
+	- name: the datasource name to use in the datasource parameter
+	- is_default: true for the datasource that is used when no datasource is specified
+`
+
+// NewListDatasourcesHandler returns a handler that serves the datasource list from
+// the in-memory cache populated at startup — no extra API call is made.
+// The response is serialized once at registration time since the list never changes.
+func NewListDatasourcesHandler(cfg models.Config) func(context.Context, *mcp.CallToolRequest, ListDatasourcesArgs) (*mcp.CallToolResult, any, error) {
+	type datasourceView struct {
+		Name      string `json:"name"`
+		IsDefault bool   `json:"is_default"`
+	}
+
+	views := make([]datasourceView, 0, len(cfg.Datasources))
+	for _, ds := range cfg.Datasources {
+		views = append(views, datasourceView{
+			Name:      ds.Name,
+			IsDefault: ds.IsDefault,
+		})
+	}
+	out, _ := json.Marshal(views) // slice of plain structs — cannot fail
+
+	return func(_ context.Context, _ *mcp.CallToolRequest, _ ListDatasourcesArgs) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: string(out)},
 			},
 		}, nil, nil
 	}

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -2092,7 +2092,7 @@ const PromqlLabelValuesQueryDetails = `
 	- datasource: (Optional) Name of the datasource to query. If omitted, uses the default configured datasource.
 
 	match_query should be a well formed, valid promql query
-	It is enouraged to not use default
+	It is encouraged to not use default
 	values of start_time and end_time and use values that are appropriate for the
 	use case
 `
@@ -2158,7 +2158,7 @@ const PromqlLabelsQueryDetails = `
 	- datasource: (Optional) Name of the datasource to query. If omitted, uses the default configured datasource.
 
 	match_query should be a well formed, valid promql query
-	It is enouraged to not use default
+	It is encouraged to not use default
 	values of start_time and end_time and use values that are appropriate for the
 	use case
 `

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -1818,6 +1818,8 @@ func resolveDatasourceCfg(cfg models.Config, datasourceName string) (models.Conf
 	cfg.PrometheusReadURL = ds.ReadURL
 	cfg.PrometheusUsername = ds.Username
 	cfg.PrometheusPassword = ds.Password
+	cfg.Region = ds.Region
+	cfg.ClusterID = ds.ClusterID
 	return cfg, nil
 }
 

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -1815,6 +1815,9 @@ func resolveDatasourceCfg(cfg models.Config, datasourceName string) (models.Conf
 	if !ok {
 		return cfg, fmt.Errorf("datasource %q not found", datasourceName)
 	}
+	if ds.ReadURL == "" || ds.Username == "" || ds.Password == "" || ds.Region == "" {
+		return cfg, fmt.Errorf("datasource %q is missing required Prometheus configuration", datasourceName)
+	}
 	cfg.PrometheusReadURL = ds.ReadURL
 	cfg.PrometheusUsername = ds.Username
 	cfg.PrometheusPassword = ds.Password

--- a/internal/apm/apm_test.go
+++ b/internal/apm/apm_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -533,8 +534,12 @@ func TestPromqlRangeHandler_DatasourceOverride(t *testing.T) {
 		Password string `json:"password"`
 	}
 
-	var captured capturedReq
+	var (
+		captured capturedReq
+		hitCount int32
+	)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hitCount, 1)
 		body, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(body, &captured)
 		w.Header().Set("Content-Type", "application/json")
@@ -548,7 +553,7 @@ func TestPromqlRangeHandler_DatasourceOverride(t *testing.T) {
 		PrometheusUsername: "default-user",
 		PrometheusPassword: "default-pass",
 		Datasources: []models.DatasourceInfo{
-			{Name: "staging", ReadURL: "https://staging.example.com/prom", Username: "staging-user", Password: "staging-pass"},
+			{Name: "staging", ReadURL: "https://staging.example.com/prom", Username: "staging-user", Password: "staging-pass", Region: "us-east-1"},
 		},
 	}
 	cfg.TokenManager = &auth.TokenManager{
@@ -587,11 +592,15 @@ func TestPromqlRangeHandler_DatasourceOverride(t *testing.T) {
 	}
 
 	// Unknown datasource — handler must return error before hitting the server
+	beforeUnknown := atomic.LoadInt32(&hitCount)
 	_, _, err = handler(context.Background(), &mcp.CallToolRequest{}, PromqlRangeQueryArgs{
 		Query: "up", LookbackMinutes: 5, Datasource: "nonexistent",
 	})
 	if err == nil {
 		t.Fatal("expected error for unknown datasource, got nil")
+	}
+	if after := atomic.LoadInt32(&hitCount); after != beforeUnknown {
+		t.Fatalf("unknown datasource: server was contacted %d time(s), want 0", after-beforeUnknown)
 	}
 }
 

--- a/internal/apm/apm_test.go
+++ b/internal/apm/apm_test.go
@@ -465,3 +465,178 @@ func TestPromqlLabelValuesHandler_Integration(t *testing.T) {
 		t.Logf("Integration test successful: found %d label value(s) for label '%s'", len(labelValues), args.Label)
 	}
 }
+
+func TestResolveDatasourceCfg(t *testing.T) {
+	cfg := models.Config{
+		PrometheusReadURL:  "https://default.example.com/prom",
+		PrometheusUsername: "default-user",
+		PrometheusPassword: "default-pass",
+		Datasources: []models.DatasourceInfo{
+			{Name: "prod", ReadURL: "https://prod.example.com/prom", Username: "prod-user", Password: "prod-pass", IsDefault: true},
+			{Name: "staging", ReadURL: "https://staging.example.com/prom", Username: "staging-user", Password: "staging-pass"},
+		},
+	}
+
+	t.Run("empty name returns original cfg unchanged", func(t *testing.T) {
+		resolved, err := resolveDatasourceCfg(cfg, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resolved.PrometheusReadURL != cfg.PrometheusReadURL {
+			t.Errorf("ReadURL = %q, want %q", resolved.PrometheusReadURL, cfg.PrometheusReadURL)
+		}
+	})
+
+	t.Run("known datasource overrides prometheus credentials", func(t *testing.T) {
+		resolved, err := resolveDatasourceCfg(cfg, "staging")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resolved.PrometheusReadURL != "https://staging.example.com/prom" {
+			t.Errorf("ReadURL = %q, want staging URL", resolved.PrometheusReadURL)
+		}
+		if resolved.PrometheusUsername != "staging-user" {
+			t.Errorf("Username = %q, want staging-user", resolved.PrometheusUsername)
+		}
+		if resolved.PrometheusPassword != "staging-pass" {
+			t.Errorf("Password = %q, want staging-pass", resolved.PrometheusPassword)
+		}
+	})
+
+	t.Run("unknown datasource returns error containing the name", func(t *testing.T) {
+		_, err := resolveDatasourceCfg(cfg, "nonexistent")
+		if err == nil {
+			t.Fatal("expected error for unknown datasource, got nil")
+		}
+		if !strings.Contains(err.Error(), "nonexistent") {
+			t.Errorf("error %q does not mention the datasource name", err.Error())
+		}
+	})
+
+	t.Run("original cfg is not mutated", func(t *testing.T) {
+		_, _ = resolveDatasourceCfg(cfg, "staging")
+		if cfg.PrometheusReadURL != "https://default.example.com/prom" {
+			t.Error("original cfg was mutated by resolveDatasourceCfg")
+		}
+	})
+}
+
+func TestPromqlRangeHandler_DatasourceOverride(t *testing.T) {
+	type capturedReq struct {
+		ReadURL  string `json:"read_url"`
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+
+	var captured capturedReq
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	cfg := models.Config{
+		APIBaseURL:         server.URL,
+		PrometheusReadURL:  "https://default.example.com/prom",
+		PrometheusUsername: "default-user",
+		PrometheusPassword: "default-pass",
+		Datasources: []models.DatasourceInfo{
+			{Name: "staging", ReadURL: "https://staging.example.com/prom", Username: "staging-user", Password: "staging-pass"},
+		},
+	}
+	cfg.TokenManager = &auth.TokenManager{
+		AccessToken: "mock-token",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+
+	handler := NewPromqlRangeQueryHandler(server.Client(), cfg)
+
+	// No datasource — default credentials should reach the server
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, PromqlRangeQueryArgs{
+		Query: "up", LookbackMinutes: 5,
+	})
+	if err != nil {
+		t.Fatalf("handler error (default): %v", err)
+	}
+	if captured.ReadURL != "https://default.example.com/prom" {
+		t.Errorf("default: read_url = %q, want default URL", captured.ReadURL)
+	}
+
+	// With datasource override — staging credentials should reach the server
+	_, _, err = handler(context.Background(), &mcp.CallToolRequest{}, PromqlRangeQueryArgs{
+		Query: "up", LookbackMinutes: 5, Datasource: "staging",
+	})
+	if err != nil {
+		t.Fatalf("handler error (staging): %v", err)
+	}
+	if captured.ReadURL != "https://staging.example.com/prom" {
+		t.Errorf("staging: read_url = %q, want staging URL", captured.ReadURL)
+	}
+	if captured.Username != "staging-user" {
+		t.Errorf("staging: username = %q, want staging-user", captured.Username)
+	}
+	if captured.Password != "staging-pass" {
+		t.Errorf("staging: password = %q, want staging-pass", captured.Password)
+	}
+
+	// Unknown datasource — handler must return error before hitting the server
+	_, _, err = handler(context.Background(), &mcp.CallToolRequest{}, PromqlRangeQueryArgs{
+		Query: "up", LookbackMinutes: 5, Datasource: "nonexistent",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown datasource, got nil")
+	}
+}
+
+func TestNewListDatasourcesHandler(t *testing.T) {
+	t.Run("returns all datasources with correct is_default flags", func(t *testing.T) {
+		cfg := models.Config{
+			Datasources: []models.DatasourceInfo{
+				{Name: "prod", IsDefault: true},
+				{Name: "staging", IsDefault: false},
+			},
+		}
+
+		handler := NewListDatasourcesHandler(cfg)
+		result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ListDatasourcesArgs{})
+		if err != nil {
+			t.Fatalf("handler returned error: %v", err)
+		}
+
+		textContent, ok := result.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatal("expected TextContent")
+		}
+
+		var views []struct {
+			Name      string `json:"name"`
+			IsDefault bool   `json:"is_default"`
+		}
+		if err := json.Unmarshal([]byte(textContent.Text), &views); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if len(views) != 2 {
+			t.Fatalf("expected 2 datasources, got %d", len(views))
+		}
+		if views[0].Name != "prod" || !views[0].IsDefault {
+			t.Errorf("first entry: name=%q is_default=%v, want prod/true", views[0].Name, views[0].IsDefault)
+		}
+		if views[1].Name != "staging" || views[1].IsDefault {
+			t.Errorf("second entry: name=%q is_default=%v, want staging/false", views[1].Name, views[1].IsDefault)
+		}
+	})
+
+	t.Run("empty datasources list returns empty JSON array", func(t *testing.T) {
+		handler := NewListDatasourcesHandler(models.Config{})
+		result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ListDatasourcesArgs{})
+		if err != nil {
+			t.Fatalf("handler returned error: %v", err)
+		}
+		textContent := result.Content[0].(*mcp.TextContent)
+		if textContent.Text != "[]" {
+			t.Errorf("empty list text = %q, want []", textContent.Text)
+		}
+	})
+}

--- a/internal/apm/apm_test.go
+++ b/internal/apm/apm_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// Note: strings import is still needed for TestNewServiceSummaryHandler_ExtraParams
 
 func TestNewServiceSummaryHandler_ExtraParams(t *testing.T) {
 	// Mock responses should match apiPromInstantResp format (direct array)
@@ -472,8 +471,8 @@ func TestResolveDatasourceCfg(t *testing.T) {
 		PrometheusUsername: "default-user",
 		PrometheusPassword: "default-pass",
 		Datasources: []models.DatasourceInfo{
-			{Name: "prod", ReadURL: "https://prod.example.com/prom", Username: "prod-user", Password: "prod-pass", IsDefault: true},
-			{Name: "staging", ReadURL: "https://staging.example.com/prom", Username: "staging-user", Password: "staging-pass"},
+			{Name: "prod", ReadURL: "https://prod.example.com/prom", Username: "prod-user", Password: "prod-pass", Region: "us-east-1", ClusterID: "prod-cluster", IsDefault: true},
+			{Name: "staging", ReadURL: "https://staging.example.com/prom", Username: "staging-user", Password: "staging-pass", Region: "ap-south-1", ClusterID: "staging-cluster"},
 		},
 	}
 
@@ -487,7 +486,7 @@ func TestResolveDatasourceCfg(t *testing.T) {
 		}
 	})
 
-	t.Run("known datasource overrides prometheus credentials", func(t *testing.T) {
+	t.Run("known datasource overrides prometheus credentials and region", func(t *testing.T) {
 		resolved, err := resolveDatasourceCfg(cfg, "staging")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -500,6 +499,12 @@ func TestResolveDatasourceCfg(t *testing.T) {
 		}
 		if resolved.PrometheusPassword != "staging-pass" {
 			t.Errorf("Password = %q, want staging-pass", resolved.PrometheusPassword)
+		}
+		if resolved.Region != "ap-south-1" {
+			t.Errorf("Region = %q, want ap-south-1", resolved.Region)
+		}
+		if resolved.ClusterID != "staging-cluster" {
+			t.Errorf("ClusterID = %q, want staging-cluster", resolved.ClusterID)
 		}
 	})
 

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -5,6 +5,18 @@ import "last9-mcp/internal/auth"
 const DefaultMaxGetLogsEntries = 5000
 const DefaultMaxGetTracesEntries = 5000
 
+// DatasourceInfo holds resolved credentials for a named datasource.
+// Populated at startup from the /datasources API response and cached in Config.Datasources.
+type DatasourceInfo struct {
+	Name      string
+	ReadURL   string
+	Username  string
+	Password  string
+	Region    string
+	ClusterID string
+	IsDefault bool
+}
+
 // Config holds the server configuration parameters
 type Config struct {
 	// Last9 connection settings
@@ -36,5 +48,23 @@ type Config struct {
 
 	ClusterID string // Cluster ID from datasource (for dashboard deep links)
 
+	// Datasources holds all available datasources fetched at startup.
+	// Used to resolve per-query datasource credentials without an extra API call.
+	Datasources []DatasourceInfo
+
 	TokenManager *auth.TokenManager // Manages authentication tokens
+}
+
+// ResolveDatasource looks up a datasource by name from the cached list.
+// Returns the zero value and false when name is empty or not found.
+func (cfg Config) ResolveDatasource(name string) (DatasourceInfo, bool) {
+	if name == "" {
+		return DatasourceInfo{}, false
+	}
+	for _, ds := range cfg.Datasources {
+		if ds.Name == name {
+			return ds, true
+		}
+	}
+	return DatasourceInfo{}, false
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -478,7 +478,7 @@ func PopulateAPICfg(cfg *models.Config) error {
 			Password:  ds.Properties.Password,
 			Region:    ds.Region,
 			ClusterID: ds.Properties.LevitateClusterID,
-			IsDefault: ds.IsDefault,
+			IsDefault: ds.Name == selectedDatasource.Name,
 		})
 	}
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -385,47 +385,6 @@ type Datasource struct {
 	} `json:"properties"`
 }
 
-// GetDatasourceByName fetches all datasources and returns the one matching the provided name.
-// If datasourceName is empty, returns nil (indicating to use default).
-// Returns an error if the datasource is not found.
-func GetDatasourceByName(ctx context.Context, client *http.Client, cfg models.Config, datasourceName string) (*Datasource, error) {
-	if datasourceName == "" {
-		return nil, nil // Use default
-	}
-
-	// Fetch all datasources
-	req, err := http.NewRequestWithContext(ctx, "GET", cfg.APIBaseURL+constants.EndpointDatasources, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request for datasources: %w", err)
-	}
-	req.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+cfg.TokenManager.GetAccessToken(ctx))
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get datasources: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("failed to get datasources: status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var datasources []Datasource
-	if err := json.NewDecoder(resp.Body).Decode(&datasources); err != nil {
-		return nil, fmt.Errorf("failed to decode datasources response: %w", err)
-	}
-
-	// Find the datasource matching the provided name
-	for _, ds := range datasources {
-		if ds.Name == datasourceName {
-			return &ds, nil
-		}
-	}
-
-	return nil, fmt.Errorf("datasource with name '%s' not found", datasourceName)
-}
-
 // PopulateAPICfg populates the API configuration with necessary details
 func PopulateAPICfg(cfg *models.Config) error {
 	if cfg.TokenManager == nil {
@@ -507,5 +466,21 @@ func PopulateAPICfg(cfg *models.Config) error {
 	if cfg.PrometheusReadURL == "" || cfg.PrometheusUsername == "" || cfg.PrometheusPassword == "" || cfg.Region == "" {
 		return errors.New("selected datasource missing required properties")
 	}
+
+	// Cache all datasources so handlers can resolve per-query datasource credentials
+	// without an extra API call on each request.
+	cfg.Datasources = make([]models.DatasourceInfo, 0, len(datasourcesList))
+	for _, ds := range datasourcesList {
+		cfg.Datasources = append(cfg.Datasources, models.DatasourceInfo{
+			Name:      ds.Name,
+			ReadURL:   ds.URL,
+			Username:  ds.Properties.Username,
+			Password:  ds.Properties.Password,
+			Region:    ds.Region,
+			ClusterID: ds.Properties.LevitateClusterID,
+			IsDefault: ds.IsDefault,
+		})
+	}
+
 	return nil
 }

--- a/tools.go
+++ b/tools.go
@@ -78,6 +78,12 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCa
 		Description: apm.GetServiceDependencyGraphDetails,
 	}, apm.NewServiceDependencyGraphHandler(client, cfg))
 
+	// Register list datasources tool
+	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+		Name:        "list_datasources",
+		Description: apm.ListDatasourcesDescription,
+	}, apm.NewListDatasourcesHandler(cfg))
+
 	// Register PromQL range query tool (enhanced with metrics instructions)
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
 		Name:        "prometheus_range_query",


### PR DESCRIPTION
## Summary

- Adds optional `datasource` parameter to all 4 Prometheus tools (`prometheus_range_query`, `prometheus_instant_query`, `prometheus_label_values`, `prometheus_labels`) — when set, credentials for the named datasource are resolved from the startup-cached list instead of the server-wide default
- Adds `list_datasources` tool so agents can discover available datasource names (and which is the default) before querying
- Removes dead `GetDatasourceByName` utility that made a live API call on every invocation; all per-query resolution now uses the in-memory cache

## How it works

All datasources are already fetched from the API at startup in `PopulateAPICfg`. We now cache them in `cfg.Datasources []DatasourceInfo`. At query time, `resolveDatasourceCfg` copies `cfg` by value and overwrites only the three Prometheus credential fields — safe across concurrent requests with no locking.

The `list_datasources` response is serialized once at handler registration since the list never changes after startup.

## Test plan

- [ ] `list_datasources` returns all datasources with correct `is_default` flag
- [ ] Prometheus tools use default datasource when `datasource` param is omitted
- [ ] Prometheus tools use overridden credentials when `datasource` param is set to a valid name
- [ ] Prometheus tools return a clear error when `datasource` param is set to an unknown name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-query Prometheus datasource selection for PromQL (range, instant, label values, labels).
  * New tool to list configured datasources and their default status.

* **Improvements**
  * Datasource metadata cached at startup for faster, offline resolution.

* **Bug Fixes**
  * Handlers now validate datasource names and fail early on invalid or incomplete selections.

* **Tests**
  * Added tests for datasource resolution, query overrides, and the listing tool.

* **Documentation**
  * PromQL tool help updated to document the optional datasource parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->