### PR TITLE
fix(promql): anchor range/labels queries on end time, not start time

### DIFF
--- a/internal/utils/promql_request_test.go
+++ b/internal/utils/promql_request_test.go
@@ -1,0 +1,148 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/models"
+)
+
+// Regression test for the PromQL range/labels/label-values "timestamp anchor"
+// bug.
+//
+// The Last9 PromQL HTTP endpoint interprets the JSON `timestamp` field as the
+// END of the query window and runs Prometheus over [timestamp - window,
+// timestamp] (this is also how MakePromInstantAPIQuery uses endTimeParam as
+// `timestamp`). Sending startTimeParam as `timestamp` therefore shifted every
+// range query backwards by exactly one window length.
+//
+// These tests pin the contract: the marshalled body must carry
+// timestamp = endTimeParam and window = endTimeParam - startTimeParam.
+
+const (
+	testStartUnix int64 = 1_700_000_000
+	testEndUnix   int64 = 1_700_003_600 // start + 1h
+)
+
+func newCapturingServer(t *testing.T, capture *[]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		*capture = body
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+}
+
+// stubTokenManagerCfg builds a Config whose TokenManager has a pre-populated
+// access token so we never hit the real refresh endpoint.
+func stubTokenManagerCfg(t *testing.T, apiBaseURL string) models.Config {
+	t.Helper()
+	tm := &auth.TokenManager{
+		AccessToken:  "test-token",
+		RefreshToken: "test-refresh",
+		ExpiresAt:    time.Now().Add(1 * time.Hour),
+	}
+	return models.Config{
+		APIBaseURL:         apiBaseURL,
+		PrometheusReadURL:  "https://prom.example/read",
+		PrometheusUsername: "u",
+		PrometheusPassword: "p",
+		TokenManager:       tm,
+	}
+}
+
+func decodeBody(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var got map[string]any
+	if err := json.NewDecoder(bytes.NewReader(raw)).Decode(&got); err != nil {
+		t.Fatalf("decode body: %v\nraw=%s", err, string(raw))
+	}
+	return got
+}
+
+func wantWindow() int64 { return testEndUnix - testStartUnix }
+
+func assertRightAnchored(t *testing.T, body map[string]any) {
+	t.Helper()
+	ts, ok := body["timestamp"].(float64)
+	if !ok {
+		t.Fatalf("timestamp missing or wrong type: %v", body["timestamp"])
+	}
+	if int64(ts) != testEndUnix {
+		t.Errorf("timestamp = %d, want %d (= endTimeParam). "+
+			"Sending startTimeParam here shifts the returned window backwards "+
+			"by one window length.", int64(ts), testEndUnix)
+	}
+	win, ok := body["window"].(float64)
+	if !ok {
+		t.Fatalf("window missing or wrong type: %v", body["window"])
+	}
+	if int64(win) != wantWindow() {
+		t.Errorf("window = %d, want %d (= endTimeParam - startTimeParam)",
+			int64(win), wantWindow())
+	}
+}
+
+func TestMakePromRangeAPIQuery_AnchorsOnEndTime(t *testing.T) {
+	var captured []byte
+	srv := newCapturingServer(t, &captured)
+	defer srv.Close()
+
+	cfg := stubTokenManagerCfg(t, srv.URL)
+	resp, err := MakePromRangeAPIQuery(
+		context.Background(), srv.Client(), "up", testStartUnix, testEndUnix, cfg,
+	)
+	if err != nil {
+		t.Fatalf("MakePromRangeAPIQuery: %v", err)
+	}
+	defer resp.Body.Close()
+
+	assertRightAnchored(t, decodeBody(t, captured))
+}
+
+func TestMakePromLabelValuesAPIQuery_AnchorsOnEndTime(t *testing.T) {
+	var captured []byte
+	srv := newCapturingServer(t, &captured)
+	defer srv.Close()
+
+	cfg := stubTokenManagerCfg(t, srv.URL)
+	resp, err := MakePromLabelValuesAPIQuery(
+		context.Background(), srv.Client(), "instance", "up",
+		testStartUnix, testEndUnix, cfg,
+	)
+	if err != nil {
+		t.Fatalf("MakePromLabelValuesAPIQuery: %v", err)
+	}
+	defer resp.Body.Close()
+
+	assertRightAnchored(t, decodeBody(t, captured))
+}
+
+func TestMakePromLabelsAPIQuery_AnchorsOnEndTime(t *testing.T) {
+	var captured []byte
+	srv := newCapturingServer(t, &captured)
+	defer srv.Close()
+
+	cfg := stubTokenManagerCfg(t, srv.URL)
+	resp, err := MakePromLabelsAPIQuery(
+		context.Background(), srv.Client(), "up",
+		testStartUnix, testEndUnix, cfg,
+	)
+	if err != nil {
+		t.Fatalf("MakePromLabelsAPIQuery: %v", err)
+	}
+	defer resp.Body.Close()
+
+	assertRightAnchored(t, decodeBody(t, captured))
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -143,6 +143,11 @@ func MakePromInstantAPIQuery(ctx context.Context, client *http.Client, promql st
 }
 
 func MakePromRangeAPIQuery(ctx context.Context, client *http.Client, promql string, startTimeParam, endTimeParam int64, cfg models.Config) (*http.Response, error) {
+	// The Last9 PromQL HTTP endpoint treats `timestamp` as the END of the
+	// query window and runs Prometheus over [timestamp - window, timestamp]
+	// (this is also how MakePromInstantAPIQuery above uses endTimeParam as
+	// `timestamp`). Anchoring on startTimeParam shifts every range query
+	// backwards by exactly one window length.
 	promRangeParam := struct {
 		Query     string `json:"query"`
 		Timestamp int64  `json:"timestamp"`
@@ -152,7 +157,7 @@ func MakePromRangeAPIQuery(ctx context.Context, client *http.Client, promql stri
 		Password  string `json:"password"`
 	}{
 		Query:     promql,
-		Timestamp: startTimeParam,
+		Timestamp: endTimeParam,
 		Window:    endTimeParam - startTimeParam,
 		ReadURL:   cfg.PrometheusReadURL,
 		Username:  cfg.PrometheusUsername,
@@ -189,7 +194,7 @@ func MakePromLabelValuesAPIQuery(ctx context.Context, client *http.Client, label
 		Matches   []string `json:"matches"`
 	}{
 		Label:     label,
-		Timestamp: startTimeParam,
+		Timestamp: endTimeParam,
 		Window:    endTimeParam - startTimeParam,
 		ReadURL:   cfg.PrometheusReadURL,
 		Username:  cfg.PrometheusUsername,
@@ -222,7 +227,7 @@ func MakePromLabelsAPIQuery(ctx context.Context, client *http.Client, metric str
 		Password  string `json:"password"`
 		Metric    string `json:"metric"`
 	}{
-		Timestamp: startTimeParam,
+		Timestamp: endTimeParam,
 		Window:    endTimeParam - startTimeParam,
 		ReadURL:   cfg.PrometheusReadURL,
 		Username:  cfg.PrometheusUsername,


### PR DESCRIPTION
## Summary

`MakePromRangeAPIQuery`, `MakePromLabelValuesAPIQuery`, and `MakePromLabelsAPIQuery` in `internal/utils/utils.go` all build their request body as:

```go
Timestamp: startTimeParam,
Window:    endTimeParam - startTimeParam,
```

The Last9 PromQL HTTP endpoints (`/promquery`, `/prom_label_values`, `/apm/labels`) interpret `timestamp` as the **end** of the query window and run Prometheus over `[timestamp - window, timestamp]`. (`MakePromInstantAPIQuery` right above already uses `endTimeParam` for `timestamp`, which is the correct convention.)

Anchoring on `startTimeParam` therefore shifts every range/label query backwards by exactly one window length: a request for `[start, end]` is served as `[start - duration, start]`.

This patch changes all three call sites to:

```go
Timestamp: endTimeParam,
Window:    endTimeParam - startTimeParam,
```

## Reproduction

Tested against `neubirdai/mcp-last9:v0.5.1` (same code as `main` for these functions), via `kubectl port-forward` + direct JSON-RPC `tools/call` to the running MCP server. 15 different ranges (1m / 5m / 30m / 1h / 6h / 12h, anchored at multiple points in the last 24h) were issued back-to-back. **Every** response matched the `[start - duration, start]` hypothesis exactly:

| Requested start (UTC) | Requested end (UTC) | Returned first sample (UTC) | Returned last sample (UTC) |
|---|---|---|---|
| 2026-04-24T11:27:00Z | 2026-04-24T23:27:00Z | 2026-04-23T23:27:00Z | 2026-04-24T11:27:00Z |
| 2026-04-24T22:00:00Z | 2026-04-24T23:00:00Z | 2026-04-24T21:00:00Z | 2026-04-24T22:00:00Z |
| 2026-04-24T20:00:00Z | 2026-04-25T02:00:00Z | 2026-04-24T14:00:00Z | 2026-04-24T20:00:00Z |

Cross-checked with `prometheus_instant_query` at the requested boundaries — instant values at the requested start/end did **not** match the range query's first/last samples for those same unix timestamps, confirming the misalignment is in the outbound request construction (not just a label artifact).

This was originally surfaced by a downstream agent (Neubird Falcon) reporting that its Last9 connector was returning data offset from what it asked for — the agent ended up evolving its own ad-hoc "shift compensation" prompts as a workaround.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./internal/utils/...` — full package green
- [x] New unit tests in `internal/utils/promql_request_test.go` use `httptest` to capture the marshalled JSON body and assert `timestamp == endTimeParam` and `window == end - start` for `MakePromRangeAPIQuery`, `MakePromLabelValuesAPIQuery`, and `MakePromLabelsAPIQuery`. They fail loudly against the previous (start-anchored) behavior.
- [ ] Re-run the 15-case range/instant cross-check against a build of this branch in the same environment.

## Risk

The change is in three small struct literals; behavior of `MakePromInstantAPIQuery` (already correct) is untouched. Any downstream consumer that was compensating for the off-by-one-window will see results "move forward" by one window — but they'll now match what they actually asked for.
