### PR TITLE
fix(get_logs): reject non-canonical filter shapes instead of silently dropping

### DIFF
--- a/internal/telemetry/logs/query_sanitize.go
+++ b/internal/telemetry/logs/query_sanitize.go
@@ -31,6 +31,12 @@ var logFilterFieldOperators = map[string]int{
 	"$regex":        0,
 }
 
+var logFilterLogicalOperators = map[string]struct{}{
+	"$and": {},
+	"$or":  {},
+	"$not": {},
+}
+
 var logAggregateFieldArgIndexes = map[string][]int{
 	"$avg":      {0},
 	"$max":      {0},
@@ -102,6 +108,15 @@ func sanitizeLogCondition(value interface{}, path string) (interface{}, error) {
 				continue
 			}
 
+			if _, isLogicalOperator := logFilterLogicalOperators[key]; !isLogicalOperator {
+				return nil, fmt.Errorf(
+					"invalid filter condition key %q at %s: keys must be operators ($eq, $neq, $gt, $gte, $lt, $lte, $contains, $notcontains, $icontains, $noticontains, $regex, $notregex, $iregex, $notiregex, $ieq) or logical operators ($and, $or, $not); use the form {%q: [field, value]} — for example {\"$eq\": [\"ServiceName\", \"checkout\"]} — and call get_log_attributes if you need the exact field name",
+					key,
+					path,
+					"$eq",
+				)
+			}
+
 			next, err := sanitizeLogCondition(item, path+"."+key)
 			if err != nil {
 				return nil, err
@@ -117,7 +132,11 @@ func sanitizeLogCondition(value interface{}, path string) (interface{}, error) {
 func sanitizeLogFieldOperatorArgs(value interface{}, fieldArgIndex int, path string) (interface{}, error) {
 	args, ok := value.([]interface{})
 	if !ok {
-		return value, nil
+		return nil, fmt.Errorf(
+			"invalid arguments for field operator at %s: expected an array like [field, value], got %T — use the form {\"$eq\": [\"ServiceName\", \"checkout\"]}",
+			path,
+			value,
+		)
 	}
 
 	sanitized := append([]interface{}(nil), args...)

--- a/internal/telemetry/logs/query_sanitize_test.go
+++ b/internal/telemetry/logs/query_sanitize_test.go
@@ -162,6 +162,77 @@ func TestSanitizeLogJSONQueryRejectsUnsupportedBareDottedRefs(t *testing.T) {
 	}
 }
 
+func TestSanitizeLogJSONQueryRejectsUnknownFilterConditionKeys(t *testing.T) {
+	tests := []struct {
+		name  string
+		query map[string]interface{}
+	}{
+		{
+			name:  "field as key with scalar",
+			query: map[string]interface{}{"ServiceName": "checkout"},
+		},
+		{
+			name: "field as key with nested operator",
+			query: map[string]interface{}{
+				"ServiceName": map[string]interface{}{"$eq": "checkout"},
+			},
+		},
+		{
+			name:  "operator suffix on field",
+			query: map[string]interface{}{"ServiceName=~": "checkout"},
+		},
+		{
+			name: "unknown key inside $and",
+			query: map[string]interface{}{
+				"$and": []interface{}{
+					map[string]interface{}{"ServiceName": "checkout"},
+				},
+			},
+		},
+		{
+			name:  "bare contains operator without dollar prefix",
+			query: map[string]interface{}{"contains": []interface{}{"Body", "error"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := sanitizeLogJSONQuery([]map[string]interface{}{
+				{
+					"type":  "filter",
+					"query": tt.query,
+				},
+			})
+			if err == nil {
+				t.Fatal("expected sanitizeLogJSONQuery to reject unknown filter key")
+			}
+			if !strings.Contains(err.Error(), "invalid filter condition key") {
+				t.Fatalf("expected invalid filter key error, got %v", err)
+			}
+			if !strings.Contains(err.Error(), "get_log_attributes") {
+				t.Fatalf("expected error to point callers to get_log_attributes, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSanitizeLogJSONQueryRejectsNonArrayFieldOperatorArgs(t *testing.T) {
+	_, err := sanitizeLogJSONQuery([]map[string]interface{}{
+		{
+			"type": "filter",
+			"query": map[string]interface{}{
+				"$eq": "checkout",
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected sanitizeLogJSONQuery to reject non-array field operator args")
+	}
+	if !strings.Contains(err.Error(), "invalid arguments for field operator") {
+		t.Fatalf("expected invalid args error, got %v", err)
+	}
+}
+
 func TestSanitizeLogJSONQueryRejectsGroupByCollisions(t *testing.T) {
 	_, err := sanitizeLogJSONQuery([]map[string]interface{}{
 		{


### PR DESCRIPTION
## Summary
- `get_logs` accepted filter queries in shapes the logs API can't execute — field-as-key (`{"ServiceName": "checkout"}`), field-with-operator-suffix (`{"ServiceName=~": "..."}`), scalar value for a binary operator (`{"$eq": "checkout"}`), or bare operators without a `$` prefix. The sanitizer walked past the unknown keys and forwarded them; the backend ignored the malformed filter and returned unfiltered top-N results with no error.
- Validate each map key inside a filter condition against the known field and logical operator sets (`$and`/`$or`/`$not`); require field-operator args to be arrays. Unsupported shapes now fail with a message pointing at the canonical `{"$eq": [field, value]}` form and suggesting `get_log_attributes` when the caller is unsure of field names.

## Reproduction (against production MCP before fix)
| Filter shape | Result |
|---|---|
| `{"$eq": ["ServiceName", "nginx"]}` | only nginx logs |
| `{"ServiceName": "nginx"}` | unfiltered top-N |
| `{"ServiceName": {"$eq": "nginx"}}` | unfiltered top-N |
| `{"ServiceName=~": "nginx"}` | unfiltered top-N |

## Test plan
- [x] `go test ./internal/telemetry/logs/ -count=1` — all existing tests still pass
- [x] New `TestSanitizeLogJSONQueryRejectsUnknownFilterConditionKeys` covers field-as-key (scalar + nested), operator-suffix, bare-`contains`, and unknown key inside `$and`
- [x] New `TestSanitizeLogJSONQueryRejectsNonArrayFieldOperatorArgs` covers `{"$eq": "checkout"}`
- [x] `go test ./...` green across the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened log query validation by rejecting invalid filter conditions and enforcing proper argument types, with clearer error messages for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->