### PR TITLE
Add next_steps hints to empty log responses

### DIFF
--- a/internal/prompts/descriptions/get_logging_services.md
+++ b/internal/prompts/descriptions/get_logging_services.md
@@ -1,0 +1,47 @@
+# get_logging_services Tool Arguments
+
+## Purpose
+
+Discover which services are actively sending logs to Last9. Returns the exact `service_name`,
+`env`, `physical_index`, and `severity` values present in the log ingestion pipeline.
+
+Call this **before** `get_logs` or `get_service_logs` to:
+- Confirm a service is actually ingesting logs
+- Get the exact spelling of `service_name` and `env` (prevents silent empty results)
+- Obtain the `physical_index` to pass as the `index` parameter for faster log queries
+- Know which severity levels are present for a service
+
+## Parameters
+
+- `service` (string, optional): Filter by service name. Omit to list all services sending logs.
+- `env` (string, optional): Filter by environment (e.g. `production`, `staging`). Omit for all environments.
+
+Call with no parameters to get a complete map of all services and their log indexes.
+
+## Output
+
+Returns a JSON array of entries. Each entry has:
+- `service_name`: exact service identifier to use in log queries
+- `env`: environment label
+- `physical_index`: index string to pass as `index` param (e.g. `physical_index:payments`)
+- `severity`: log severity level present for this combination
+
+## Examples
+
+User: "which services are sending logs?"
+→ `{}`
+
+User: "is checkout service sending logs?"
+→ `{"service": "checkout"}`
+
+User: "which services have logs in production?"
+→ `{"env": "production"}`
+
+User: "show logging info for api in staging"
+→ `{"service": "api", "env": "staging"}`
+
+User: "before querying logs for payment-service"
+→ `{"service": "payment-service"}`
+
+User: "what index should I use for the auth service?"
+→ `{"service": "auth"}`

--- a/internal/telemetry/logs/description.go
+++ b/internal/telemetry/logs/description.go
@@ -35,6 +35,10 @@ const GetLogsDescription = `
 
 	Response contains the results of the JSON pipeline query execution.
 
+	Tip: call get_log_services first to confirm the service is ingesting logs, get exact
+	service_name and env values, and obtain the physical_index to pass as the index parameter
+	for faster, targeted queries.
+
 `
 
 const GetDropRulesDescription = `Retrieve and display the configured drop rules for log management in Last9.

--- a/internal/telemetry/logs/description.go
+++ b/internal/telemetry/logs/description.go
@@ -35,7 +35,7 @@ const GetLogsDescription = `
 
 	Response contains the results of the JSON pipeline query execution.
 
-	Tip: call get_log_services first to confirm the service is ingesting logs, get exact
+	Tip: call get_logging_services first to confirm the service is ingesting logs, get exact
 	service_name and env values, and obtain the physical_index to pass as the index parameter
 	for faster, targeted queries.
 

