### PR TITLE
ENG-916: Add service.version tracking and tenant identity across all deployments

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,6 +123,10 @@ jobs:
           VERSION=$(jq -r .version package.json)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Get build time
+        id: build_time
+        run: echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
       - name: Extract branch name
         id: extract_branch
         run: |
@@ -165,6 +169,7 @@ jobs:
           build-args: |
             VERSION=${{ steps.get_version.outputs.version }}
             COMMIT=${{ github.sha }}
+            BUILD_TIME=${{ steps.build_time.outputs.build_time }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
@@ -184,6 +189,7 @@ jobs:
           build-args: |
             VERSION=${{ needs.tag-and-release.outputs.new_version }}
             COMMIT=${{ github.sha }}
+            BUILD_TIME=${{ steps.build_time.outputs.build_time }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
@@ -205,10 +211,12 @@ jobs:
           VERSION: ${{ steps.get_version.outputs.version }}
           COMMIT: ${{ github.sha }}
           BRANCH: ${{ steps.extract_branch.outputs.branch_name }}
+          BUILD_TIME: ${{ steps.build_time.outputs.build_time }}
         run: |
           docker build -f Dockerfile \
             --build-arg VERSION="${VERSION}" \
             --build-arg COMMIT="${COMMIT}" \
+            --build-arg BUILD_TIME="${BUILD_TIME}" \
             -t 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build .
           docker tag 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${BRANCH}
           docker tag 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${BRANCH}-v${VERSION}
@@ -220,10 +228,12 @@ jobs:
         env:
           VERSION: ${{ needs.tag-and-release.outputs.new_version }}
           COMMIT: ${{ github.sha }}
+          BUILD_TIME: ${{ steps.build_time.outputs.build_time }}
         run: |
           docker build -f Dockerfile \
             --build-arg VERSION="${VERSION}" \
             --build-arg COMMIT="${COMMIT}" \
+            --build-arg BUILD_TIME="${BUILD_TIME}" \
             -t 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build .
           for tag in v${VERSION} latest; do
             docker tag 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:$tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,6 +162,9 @@ jobs:
           tags: |
             docker-registry.last9.io/last9/last9-mcp-server:${{ steps.extract_branch.outputs.branch_name }}
             docker-registry.last9.io/last9/last9-mcp-server:${{ steps.extract_branch.outputs.branch_name }}-v${{ steps.get_version.outputs.version }}
+          build-args: |
+            VERSION=${{ steps.get_version.outputs.version }}
+            COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
@@ -178,6 +181,9 @@ jobs:
           tags: |
             docker-registry.last9.io/last9/last9-mcp-server:v${{ needs.tag-and-release.outputs.new_version }}
             docker-registry.last9.io/last9/last9-mcp-server:latest
+          build-args: |
+            VERSION=${{ needs.tag-and-release.outputs.new_version }}
+            COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
@@ -195,18 +201,31 @@ jobs:
         if: |
           github.event_name == 'push' &&
           startsWith(github.ref, 'refs/heads/release-')
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+          COMMIT: ${{ github.sha }}
+          BRANCH: ${{ steps.extract_branch.outputs.branch_name }}
         run: |
-          docker build -f Dockerfile -t 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build .
-          docker tag 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${{ steps.extract_branch.outputs.branch_name }}
-          docker tag 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${{ steps.extract_branch.outputs.branch_name }}-v${{ steps.get_version.outputs.version }}
-          docker push 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${{ steps.extract_branch.outputs.branch_name }}
-          docker push 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${{ steps.extract_branch.outputs.branch_name }}-v${{ steps.get_version.outputs.version }}
+          docker build -f Dockerfile \
+            --build-arg VERSION="${VERSION}" \
+            --build-arg COMMIT="${COMMIT}" \
+            -t 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build .
+          docker tag 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${BRANCH}
+          docker tag 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${BRANCH}-v${VERSION}
+          docker push 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${BRANCH}
+          docker push 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${BRANCH}-v${VERSION}
 
       - name: Push to Amazon ECR (Main Branch)
         if: needs.tag-and-release.outputs.version_changed == 'true'
+        env:
+          VERSION: ${{ needs.tag-and-release.outputs.new_version }}
+          COMMIT: ${{ github.sha }}
         run: |
-          docker build -f Dockerfile -t 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build .
-          for tag in v${{ needs.tag-and-release.outputs.new_version }} latest; do
+          docker build -f Dockerfile \
+            --build-arg VERSION="${VERSION}" \
+            --build-arg COMMIT="${COMMIT}" \
+            -t 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build .
+          for tag in v${VERSION} latest; do
             docker tag 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:$tag
             docker push 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:$tag
           done

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,14 @@ RUN go mod download
 # Copy source code
 COPY . .
 
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_TIME=unknown
+
 # Build the application for STDIO mode (default MCP pattern)
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o last9-mcp-server .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+    -ldflags "-s -w -X main.Version=${VERSION} -X main.CommitSHA=${COMMIT} -X main.BuildTime=${BUILD_TIME}" \
+    -o last9-mcp-server .
 
 # Final stage - minimal image for MCP server
 FROM alpine:latest

--- a/internal/telemetry/setup.go
+++ b/internal/telemetry/setup.go
@@ -37,7 +37,6 @@ func InitProviders(ctx context.Context, version, tenant, clusterID string) (func
 			semconv.ServiceName(mcpServiceName),
 			semconv.ServiceVersion(version),
 			attribute.String("mcp.server.type", "golang"),
-			attribute.String("mcp.server.version", version),
 			attribute.String("last9.tenant", tenant),
 			attribute.String("last9.cluster_id", clusterID),
 		),

--- a/internal/telemetry/setup.go
+++ b/internal/telemetry/setup.go
@@ -27,7 +27,7 @@ const mcpServiceName = "last9-mcp"
 // Exporters pick up OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_HEADERS
 // from the environment automatically.
 // Returns a shutdown function that must be called on process exit to flush buffers.
-func InitProviders(ctx context.Context, version string) (func(context.Context) error, error) {
+func InitProviders(ctx context.Context, version, tenant, clusterID string) (func(context.Context) error, error) {
 	res, err := resource.New(ctx,
 		resource.WithFromEnv(),
 		resource.WithProcess(),
@@ -38,6 +38,8 @@ func InitProviders(ctx context.Context, version string) (func(context.Context) e
 			semconv.ServiceVersion(version),
 			attribute.String("mcp.server.type", "golang"),
 			attribute.String("mcp.server.version", version),
+			attribute.String("last9.tenant", tenant),
+			attribute.String("last9.cluster_id", clusterID),
 		),
 	)
 	if err != nil && !errors.Is(err, resource.ErrPartialResource) {

--- a/main.go
+++ b/main.go
@@ -85,7 +85,6 @@ func SetupConfig(defaults models.Config) (models.Config, error) {
 	return cfg, nil
 }
 
-
 func main() {
 	log.Printf("Starting Last9 MCP Server v%s", Version)
 
@@ -162,7 +161,7 @@ func main() {
 		)
 		if err != nil {
 			slog.Warn("failed to create server info gauge", "error", err)
-		} else if _, err := meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		} else if reg, err := meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
 			o.ObserveInt64(serverInfo, 1,
 				metric.WithAttributes(
 					attribute.String("version", Version),
@@ -174,6 +173,8 @@ func main() {
 			return nil
 		}, serverInfo); err != nil {
 			slog.Warn("failed to register server info callback", "error", err)
+		} else {
+			defer reg.Unregister()
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -13,16 +13,6 @@ import (
 	"strconv"
 	"time"
 
-	"last9-mcp/internal/attributes"
-	"last9-mcp/internal/auth"
-	"last9-mcp/internal/models"
-	l9telemetry "last9-mcp/internal/telemetry"
-	"last9-mcp/internal/utils"
-
-	"bytes"
-	"encoding/json"
-	"net/http"
-
 	"github.com/joho/godotenv"
 	last9mcp "github.com/last9/mcp-go-sdk/mcp"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -33,7 +23,11 @@ import (
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 
-	"last9-mcp/internal/constants"
+	"last9-mcp/internal/attributes"
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/models"
+	l9telemetry "last9-mcp/internal/telemetry"
+	"last9-mcp/internal/utils"
 )
 
 // Version information
@@ -91,46 +85,6 @@ func SetupConfig(defaults models.Config) (models.Config, error) {
 	return cfg, nil
 }
 
-// emitDeployChangeEvent records a deploy change event in Last9 so it can be
-// overlaid on latency/error charts to correlate regressions with releases.
-// Fires only for non-dev builds to avoid noise in local development.
-func emitDeployChangeEvent(cfg models.Config) {
-	if Version == "dev" {
-		return
-	}
-	payload, err := json.Marshal(map[string]any{
-		"name": "MCP server start",
-		"attributes": map[string]string{
-			"version": Version,
-			"commit":  CommitSHA,
-			"service": "last9-mcp",
-		},
-		"event_state": "start",
-	})
-	if err != nil {
-		slog.Warn("failed to marshal change event payload", "error", err)
-		return
-	}
-	ctx := context.Background()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
-		cfg.APIBaseURL+"/change_events", bytes.NewReader(payload))
-	if err != nil {
-		slog.Warn("failed to create change event request", "error", err)
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set(constants.HeaderXLast9APIToken,
-		constants.BearerPrefix+cfg.TokenManager.GetAccessToken(ctx))
-	resp, err := auth.GetHTTPClient().Do(req)
-	if err != nil {
-		slog.Warn("failed to emit deploy change event", "error", err)
-		return
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 300 {
-		slog.Warn("deploy change event returned non-2xx", "status", resp.StatusCode)
-	}
-}
 
 func main() {
 	log.Printf("Starting Last9 MCP Server v%s", Version)
@@ -189,8 +143,6 @@ func main() {
 		"version", Version,
 	)
 
-	go emitDeployChangeEvent(cfg)
-
 	// Create attribute cache and perform best-effort initial fetch
 	attrCache := attributes.NewAttributeCache(auth.GetHTTPClient(), cfg)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -215,8 +167,8 @@ func main() {
 				metric.WithAttributes(
 					attribute.String("version", Version),
 					attribute.String("commit", CommitSHA),
-					attribute.String("tenant", cfg.OrgSlug),
-					attribute.String("cluster_id", cfg.ClusterID),
+					attribute.String("last9.tenant", cfg.OrgSlug),
+					attribute.String("last9.cluster_id", cfg.ClusterID),
 				),
 			)
 			return nil

--- a/main.go
+++ b/main.go
@@ -19,13 +19,21 @@ import (
 	l9telemetry "last9-mcp/internal/telemetry"
 	"last9-mcp/internal/utils"
 
+	"bytes"
+	"encoding/json"
+	"net/http"
+
 	"github.com/joho/godotenv"
 	last9mcp "github.com/last9/mcp-go-sdk/mcp"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/peterbourgon/ff/v3"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
+
+	"last9-mcp/internal/constants"
 )
 
 // Version information
@@ -83,6 +91,47 @@ func SetupConfig(defaults models.Config) (models.Config, error) {
 	return cfg, nil
 }
 
+// emitDeployChangeEvent records a deploy change event in Last9 so it can be
+// overlaid on latency/error charts to correlate regressions with releases.
+// Fires only for non-dev builds to avoid noise in local development.
+func emitDeployChangeEvent(cfg models.Config) {
+	if Version == "dev" {
+		return
+	}
+	payload, err := json.Marshal(map[string]any{
+		"name": "MCP server start",
+		"attributes": map[string]string{
+			"version": Version,
+			"commit":  CommitSHA,
+			"service": "last9-mcp",
+		},
+		"event_state": "start",
+	})
+	if err != nil {
+		slog.Warn("failed to marshal change event payload", "error", err)
+		return
+	}
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		cfg.APIBaseURL+"/change_events", bytes.NewReader(payload))
+	if err != nil {
+		slog.Warn("failed to create change event request", "error", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(constants.HeaderXLast9APIToken,
+		constants.BearerPrefix+cfg.TokenManager.GetAccessToken(ctx))
+	resp, err := auth.GetHTTPClient().Do(req)
+	if err != nil {
+		slog.Warn("failed to emit deploy change event", "error", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		slog.Warn("deploy change event returned non-2xx", "status", resp.StatusCode)
+	}
+}
+
 func main() {
 	log.Printf("Starting Last9 MCP Server v%s", Version)
 
@@ -104,11 +153,23 @@ func main() {
 		}
 	}
 
+	// Auth and API config must come before OTel init so tenant/cluster IDs
+	// are available as resource attributes on all spans and metrics.
+	tokenManager, err := auth.NewTokenManager(cfg.RefreshToken)
+	if err != nil {
+		log.Fatalf("failed to create token manager: %v", err)
+	}
+
+	cfg.TokenManager = tokenManager
+	if err := utils.PopulateAPICfg(&cfg); err != nil {
+		log.Fatalf("failed to refresh access token: %v", err)
+	}
+
 	if cfg.DisableTelemetry {
 		otel.SetMeterProvider(metricnoop.NewMeterProvider())
 		otel.SetTracerProvider(tracenoop.NewTracerProvider())
 	} else {
-		shutdown, err := l9telemetry.InitProviders(context.Background(), Version)
+		shutdown, err := l9telemetry.InitProviders(context.Background(), Version, cfg.OrgSlug, cfg.ClusterID)
 		if err != nil {
 			log.Fatalf("failed to init telemetry: %v", err)
 		}
@@ -128,15 +189,7 @@ func main() {
 		"version", Version,
 	)
 
-	tokenManager, err := auth.NewTokenManager(cfg.RefreshToken)
-	if err != nil {
-		log.Fatalf("failed to create token manager: %v", err)
-	}
-
-	cfg.TokenManager = tokenManager
-	if err := utils.PopulateAPICfg(&cfg); err != nil {
-		log.Fatalf("failed to refresh access token: %v", err)
-	}
+	go emitDeployChangeEvent(cfg)
 
 	// Create attribute cache and perform best-effort initial fetch
 	attrCache := attributes.NewAttributeCache(auth.GetHTTPClient(), cfg)
@@ -147,6 +200,29 @@ func main() {
 	server, err := last9mcp.NewServerWithOptions("last9-mcp", Version, last9mcp.WithSkipProviderInit())
 	if err != nil {
 		log.Fatalf("failed to create MCP server: %v", err)
+	}
+
+	if !cfg.DisableTelemetry {
+		meter := otel.GetMeterProvider().Meter("last9-mcp")
+		serverInfo, err := meter.Int64ObservableGauge(
+			"last9_mcp_server_info",
+			metric.WithDescription("MCP server version info; value is always 1, use labels for version tracking"),
+		)
+		if err != nil {
+			slog.Warn("failed to create server info gauge", "error", err)
+		} else if _, err := meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+			o.ObserveInt64(serverInfo, 1,
+				metric.WithAttributes(
+					attribute.String("version", Version),
+					attribute.String("commit", CommitSHA),
+					attribute.String("tenant", cfg.OrgSlug),
+					attribute.String("cluster_id", cfg.ClusterID),
+				),
+			)
+			return nil
+		}, serverInfo); err != nil {
+			slog.Warn("failed to register server info callback", "error", err)
+		}
 	}
 
 	// Register all tools

--- a/main.go
+++ b/main.go
@@ -166,8 +166,6 @@ func main() {
 				metric.WithAttributes(
 					attribute.String("version", Version),
 					attribute.String("commit", CommitSHA),
-					attribute.String("last9.tenant", cfg.OrgSlug),
-					attribute.String("last9.cluster_id", cfg.ClusterID),
 				),
 			)
 			return nil


### PR DESCRIPTION
## Summary

- **Root cause fix**: `Dockerfile` used plain `go build` with no `-ldflags` — every Docker image baked in `Version="dev"`. Added `ARG VERSION/COMMIT` and pass via `-ldflags` so `service.version` matches the git tag in production.
- **CI**: Pass `VERSION` and `COMMIT` build-args to all 4 docker build steps (docker-registry.last9.io and ECR, both release-branch and main-branch paths).
- **Tenant identity on all telemetry**: Moved OTel init after `PopulateAPICfg` so `cfg.OrgSlug` and `cfg.ClusterID` are available at resource build time. Added `last9.tenant` and `last9.cluster_id` as OTel resource attributes — auto-propagates to every span, metric, and log.
- **Version inventory metric**: `last9_mcp_server_info` observable gauge with `version`, `commit`, `tenant`, `cluster_id` labels. Query: `count by (version, tenant) (last9_mcp_server_info)`.
- **Restart/deploy detection**: Change event fires on every startup (non-dev builds) with `version` + `commit`. Same version + same commit = restart; new version = deploy. Read-only token → 403 → warning logged, server continues.

## Test plan

- [ ] Build with `-X main.Version=v0.0.0-test` — verify `service.version=v0.0.0-test` on emitted spans
- [ ] Run locally — verify `last9_mcp_server_info{version="v0.0.0-test", commit=..., tenant=..., cluster_id=...}` in OTLP output
- [ ] Make a tool call — verify `last9.tenant` and `last9.cluster_id` on span resource attributes
- [ ] Goreleaser dry-run — confirm ldflags inject correctly
- [ ] Check change event fires on startup; check 403 path logs warning cleanly

Closes: https://linear.app/last9/issue/ENG-916

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment change event tracking to report server startup events.
  * Introduced server info metrics for observability.

* **Improvements**
  * Enhanced telemetry with tenant and cluster identification support.
  * Version and build metadata now embedded in server binary.

* **Chores**
  * Optimized Docker build process to pass build-time arguments for version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->