### PR TITLE
fix(apm): use service_name label in get_service_environments filter

### DIFF
--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -2058,7 +2058,7 @@ func NewServiceEnvironmentsHandler(client *http.Client, cfg models.Config) func(
 
 		var matchQuery string
 		if args.Service != "" {
-			matchQuery = fmt.Sprintf("domain_attributes_count{span_kind='SPAN_KIND_SERVER',service=%q}", args.Service)
+			matchQuery = fmt.Sprintf("domain_attributes_count{span_kind='SPAN_KIND_SERVER',service_name=%q}", args.Service)
 		} else {
 			matchQuery = "domain_attributes_count{span_kind='SPAN_KIND_SERVER'}"
 		}


### PR DESCRIPTION
## Summary

Fix the `service` filter on `get_service_environments` added in #123 — it was always returning `[]` because it queried the wrong Prometheus label.

The handler built:
```promql
domain_attributes_count{span_kind='SPAN_KIND_SERVER',service="<name>"}
```
but the actual label on that metric is `service_name`. The selector matched zero series, so every call with a service argument returned an empty array even when the service clearly had active traffic.

Every other PromQL expression in `internal/apm/apm.go` already uses `service_name` — this was a one-line oversight in the new code path.

## Repro (before fix)

```
get_service_environments()                         → ["gamma","production"]
get_service_environments(service="last9-api")      → []                        # BUG
get_service_environments(service="engineer9-web")  → []                        # BUG
get_service_environments(service="tempo-api")      → []                        # BUG
```

All three services have confirmed active traces and show up in `get_service_summary`.

Verified the label name with `prometheus_labels`:
```
domain_attributes_count{span_kind="SPAN_KIND_SERVER"} labels:
  __name__, env, l6ecluster, l6elake, l6etenant, process_runtime_name,
  process_runtime_version, segment, service_name, span_kind, telemetry_sdk_language
```

Direct check:
- `{..., service_name="last9-api"}` → `["gamma","production"]` ✅
- `{..., service="last9-api"}`      → `[]` ❌

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/apm/...` passes
- [ ] After deploy: `get_service_environments(service="last9-api")` returns non-empty env list
- [ ] After deploy: `get_service_environments()` (no arg) still returns all envs

🤖 Generated with [Claude Code](https://claude.com/claude-code)