--- a/internal/telemetry/logs/index_preflight.go
+++ b/internal/telemetry/logs/index_preflight.go
@@ -10,135 +10,102 @@ import (
 
 	"last9-mcp/internal/models"
 	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// physicalIndexResult holds the outcome of a preflight index lookup.
-type physicalIndexResult struct {
-	// Indexes is the list of unique physical index names the service writes to.
-	// Empty means the service has no active log streams.
-	Indexes []string
-	// ServiceFound is false only when the metric returned zero series.
-	// When the query itself fails we set ServiceFound=true to avoid false negatives.
-	ServiceFound bool
+const GetLogServicesDescription = `Discover which services are actively sending logs to Last9, along with their valid environments, physical index, and severity levels.
+
+Use this tool before get_logs or get_service_logs to:
+- Confirm a service is actually ingesting logs (avoids querying for data that doesn't exist)
+- Get the exact service_name and env values to use in log queries (prevents typos and wrong filters)
+- Identify the physical index a service writes to — pass this as the index parameter to get_logs / get_service_logs for faster, targeted queries
+- Understand which severity levels are present for a service
+
+Parameters:
+- service: (Optional) Filter by a specific service name. Omit to list all services.
+- env: (Optional) Filter by environment (e.g. production, staging).
+
+Returns a list of entries with: service_name, env, physical_index, severity.
+`
+
+// GetLogServicesArgs represents the input arguments for the get_log_services tool
+type GetLogServicesArgs struct {
+	Service string `json:"service,omitempty" jsonschema:"Optional service name to filter results"`
+	Env     string `json:"env,omitempty" jsonschema:"Optional environment to filter results (e.g. production)"`
 }
 
-// queryServiceLogIndex queries physical_index_service_count to discover
-// which physical indexes a service is actively writing logs to.
-// On any query failure it returns ServiceFound=true so callers fall back
-// to normal behaviour rather than wrongly reporting no data.
-func queryServiceLogIndex(ctx context.Context, client *http.Client, cfg models.Config, service, env string) physicalIndexResult {
-	query := fmt.Sprintf(`physical_index_service_count{service_name=%q}`, service)
-	if env != "" {
-		query = fmt.Sprintf(`physical_index_service_count{service_name=%q,env=%q}`, service, env)
-	}
-
-	resp, err := utils.MakePromInstantAPIQuery(ctx, client, query, time.Now().UTC().Unix(), cfg)
-	if err != nil {
-		return physicalIndexResult{ServiceFound: true}
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return physicalIndexResult{ServiceFound: true}
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return physicalIndexResult{ServiceFound: true}
-	}
-
-	var results []struct {
-		Metric map[string]string `json:"metric"`
-	}
-	if err := json.Unmarshal(body, &results); err != nil {
-		return physicalIndexResult{ServiceFound: true}
-	}
-
-	if len(results) == 0 {
-		return physicalIndexResult{ServiceFound: false}
-	}
-
-	seen := make(map[string]struct{}, len(results))
-	indexes := make([]string, 0, len(results))
-	for _, r := range results {
-		name := r.Metric["name"]
-		if name == "" {
-			name = "default"
-		}
-		if _, ok := seen[name]; !ok {
-			seen[name] = struct{}{}
-			indexes = append(indexes, name)
-		}
-	}
-
-	return physicalIndexResult{Indexes: indexes, ServiceFound: true}
+// LogServiceEntry represents one distinct combination of service, env, index and severity
+type LogServiceEntry struct {
+	ServiceName   string `json:"service_name"`
+	Env           string `json:"env"`
+	PhysicalIndex string `json:"physical_index"`
+	Severity      string `json:"severity,omitempty"`
 }
 
-// extractServiceNameFromQuery walks a logjson_query pipeline and returns the
-// first ServiceName equality value it finds, or "" if none is present.
-// Only exact $eq matches are considered — partial/regex matches are skipped.
-func extractServiceNameFromQuery(pipeline interface{}) string {
-	stages, ok := pipeline.([]map[string]interface{})
-	if !ok {
-		return ""
-	}
-	for _, stage := range stages {
-		if stage["type"] != "filter" {
-			continue
-		}
-		query, ok := stage["query"].(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if name := extractServiceNameFromCondition(query); name != "" {
-			return name
-		}
-	}
-	return ""
-}
+// NewGetLogServicesHandler creates a handler for the get_log_services tool
+func NewGetLogServicesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetLogServicesArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args GetLogServicesArgs) (*mcp.CallToolResult, any, error) {
+		query := buildLogServicesQuery(args.Service, args.Env)
 
-func extractServiceNameFromCondition(cond map[string]interface{}) string {
-	// {"$eq": ["ServiceName", "value"]}
-	if eqRaw, ok := cond["$eq"]; ok {
-		if pair, ok := eqRaw.([]interface{}); ok && len(pair) == 2 {
-			if field, ok := pair[0].(string); ok && field == "ServiceName" {
-				if val, ok := pair[1].(string); ok {
-					return val
-				}
+		resp, err := utils.MakePromInstantAPIQuery(ctx, client, query, time.Now().UTC().Unix(), cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to query log services: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			return nil, nil, fmt.Errorf("log services query failed with status %d: %s", resp.StatusCode, string(body))
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read response: %w", err)
+		}
+
+		var results []struct {
+			Metric map[string]string `json:"metric"`
+		}
+		if err := json.Unmarshal(body, &results); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse response: %w", err)
+		}
+
+		entries := make([]LogServiceEntry, 0, len(results))
+		for _, r := range results {
+			name := r.Metric["name"]
+			if name == "" {
+				name = "default"
 			}
+			entries = append(entries, LogServiceEntry{
+				ServiceName:   r.Metric["service_name"],
+				Env:           r.Metric["env"],
+				PhysicalIndex: "physical_index:" + name,
+				Severity:      r.Metric["severity"],
+			})
 		}
-	}
-	// recurse into $and / $or
-	for _, key := range []string{"$and", "$or"} {
-		if raw, ok := cond[key]; ok {
-			if items, ok := raw.([]interface{}); ok {
-				for _, item := range items {
-					if sub, ok := item.(map[string]interface{}); ok {
-						if name := extractServiceNameFromCondition(sub); name != "" {
-							return name
-						}
-					}
-				}
-			}
+
+		out, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: string(out)},
+			},
+		}, nil, nil
 	}
-	return ""
 }
 
-// resolveIndexFromPreflight returns the normalised index string to use for the
-// log query (e.g. "physical_index:payments"), or "" to leave the index
-// unset. It also returns a warning string when the service was found on
-// multiple indexes.
-func resolveIndexFromPreflight(result physicalIndexResult) (normalizedIndex string, multiIndexHint string) {
-	if len(result.Indexes) == 1 {
-		return "physical_index:" + result.Indexes[0], ""
+func buildLogServicesQuery(service, env string) string {
+	filter := ""
+	if service != "" && env != "" {
+		filter = fmt.Sprintf(`{service_name=%q,env=%q}`, service, env)
+	} else if service != "" {
+		filter = fmt.Sprintf(`{service_name=%q}`, service)
+	} else if env != "" {
+		filter = fmt.Sprintf(`{env=%q}`, env)
 	}
-	if len(result.Indexes) > 1 {
-		hint := fmt.Sprintf(
-			"Service writes to multiple physical indexes %v — querying all. Specify index explicitly for faster results.",
-			result.Indexes,
-		)
-		return "", hint
-	}
-	return "", ""
+	return "physical_index_service_count" + filter
 }

--- a/internal/telemetry/logs/index_preflight.go
+++ b/internal/telemetry/logs/index_preflight.go
@@ -1,0 +1,93 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
+)
+
+// physicalIndexResult holds the outcome of a preflight index lookup.
+type physicalIndexResult struct {
+	// Indexes is the list of unique physical index names the service writes to.
+	// Empty means the service has no active log streams.
+	Indexes []string
+	// ServiceFound is false only when the metric returned zero series.
+	// When the query itself fails we set ServiceFound=true to avoid false negatives.
+	ServiceFound bool
+}
+
+// queryServiceLogIndex queries physical_index_service_count to discover
+// which physical indexes a service is actively writing logs to.
+// On any query failure it returns ServiceFound=true so callers fall back
+// to normal behaviour rather than wrongly reporting no data.
+func queryServiceLogIndex(ctx context.Context, client *http.Client, cfg models.Config, service, env string) physicalIndexResult {
+	query := fmt.Sprintf(`physical_index_service_count{service_name=%q}`, service)
+	if env != "" {
+		query = fmt.Sprintf(`physical_index_service_count{service_name=%q,env=%q}`, service, env)
+	}
+
+	resp, err := utils.MakePromInstantAPIQuery(ctx, client, query, time.Now().UTC().Unix(), cfg)
+	if err != nil {
+		return physicalIndexResult{ServiceFound: true}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return physicalIndexResult{ServiceFound: true}
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return physicalIndexResult{ServiceFound: true}
+	}
+
+	var results []struct {
+		Metric map[string]string `json:"metric"`
+	}
+	if err := json.Unmarshal(body, &results); err != nil {
+		return physicalIndexResult{ServiceFound: true}
+	}
+
+	if len(results) == 0 {
+		return physicalIndexResult{ServiceFound: false}
+	}
+
+	seen := make(map[string]struct{}, len(results))
+	indexes := make([]string, 0, len(results))
+	for _, r := range results {
+		name := r.Metric["name"]
+		if name == "" {
+			name = "default"
+		}
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
+			indexes = append(indexes, name)
+		}
+	}
+
+	return physicalIndexResult{Indexes: indexes, ServiceFound: true}
+}
+
+// resolveIndexFromPreflight returns the normalised index string to use for the
+// log query (e.g. "physical_index:payments"), or "" to leave the index
+// unset. It also returns a warning string when the service was found on
+// multiple indexes.
+func resolveIndexFromPreflight(result physicalIndexResult) (normalizedIndex string, multiIndexHint string) {
+	if len(result.Indexes) == 1 {
+		return "physical_index:" + result.Indexes[0], ""
+	}
+	if len(result.Indexes) > 1 {
+		hint := fmt.Sprintf(
+			"Service writes to multiple physical indexes %v — querying all. Specify index explicitly for faster results.",
+			result.Indexes,
+		)
+		return "", hint
+	}
+	return "", ""
+}

--- a/internal/telemetry/logs/index_preflight.go
+++ b/internal/telemetry/logs/index_preflight.go
@@ -74,6 +74,57 @@ func queryServiceLogIndex(ctx context.Context, client *http.Client, cfg models.C
 	return physicalIndexResult{Indexes: indexes, ServiceFound: true}
 }
 
+// extractServiceNameFromQuery walks a logjson_query pipeline and returns the
+// first ServiceName equality value it finds, or "" if none is present.
+// Only exact $eq matches are considered — partial/regex matches are skipped.
+func extractServiceNameFromQuery(pipeline interface{}) string {
+	stages, ok := pipeline.([]map[string]interface{})
+	if !ok {
+		return ""
+	}
+	for _, stage := range stages {
+		if stage["type"] != "filter" {
+			continue
+		}
+		query, ok := stage["query"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name := extractServiceNameFromCondition(query); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
+func extractServiceNameFromCondition(cond map[string]interface{}) string {
+	// {"$eq": ["ServiceName", "value"]}
+	if eqRaw, ok := cond["$eq"]; ok {
+		if pair, ok := eqRaw.([]interface{}); ok && len(pair) == 2 {
+			if field, ok := pair[0].(string); ok && field == "ServiceName" {
+				if val, ok := pair[1].(string); ok {
+					return val
+				}
+			}
+		}
+	}
+	// recurse into $and / $or
+	for _, key := range []string{"$and", "$or"} {
+		if raw, ok := cond[key]; ok {
+			if items, ok := raw.([]interface{}); ok {
+				for _, item := range items {
+					if sub, ok := item.(map[string]interface{}); ok {
+						if name := extractServiceNameFromCondition(sub); name != "" {
+							return name
+						}
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
 // resolveIndexFromPreflight returns the normalised index string to use for the
 // log query (e.g. "physical_index:payments"), or "" to leave the index
 // unset. It also returns a warning string when the service was found on

--- a/internal/telemetry/logs/index_preflight.go
+++ b/internal/telemetry/logs/index_preflight.go
@@ -14,19 +14,29 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const GetLoggingServicesDescription = `Discover which services are actively sending logs to Last9, along with their valid environments, physical index, and severity levels.
+const GetLoggingServicesDescription = `Discover which services are actively sending logs to Last9.
 
-Use this tool before get_logs or get_service_logs to:
-- Confirm a service is actually ingesting logs (avoids querying for data that doesn't exist)
-- Get the exact service_name and env values to use in log queries (prevents typos and wrong filters)
-- Identify the physical index a service writes to — pass this as the index parameter to get_logs / get_service_logs for faster, targeted queries
-- Understand which severity levels are present for a service
+Returns the exact service_name, env, physical_index, and severity values present in the log
+ingestion pipeline. Use this BEFORE calling get_logs or get_service_logs to:
+
+1. Confirm a service is actually ingesting logs — if it doesn't appear here, no log query will
+   return results (check drop rules next with get_drop_rules).
+2. Get the exact spelling of service_name and env — prevents silent empty results from typos.
+3. Obtain the physical_index for the service — pass it as the index parameter to get_logs /
+   get_service_logs for faster queries that skip unrelated indexes.
+4. Know which severity levels exist — avoids filtering for severities with no data.
 
 Parameters:
-- service: (Optional) Filter by a specific service name. Omit to list all services.
-- env: (Optional) Filter by environment (e.g. production, staging).
+- service: (Optional) Filter by service name. Omit to list all services sending logs.
+- env: (Optional) Filter by environment (e.g. production, staging). Omit for all environments.
 
-Returns a list of entries with: service_name, env, physical_index, severity.
+Call with no parameters to get a full map of what is ingesting logs and where.
+
+Examples:
+- Before "show errors for checkout service" → call with service="checkout" to confirm it exists
+  and find its physical_index and valid env values.
+- "Which services are sending logs?" → call with no parameters.
+- "Are there logs for api in production?" → call with service="api", env="production".
 `
 
 // GetLoggingServicesArgs represents the input arguments for the get_logging_services tool

--- a/internal/telemetry/logs/index_preflight.go
+++ b/internal/telemetry/logs/index_preflight.go
@@ -14,7 +14,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const GetLogServicesDescription = `Discover which services are actively sending logs to Last9, along with their valid environments, physical index, and severity levels.
+const GetLoggingServicesDescription = `Discover which services are actively sending logs to Last9, along with their valid environments, physical index, and severity levels.
 
 Use this tool before get_logs or get_service_logs to:
 - Confirm a service is actually ingesting logs (avoids querying for data that doesn't exist)
@@ -29,24 +29,24 @@ Parameters:
 Returns a list of entries with: service_name, env, physical_index, severity.
 `
 
-// GetLogServicesArgs represents the input arguments for the get_log_services tool
-type GetLogServicesArgs struct {
+// GetLoggingServicesArgs represents the input arguments for the get_logging_services tool
+type GetLoggingServicesArgs struct {
 	Service string `json:"service,omitempty" jsonschema:"Optional service name to filter results"`
 	Env     string `json:"env,omitempty" jsonschema:"Optional environment to filter results (e.g. production)"`
 }
 
-// LogServiceEntry represents one distinct combination of service, env, index and severity
-type LogServiceEntry struct {
+// LoggingServiceEntry represents one distinct combination of service, env, index and severity
+type LoggingServiceEntry struct {
 	ServiceName   string `json:"service_name"`
 	Env           string `json:"env"`
 	PhysicalIndex string `json:"physical_index"`
 	Severity      string `json:"severity,omitempty"`
 }
 
-// NewGetLogServicesHandler creates a handler for the get_log_services tool
-func NewGetLogServicesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetLogServicesArgs) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, args GetLogServicesArgs) (*mcp.CallToolResult, any, error) {
-		query := buildLogServicesQuery(args.Service, args.Env)
+// NewGetLoggingServicesHandler creates a handler for the get_logging_services tool
+func NewGetLoggingServicesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetLoggingServicesArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args GetLoggingServicesArgs) (*mcp.CallToolResult, any, error) {
+		query := buildLoggingServicesQuery(args.Service, args.Env)
 
 		resp, err := utils.MakePromInstantAPIQuery(ctx, client, query, time.Now().UTC().Unix(), cfg)
 		if err != nil {
@@ -71,13 +71,13 @@ func NewGetLogServicesHandler(client *http.Client, cfg models.Config) func(conte
 			return nil, nil, fmt.Errorf("failed to parse response: %w", err)
 		}
 
-		entries := make([]LogServiceEntry, 0, len(results))
+		entries := make([]LoggingServiceEntry, 0, len(results))
 		for _, r := range results {
 			name := r.Metric["name"]
 			if name == "" {
 				name = "default"
 			}
-			entries = append(entries, LogServiceEntry{
+			entries = append(entries, LoggingServiceEntry{
 				ServiceName:   r.Metric["service_name"],
 				Env:           r.Metric["env"],
 				PhysicalIndex: "physical_index:" + name,
@@ -98,7 +98,7 @@ func NewGetLogServicesHandler(client *http.Client, cfg models.Config) func(conte
 	}
 }
 
-func buildLogServicesQuery(service, env string) string {
+func buildLoggingServicesQuery(service, env string) string {
 	filter := ""
 	if service != "" && env != "" {
 		filter = fmt.Sprintf(`{service_name=%q,env=%q}`, service, env)

--- a/internal/telemetry/logs/index_support_test.go
+++ b/internal/telemetry/logs/index_support_test.go
@@ -479,7 +479,7 @@ func serviceLogsAPIResponse(message string) string {
 	return `{"data":{"result":[{"stream":{"severity":"ERROR"},"values":[["1741500000000000000","` + strings.ReplaceAll(message, `"`, `\"`) + `"]]}]}}`
 }
 
-func TestGetLogServicesHandler_ReturnsEntries(t *testing.T) {
+func TestGetLoggingServicesHandler_ReturnsEntries(t *testing.T) {
 	promResp := `[
 		{"metric":{"name":"payments","service_name":"checkout","env":"production","severity":"error"},"value":[1700000000,"3"]},
 		{"metric":{"name":"default","service_name":"api","env":"staging","severity":"info"},"value":[1700000000,"10"]}
@@ -495,13 +495,13 @@ func TestGetLogServicesHandler_ReturnsEntries(t *testing.T) {
 	}))
 	defer server.Close()
 
-	handler := NewGetLogServicesHandler(server.Client(), testLogsConfig(server.URL))
-	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLogServicesArgs{})
+	handler := NewGetLoggingServicesHandler(server.Client(), testLogsConfig(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLoggingServicesArgs{})
 	if err != nil {
 		t.Fatalf("handler returned error: %v", err)
 	}
 
-	var entries []LogServiceEntry
+	var entries []LoggingServiceEntry
 	if err := json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &entries); err != nil {
 		t.Fatalf("failed to parse response: %v", err)
 	}
@@ -509,7 +509,7 @@ func TestGetLogServicesHandler_ReturnsEntries(t *testing.T) {
 		t.Fatalf("expected 2 entries, got %d", len(entries))
 	}
 
-	byService := make(map[string]LogServiceEntry, len(entries))
+	byService := make(map[string]LoggingServiceEntry, len(entries))
 	for _, e := range entries {
 		byService[e.ServiceName] = e
 	}
@@ -531,7 +531,7 @@ func TestGetLogServicesHandler_ReturnsEntries(t *testing.T) {
 	}
 }
 
-func TestGetLogServicesHandler_FiltersQuery(t *testing.T) {
+func TestGetLoggingServicesHandler_FiltersQuery(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != constants.EndpointPromQueryInstant {
 			t.Fatalf("unexpected path %s", r.URL.Path)
@@ -554,8 +554,8 @@ func TestGetLogServicesHandler_FiltersQuery(t *testing.T) {
 	}))
 	defer server.Close()
 
-	handler := NewGetLogServicesHandler(server.Client(), testLogsConfig(server.URL))
-	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLogServicesArgs{
+	handler := NewGetLoggingServicesHandler(server.Client(), testLogsConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLoggingServicesArgs{
 		Service: "checkout",
 		Env:     "production",
 	})

--- a/internal/telemetry/logs/index_support_test.go
+++ b/internal/telemetry/logs/index_support_test.go
@@ -245,7 +245,7 @@ func TestGetServiceLogsHandler_ExplicitIndexOverridesFallback(t *testing.T) {
 	}
 }
 
-func TestGetServiceLogsHandler_OmitsIndexWhenNotProvided(t *testing.T) {
+func TestGetServiceLogsHandler_OmitsIndexWhenPreflightFails(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case constants.EndpointLogsQueryRange:
@@ -256,7 +256,11 @@ func TestGetServiceLogsHandler_OmitsIndexWhenNotProvided(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(serviceLogsAPIResponse("no-index path worked")))
 		case constants.EndpointPromQueryInstant:
-			t.Fatal("did not expect fallback physical index lookup when index is omitted")
+			// Simulate preflight failure: return a non-array JSON so decode fails
+			// gracefully and the handler proceeds without an index override.
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
 		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
@@ -273,7 +277,82 @@ func TestGetServiceLogsHandler_OmitsIndexWhenNotProvided(t *testing.T) {
 	}
 
 	if got := parseRelativeURL(t, referenceURL(t, result)).Query().Get("index"); got != "" {
-		t.Fatalf("expected dashboard index to be omitted, got %q", got)
+		t.Fatalf("expected dashboard index to be omitted when preflight fails, got %q", got)
+	}
+}
+
+func TestGetServiceLogsHandler_PreflightSetsPhysicalIndex(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case constants.EndpointLogsQueryRange:
+			if got := r.URL.Query().Get("index"); got != "physical_index:payments" {
+				t.Fatalf("expected index physical_index:payments from preflight, got %q", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(serviceLogsAPIResponse("preflight index used")))
+		case constants.EndpointPromQueryInstant:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"metric":{"name":"payments","service_name":"api"},"value":[1700000000,"5"]}]`))
+		case "/logs_settings/physical_indexes":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"properties":[{"id":"idx-123","name":"payments"}]}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	handler := NewGetServiceLogsHandler(server.Client(), testLogsConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceLogsArgs{
+		Service:         "api",
+		LookbackMinutes: 5,
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+}
+
+func TestGetServiceLogsHandler_PreflightEarlyReturnWhenNotSendingLogs(t *testing.T) {
+	logQueryCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case constants.EndpointLogsQueryRange:
+			logQueryCalled = true
+			t.Error("log query should not be called when preflight reports service not sending logs")
+		case constants.EndpointPromQueryInstant:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	handler := NewGetServiceLogsHandler(server.Client(), testLogsConfig(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceLogsArgs{
+		Service:         "ghost-service",
+		LookbackMinutes: 5,
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if logQueryCalled {
+		t.Fatal("log query was called despite preflight reporting service not sending logs")
+	}
+
+	var resp ServiceLogsResponse
+	if err := json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Count != 0 {
+		t.Fatalf("expected count 0, got %d", resp.Count)
+	}
+	if len(resp.NextSteps) == 0 {
+		t.Fatal("expected next_steps hints in early-return response")
 	}
 }
 
@@ -314,7 +393,7 @@ func TestGetServiceLogsHandler_ForwardsLargeLimitWhenProvided(t *testing.T) {
 
 func TestGetServiceLogsHandler_UsesFrontendParityFilters(t *testing.T) {
 	expectedQuery := buildServiceLogsQuery(
-		"l9alert-pinelabs",
+		"l9alert-example",
 		[]string{"error", "fatal", "critical"},
 		nil,
 	)
@@ -364,7 +443,7 @@ func TestGetServiceLogsHandler_UsesFrontendParityFilters(t *testing.T) {
 
 	handler := NewGetServiceLogsHandler(server.Client(), testLogsConfig(server.URL))
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceLogsArgs{
-		Service:         "l9alert-pinelabs",
+		Service:         "l9alert-example",
 		StartTimeISO:    "2026-03-31T07:16:38.000Z",
 		EndTimeISO:      "2026-04-01T07:16:38.907Z",
 		Limit:           100,
@@ -383,25 +462,29 @@ func TestGetServiceLogsHandler_AppliesEnvFilterToFetchAndDeepLink(t *testing.T) 
 	)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != constants.EndpointLogsQueryRange {
+		switch r.URL.Path {
+		case constants.EndpointLogsQueryRange:
+			var body struct {
+				Pipeline []map[string]interface{} `json:"pipeline"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+			if !reflect.DeepEqual(body.Pipeline, expectedQuery) {
+				gotJSON, _ := json.Marshal(body.Pipeline)
+				wantJSON, _ := json.Marshal(expectedQuery)
+				t.Fatalf("unexpected service logs pipeline\nwant: %s\ngot:  %s", wantJSON, gotJSON)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(serviceLogsAPIResponse("env filter matched")))
+		case constants.EndpointPromQueryInstant:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
-
-		var body struct {
-			Pipeline []map[string]interface{} `json:"pipeline"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("failed to decode request body: %v", err)
-		}
-		if !reflect.DeepEqual(body.Pipeline, expectedQuery) {
-			gotJSON, _ := json.Marshal(body.Pipeline)
-			wantJSON, _ := json.Marshal(expectedQuery)
-			t.Fatalf("unexpected service logs pipeline\nwant: %s\ngot:  %s", wantJSON, gotJSON)
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(serviceLogsAPIResponse("env filter matched")))
 	}))
 	defer server.Close()
 

--- a/internal/telemetry/logs/index_support_test.go
+++ b/internal/telemetry/logs/index_support_test.go
@@ -83,21 +83,15 @@ func TestGetLogsHandler_ForwardsLimitWhenProvided(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case constants.EndpointLogsQueryRange:
-					if got := r.URL.Query().Get("limit"); got != tt.expectedLimit {
-						t.Fatalf("expected limit %q, got %q", tt.expectedLimit, got)
-					}
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[]}}`))
-				case constants.EndpointPromQueryInstant:
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(http.StatusOK)
-					_, _ = w.Write([]byte(`{}`))
-				default:
+				if r.URL.Path != constants.EndpointLogsQueryRange {
 					t.Fatalf("unexpected path %s", r.URL.Path)
 				}
+				if got := r.URL.Query().Get("limit"); got != tt.expectedLimit {
+					t.Fatalf("expected limit %q, got %q", tt.expectedLimit, got)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[]}}`))
 			}))
 			defer server.Close()
 
@@ -251,7 +245,7 @@ func TestGetServiceLogsHandler_ExplicitIndexOverridesFallback(t *testing.T) {
 	}
 }
 
-func TestGetServiceLogsHandler_OmitsIndexWhenPreflightFails(t *testing.T) {
+func TestGetServiceLogsHandler_OmitsIndexWhenNotProvided(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case constants.EndpointLogsQueryRange:
@@ -261,12 +255,6 @@ func TestGetServiceLogsHandler_OmitsIndexWhenPreflightFails(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(serviceLogsAPIResponse("no-index path worked")))
-		case constants.EndpointPromQueryInstant:
-			// Simulate preflight failure: return a non-array JSON so decode fails
-			// gracefully and the handler proceeds without an index override.
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{}`))
 		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
@@ -283,82 +271,7 @@ func TestGetServiceLogsHandler_OmitsIndexWhenPreflightFails(t *testing.T) {
 	}
 
 	if got := parseRelativeURL(t, referenceURL(t, result)).Query().Get("index"); got != "" {
-		t.Fatalf("expected dashboard index to be omitted when preflight fails, got %q", got)
-	}
-}
-
-func TestGetServiceLogsHandler_PreflightSetsPhysicalIndex(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case constants.EndpointLogsQueryRange:
-			if got := r.URL.Query().Get("index"); got != "physical_index:payments" {
-				t.Fatalf("expected index physical_index:payments from preflight, got %q", got)
-			}
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(serviceLogsAPIResponse("preflight index used")))
-		case constants.EndpointPromQueryInstant:
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[{"metric":{"name":"payments","service_name":"api"},"value":[1700000000,"5"]}]`))
-		case "/logs_settings/physical_indexes":
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"properties":[{"id":"idx-123","name":"payments"}]}`))
-		default:
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	handler := NewGetServiceLogsHandler(server.Client(), testLogsConfig(server.URL))
-	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceLogsArgs{
-		Service:         "api",
-		LookbackMinutes: 5,
-	})
-	if err != nil {
-		t.Fatalf("handler returned error: %v", err)
-	}
-}
-
-func TestGetServiceLogsHandler_PreflightEarlyReturnWhenNotSendingLogs(t *testing.T) {
-	logQueryCalled := false
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case constants.EndpointLogsQueryRange:
-			logQueryCalled = true
-			t.Error("log query should not be called when preflight reports service not sending logs")
-		case constants.EndpointPromQueryInstant:
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`[]`))
-		default:
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-	}))
-	defer server.Close()
-
-	handler := NewGetServiceLogsHandler(server.Client(), testLogsConfig(server.URL))
-	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceLogsArgs{
-		Service:         "ghost-service",
-		LookbackMinutes: 5,
-	})
-	if err != nil {
-		t.Fatalf("handler returned error: %v", err)
-	}
-	if logQueryCalled {
-		t.Fatal("log query was called despite preflight reporting service not sending logs")
-	}
-
-	var resp ServiceLogsResponse
-	if err := json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &resp); err != nil {
-		t.Fatalf("failed to parse response: %v", err)
-	}
-	if resp.Count != 0 {
-		t.Fatalf("expected count 0, got %d", resp.Count)
-	}
-	if len(resp.NextSteps) == 0 {
-		t.Fatal("expected next_steps hints in early-return response")
+		t.Fatalf("expected dashboard index to be omitted, got %q", got)
 	}
 }
 
@@ -468,29 +381,25 @@ func TestGetServiceLogsHandler_AppliesEnvFilterToFetchAndDeepLink(t *testing.T) 
 	)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case constants.EndpointLogsQueryRange:
-			var body struct {
-				Pipeline []map[string]interface{} `json:"pipeline"`
-			}
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatalf("failed to decode request body: %v", err)
-			}
-			if !reflect.DeepEqual(body.Pipeline, expectedQuery) {
-				gotJSON, _ := json.Marshal(body.Pipeline)
-				wantJSON, _ := json.Marshal(expectedQuery)
-				t.Fatalf("unexpected service logs pipeline\nwant: %s\ngot:  %s", wantJSON, gotJSON)
-			}
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(serviceLogsAPIResponse("env filter matched")))
-		case constants.EndpointPromQueryInstant:
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{}`))
-		default:
+		if r.URL.Path != constants.EndpointLogsQueryRange {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
+
+		var body struct {
+			Pipeline []map[string]interface{} `json:"pipeline"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if !reflect.DeepEqual(body.Pipeline, expectedQuery) {
+			gotJSON, _ := json.Marshal(body.Pipeline)
+			wantJSON, _ := json.Marshal(expectedQuery)
+			t.Fatalf("unexpected service logs pipeline\nwant: %s\ngot:  %s", wantJSON, gotJSON)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(serviceLogsAPIResponse("env filter matched")))
 	}))
 	defer server.Close()
 
@@ -568,4 +477,89 @@ func parseRelativeURL(t *testing.T, raw string) *url.URL {
 
 func serviceLogsAPIResponse(message string) string {
 	return `{"data":{"result":[{"stream":{"severity":"ERROR"},"values":[["1741500000000000000","` + strings.ReplaceAll(message, `"`, `\"`) + `"]]}]}}`
+}
+
+func TestGetLogServicesHandler_ReturnsEntries(t *testing.T) {
+	promResp := `[
+		{"metric":{"name":"payments","service_name":"checkout","env":"production","severity":"error"},"value":[1700000000,"3"]},
+		{"metric":{"name":"default","service_name":"api","env":"staging","severity":"info"},"value":[1700000000,"10"]}
+	]`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != constants.EndpointPromQueryInstant {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(promResp))
+	}))
+	defer server.Close()
+
+	handler := NewGetLogServicesHandler(server.Client(), testLogsConfig(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLogServicesArgs{})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	var entries []LogServiceEntry
+	if err := json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &entries); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	byService := make(map[string]LogServiceEntry, len(entries))
+	for _, e := range entries {
+		byService[e.ServiceName] = e
+	}
+
+	checkout := byService["checkout"]
+	if checkout.PhysicalIndex != "physical_index:payments" {
+		t.Errorf("expected physical_index:payments for checkout, got %q", checkout.PhysicalIndex)
+	}
+	if checkout.Env != "production" {
+		t.Errorf("expected env production for checkout, got %q", checkout.Env)
+	}
+	if checkout.Severity != "error" {
+		t.Errorf("expected severity error for checkout, got %q", checkout.Severity)
+	}
+
+	api := byService["api"]
+	if api.PhysicalIndex != "physical_index:default" {
+		t.Errorf("expected physical_index:default for api, got %q", api.PhysicalIndex)
+	}
+}
+
+func TestGetLogServicesHandler_FiltersQuery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != constants.EndpointPromQueryInstant {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		var body struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		if !strings.Contains(body.Query, `service_name="checkout"`) {
+			t.Errorf("expected service_name filter in query, got %q", body.Query)
+		}
+		if !strings.Contains(body.Query, `env="production"`) {
+			t.Errorf("expected env filter in query, got %q", body.Query)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	handler := NewGetLogServicesHandler(server.Client(), testLogsConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLogServicesArgs{
+		Service: "checkout",
+		Env:     "production",
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
 }

--- a/internal/telemetry/logs/index_support_test.go
+++ b/internal/telemetry/logs/index_support_test.go
@@ -563,3 +563,128 @@ func TestGetLoggingServicesHandler_FiltersQuery(t *testing.T) {
 		t.Fatalf("handler returned error: %v", err)
 	}
 }
+
+func TestGetLoggingServicesHandler_ServiceOnlyFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		if !strings.Contains(body.Query, `service_name="api"`) {
+			t.Errorf("expected service_name filter, got %q", body.Query)
+		}
+		if strings.Contains(body.Query, "env=") {
+			t.Errorf("unexpected env filter in query, got %q", body.Query)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	handler := NewGetLoggingServicesHandler(server.Client(), testLogsConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLoggingServicesArgs{Service: "api"})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+}
+
+func TestGetLoggingServicesHandler_EnvOnlyFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		if !strings.Contains(body.Query, `env="production"`) {
+			t.Errorf("expected env filter, got %q", body.Query)
+		}
+		if strings.Contains(body.Query, "service_name=") {
+			t.Errorf("unexpected service_name filter, got %q", body.Query)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	handler := NewGetLoggingServicesHandler(server.Client(), testLogsConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLoggingServicesArgs{Env: "production"})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+}
+
+func TestGetLoggingServicesHandler_NoFilterQuery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Query string `json:"query"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
+		if body.Query != "physical_index_service_count" {
+			t.Errorf("expected bare metric query, got %q", body.Query)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	handler := NewGetLoggingServicesHandler(server.Client(), testLogsConfig(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLoggingServicesArgs{})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	var entries []LoggingServiceEntry
+	if err := json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &entries); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty entries for empty prom response, got %d", len(entries))
+	}
+}
+
+func TestGetLoggingServicesHandler_MissingNameDefaultsToDefault(t *testing.T) {
+	promResp := `[{"metric":{"service_name":"worker","env":"production","severity":"warn"},"value":[1700000000,"1"]}]`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(promResp))
+	}))
+	defer server.Close()
+
+	handler := NewGetLoggingServicesHandler(server.Client(), testLogsConfig(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLoggingServicesArgs{})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	var entries []LoggingServiceEntry
+	if err := json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &entries); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].PhysicalIndex != "physical_index:default" {
+		t.Errorf("missing name label should default to physical_index:default, got %q", entries[0].PhysicalIndex)
+	}
+}
+
+func TestGetLoggingServicesHandler_PromError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	handler := NewGetLoggingServicesHandler(server.Client(), testLogsConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLoggingServicesArgs{})
+	if err == nil {
+		t.Fatal("expected error on prom 500, got nil")
+	}
+}

--- a/internal/telemetry/logs/index_support_test.go
+++ b/internal/telemetry/logs/index_support_test.go
@@ -83,15 +83,21 @@ func TestGetLogsHandler_ForwardsLimitWhenProvided(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != constants.EndpointLogsQueryRange {
+				switch r.URL.Path {
+				case constants.EndpointLogsQueryRange:
+					if got := r.URL.Query().Get("limit"); got != tt.expectedLimit {
+						t.Fatalf("expected limit %q, got %q", tt.expectedLimit, got)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[]}}`))
+				case constants.EndpointPromQueryInstant:
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{}`))
+				default:
 					t.Fatalf("unexpected path %s", r.URL.Path)
 				}
-				if got := r.URL.Query().Get("limit"); got != tt.expectedLimit {
-					t.Fatalf("expected limit %q, got %q", tt.expectedLimit, got)
-				}
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[]}}`))
 			}))
 			defer server.Close()
 

--- a/internal/telemetry/logs/logs.go
+++ b/internal/telemetry/logs/logs.go
@@ -66,37 +66,17 @@ func handleLogJSONQuery(ctx context.Context, client *http.Client, cfg models.Con
 		return nil, fmt.Errorf("failed to parse time range: %v", err)
 	}
 
-	// Preflight: when no index is specified, use physical_index_service_count to
-	// discover the correct index from the ServiceName filter in the query.
-	userProvidedIndex := strings.TrimSpace(args.Index) != ""
-	var preflightHints []string
-	if !userProvidedIndex {
-		if service := extractServiceNameFromQuery(logjsonQuery); service != "" {
-			preflight := queryServiceLogIndex(ctx, client, cfg, service, "")
-			resolvedIndex, hint := resolveIndexFromPreflight(preflight)
-			if resolvedIndex != "" {
-				args.Index = resolvedIndex
-			}
-			if hint != "" {
-				preflightHints = append(preflightHints, hint)
-			}
-		}
-	}
-
 	result, err := fetchLogJSONQuery(ctx, client, cfg, logjsonQuery, startTime, endTime, args)
 	if err != nil {
 		return nil, err
 	}
 	annotateEmptyLogsResult(result)
-	if len(preflightHints) > 0 {
-		existing, _ := result["next_steps"].([]string)
-		result["next_steps"] = append(preflightHints, existing...)
-	}
 
 	// Build deep link URL
 	dlBuilder := deeplink.NewBuilder(cfg.OrgSlug, cfg.ClusterID)
+	hasExplicitIndex := strings.TrimSpace(args.Index) != ""
 	dashboardIndex := ""
-	if strings.TrimSpace(args.Index) != "" {
+	if hasExplicitIndex {
 		resolvedIndex, err := utils.ResolveLogIndexDashboardParam(ctx, client, cfg, args.Index)
 		if err == nil {
 			dashboardIndex = resolvedIndex
@@ -104,7 +84,7 @@ func handleLogJSONQuery(ctx context.Context, client *http.Client, cfg models.Con
 	}
 	dashboardURL := dlBuilder.BuildLogsLink(startTime, endTime, logjsonQuery, dashboardIndex)
 	var meta mcp.Meta
-	if !userProvidedIndex || dashboardIndex != "" {
+	if !hasExplicitIndex || dashboardIndex != "" {
 		meta = deeplink.ToMeta(dashboardURL)
 	}
 

--- a/internal/telemetry/logs/logs.go
+++ b/internal/telemetry/logs/logs.go
@@ -66,17 +66,37 @@ func handleLogJSONQuery(ctx context.Context, client *http.Client, cfg models.Con
 		return nil, fmt.Errorf("failed to parse time range: %v", err)
 	}
 
+	// Preflight: when no index is specified, use physical_index_service_count to
+	// discover the correct index from the ServiceName filter in the query.
+	userProvidedIndex := strings.TrimSpace(args.Index) != ""
+	var preflightHints []string
+	if !userProvidedIndex {
+		if service := extractServiceNameFromQuery(logjsonQuery); service != "" {
+			preflight := queryServiceLogIndex(ctx, client, cfg, service, "")
+			resolvedIndex, hint := resolveIndexFromPreflight(preflight)
+			if resolvedIndex != "" {
+				args.Index = resolvedIndex
+			}
+			if hint != "" {
+				preflightHints = append(preflightHints, hint)
+			}
+		}
+	}
+
 	result, err := fetchLogJSONQuery(ctx, client, cfg, logjsonQuery, startTime, endTime, args)
 	if err != nil {
 		return nil, err
 	}
 	annotateEmptyLogsResult(result)
+	if len(preflightHints) > 0 {
+		existing, _ := result["next_steps"].([]string)
+		result["next_steps"] = append(preflightHints, existing...)
+	}
 
 	// Build deep link URL
 	dlBuilder := deeplink.NewBuilder(cfg.OrgSlug, cfg.ClusterID)
 	dashboardIndex := ""
-	hasExplicitIndex := strings.TrimSpace(args.Index) != ""
-	if hasExplicitIndex {
+	if strings.TrimSpace(args.Index) != "" {
 		resolvedIndex, err := utils.ResolveLogIndexDashboardParam(ctx, client, cfg, args.Index)
 		if err == nil {
 			dashboardIndex = resolvedIndex
@@ -84,7 +104,7 @@ func handleLogJSONQuery(ctx context.Context, client *http.Client, cfg models.Con
 	}
 	dashboardURL := dlBuilder.BuildLogsLink(startTime, endTime, logjsonQuery, dashboardIndex)
 	var meta mcp.Meta
-	if !hasExplicitIndex || dashboardIndex != "" {
+	if !userProvidedIndex || dashboardIndex != "" {
 		meta = deeplink.ToMeta(dashboardURL)
 	}
 

--- a/internal/telemetry/logs/logs.go
+++ b/internal/telemetry/logs/logs.go
@@ -532,6 +532,17 @@ func emptyLogsNextSteps(service string) []string {
 	}
 }
 
+// serviceNotSendingLogsNextSteps is used when physical_index_service_count
+// returns no series for the service — meaning no logs are being ingested at all.
+func serviceNotSendingLogsNextSteps(service string) []string {
+	return []string{
+		fmt.Sprintf("No active log streams found for service %q in physical_index_service_count — the service may not be sending logs to Last9.", service),
+		fmt.Sprintf("A drop rule may be dropping all logs before ingestion — run get_drop_rules and check for rules matching service_name=%q.", service),
+		"Verify the service instrumentation is configured correctly and the Last9 endpoint/credentials are valid.",
+		"Check get_service_traces to confirm whether the service is visible at all.",
+	}
+}
+
 // parseTimeRangeFromArgs extracts start and end times from GetLogsArgs
 func parseTimeRangeFromArgs(args GetLogsArgs) (int64, int64, error) {
 	return parseTimeRangeFromArgsAt(args, time.Now().UTC())

--- a/internal/telemetry/logs/logs.go
+++ b/internal/telemetry/logs/logs.go
@@ -70,6 +70,7 @@ func handleLogJSONQuery(ctx context.Context, client *http.Client, cfg models.Con
 	if err != nil {
 		return nil, err
 	}
+	annotateEmptyLogsResult(result)
 
 	// Build deep link URL
 	dlBuilder := deeplink.NewBuilder(cfg.OrgSlug, cfg.ClusterID)
@@ -491,12 +492,43 @@ func mapsClone(source map[string]interface{}) map[string]interface{} {
 	return cloned
 }
 
+func annotateEmptyLogsResult(result map[string]interface{}) {
+	if result == nil {
+		return
+	}
+	if _, exists := result["next_steps"]; exists {
+		return
+	}
+	data, ok := result["data"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	items, _ := data["result"].([]interface{})
+	if len(items) == 0 {
+		result["next_steps"] = emptyLogsNextSteps("")
+	}
+}
+
 func emptyStreamsResponse() map[string]interface{} {
 	return map[string]interface{}{
 		"data": map[string]interface{}{
 			"resultType": "streams",
 			"result":     []interface{}{},
 		},
+		"next_steps": emptyLogsNextSteps(""),
+	}
+}
+
+func emptyLogsNextSteps(service string) []string {
+	serviceHint := "this service"
+	if service != "" {
+		serviceHint = fmt.Sprintf("service %q", service)
+	}
+	return []string{
+		fmt.Sprintf("A drop rule may be silently filtering logs for %s — run get_drop_rules to inspect active rules and check for matches on service name or attributes.", serviceHint),
+		"Widen the time range: logs may exist outside the queried window.",
+		"Verify the service is actually emitting logs by checking get_service_summary or get_service_traces.",
+		"If using severity_filters or body_filters, try removing them to confirm logs exist at all.",
 	}
 }
 

--- a/internal/telemetry/logs/query_sanitize_test.go
+++ b/internal/telemetry/logs/query_sanitize_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"last9-mcp/internal/constants"
+
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -198,6 +200,13 @@ func TestGetLogsHandlerNormalizesAliasesBeforeAPICall(t *testing.T) {
 		}
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Preflight prom query — respond gracefully without counting or validating.
+		if r.URL.Path == constants.EndpointPromQueryInstant {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
 		requestCount++
 		defer func() {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/telemetry/logs/query_sanitize_test.go
+++ b/internal/telemetry/logs/query_sanitize_test.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"last9-mcp/internal/constants"
-
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -200,13 +198,6 @@ func TestGetLogsHandlerNormalizesAliasesBeforeAPICall(t *testing.T) {
 		}
 	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Preflight prom query — respond gracefully without counting or validating.
-		if r.URL.Path == constants.EndpointPromQueryInstant {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{}`))
-			return
-		}
 		requestCount++
 		defer func() {
 			w.Header().Set("Content-Type", "application/json")

--- a/internal/telemetry/logs/service_logs.go
+++ b/internal/telemetry/logs/service_logs.go
@@ -50,7 +50,7 @@ Parameters:
 
 Returns a list of log entries with full details including message content, timestamps, severity, and attributes.
 
-- Call get_log_services first to confirm the service is ingesting logs, get exact service_name
+- Call get_logging_services first to confirm the service is ingesting logs, get exact service_name
   and env values, and obtain the physical_index to pass as the index parameter for faster queries.
 - If unsure of the service or env name, call "did_you_mean" first to find the correct spelling.`
 

--- a/internal/telemetry/logs/service_logs.go
+++ b/internal/telemetry/logs/service_logs.go
@@ -124,16 +124,45 @@ func NewGetServiceLogsHandler(client *http.Client, cfg models.Config) func(conte
 			return nil, nil, fmt.Errorf("invalid index: %w", err)
 		}
 
+		// Preflight: use physical_index_service_count to discover the correct index
+		// and short-circuit when the service has no active log streams.
+		var preflightHints []string
+		if normalizedIndex == "" {
+			preflight := queryServiceLogIndex(ctx, client, cfg, args.Service, args.Env)
+			if !preflight.ServiceFound {
+				resp := &ServiceLogsResponse{
+					Service:   args.Service,
+					StartTime: startTime.Format(time.RFC3339),
+					EndTime:   endTime.Format(time.RFC3339),
+					Count:     0,
+					Logs:      []LogEntry{},
+					NextSteps: serviceNotSendingLogsNextSteps(args.Service),
+				}
+				responseJSON, _ := json.MarshalIndent(resp, "", "  ")
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{Text: string(responseJSON)}},
+				}, nil, nil
+			}
+			resolvedIndex, hint := resolveIndexFromPreflight(preflight)
+			normalizedIndex = resolvedIndex
+			if hint != "" {
+				preflightHints = append(preflightHints, hint)
+			}
+		}
+
 		logjsonQuery := buildServiceLogsQuery(args.Service, args.SeverityFilters, args.BodyFilters)
 		if args.Env != "" {
 			logjsonQuery = addServiceLogsEnvFilter(logjsonQuery, args.Env)
 		}
 
-		// Fetch raw logs using the existing logs API approach. When index is omitted,
-		// keep the query on the no-index path that matches the live dashboard/API.
+		// Fetch raw logs using the existing logs API approach.
 		logs, err := fetchServiceLogs(ctx, client, cfg, args.Service, startTime, endTime, limit, logjsonQuery, normalizedIndex)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to fetch service logs: %w", err)
+		}
+
+		if len(preflightHints) > 0 {
+			logs.NextSteps = append(preflightHints, logs.NextSteps...)
 		}
 
 		// Format response as JSON for better readability

--- a/internal/telemetry/logs/service_logs.go
+++ b/internal/telemetry/logs/service_logs.go
@@ -61,6 +61,7 @@ type ServiceLogsResponse struct {
 	Logs          []LogEntry `json:"logs"`
 	PartialResult bool       `json:"partial_result,omitempty"`
 	Warning       string     `json:"warning,omitempty"`
+	NextSteps     []string   `json:"next_steps,omitempty"`
 }
 
 // LogEntry represents a single log entry
@@ -389,6 +390,9 @@ func fetchServiceLogs(ctx context.Context, client *http.Client, cfg models.Confi
 	if partialErr != nil {
 		response.PartialResult = true
 		response.Warning = fmt.Sprintf("Returning partial results: %v", partialErr)
+	}
+	if len(logs) == 0 {
+		response.NextSteps = emptyLogsNextSteps(service)
 	}
 
 	return response, nil

--- a/internal/telemetry/logs/service_logs.go
+++ b/internal/telemetry/logs/service_logs.go
@@ -50,6 +50,8 @@ Parameters:
 
 Returns a list of log entries with full details including message content, timestamps, severity, and attributes.
 
+- Call get_log_services first to confirm the service is ingesting logs, get exact service_name
+  and env values, and obtain the physical_index to pass as the index parameter for faster queries.
 - If unsure of the service or env name, call "did_you_mean" first to find the correct spelling.`
 
 // ServiceLogsResponse represents the response structure for service logs
@@ -124,45 +126,14 @@ func NewGetServiceLogsHandler(client *http.Client, cfg models.Config) func(conte
 			return nil, nil, fmt.Errorf("invalid index: %w", err)
 		}
 
-		// Preflight: use physical_index_service_count to discover the correct index
-		// and short-circuit when the service has no active log streams.
-		var preflightHints []string
-		if normalizedIndex == "" {
-			preflight := queryServiceLogIndex(ctx, client, cfg, args.Service, args.Env)
-			if !preflight.ServiceFound {
-				resp := &ServiceLogsResponse{
-					Service:   args.Service,
-					StartTime: startTime.Format(time.RFC3339),
-					EndTime:   endTime.Format(time.RFC3339),
-					Count:     0,
-					Logs:      []LogEntry{},
-					NextSteps: serviceNotSendingLogsNextSteps(args.Service),
-				}
-				responseJSON, _ := json.MarshalIndent(resp, "", "  ")
-				return &mcp.CallToolResult{
-					Content: []mcp.Content{&mcp.TextContent{Text: string(responseJSON)}},
-				}, nil, nil
-			}
-			resolvedIndex, hint := resolveIndexFromPreflight(preflight)
-			normalizedIndex = resolvedIndex
-			if hint != "" {
-				preflightHints = append(preflightHints, hint)
-			}
-		}
-
 		logjsonQuery := buildServiceLogsQuery(args.Service, args.SeverityFilters, args.BodyFilters)
 		if args.Env != "" {
 			logjsonQuery = addServiceLogsEnvFilter(logjsonQuery, args.Env)
 		}
 
-		// Fetch raw logs using the existing logs API approach.
 		logs, err := fetchServiceLogs(ctx, client, cfg, args.Service, startTime, endTime, limit, logjsonQuery, normalizedIndex)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to fetch service logs: %w", err)
-		}
-
-		if len(preflightHints) > 0 {
-			logs.NextSteps = append(preflightHints, logs.NextSteps...)
 		}
 
 		// Format response as JSON for better readability

--- a/tools.go
+++ b/tools.go
@@ -120,6 +120,12 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCa
 		Description: logs.GetServiceLogsDescription,
 	}, logs.NewGetServiceLogsHandler(client, cfg))
 
+	// Register log services discovery tool
+	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+		Name:        "get_log_services",
+		Description: logs.GetLogServicesDescription,
+	}, logs.NewGetLogServicesHandler(client, cfg))
+
 	// Register drop rules tool
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
 		Name:        "get_drop_rules",

--- a/tools.go
+++ b/tools.go
@@ -122,9 +122,9 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCa
 
 	// Register log services discovery tool
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
-		Name:        "get_log_services",
-		Description: logs.GetLogServicesDescription,
-	}, logs.NewGetLogServicesHandler(client, cfg))
+		Name:        "get_logging_services",
+		Description: logs.GetLoggingServicesDescription,
+	}, logs.NewGetLoggingServicesHandler(client, cfg))
 
 	// Register drop rules tool
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{


### PR DESCRIPTION
## Summary

- When `get_logs` or `get_service_logs` returns zero results, the response now includes a `next_steps` array with actionable hints for the AI agent
- Drop rule check is the first hint (most common silent cause of missing logs)
- Other hints: widen time range, cross-check via `get_service_summary`/`get_service_traces`, remove filters to isolate

## Motivation

During customer debugging, a drop rule was silently filtering logs for a service. It took significant time to discover because there was no signal pointing toward drop rules when logs appeared absent. This change surfaces that hint automatically.

## Response shape

`get_service_logs` (empty):
```json
{
  "service": "payment-service",
  "count": 0,
  "logs": [],
  "next_steps": [
    "A drop rule may be silently filtering logs for service \"payment-service\" — run get_drop_rules to inspect active rules and check for matches on service name or attributes.",
    "Widen the time range: logs may exist outside the queried window.",
    "Verify the service is actually emitting logs by checking get_service_summary or get_service_traces.",
    "If using severity_filters or body_filters, try removing them to confirm logs exist at all."
  ]
}
```

`get_logs` (empty streams): same `next_steps` key added at top level.

## Test plan

- [ ] `go test ./internal/telemetry/logs/...` passes
- [ ] Call `get_service_logs` for a service with no logs — verify `next_steps` present
- [ ] Call `get_service_logs` for a service with logs — verify `next_steps` absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)