### PR TITLE
ci: automate npm publish via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,6 +100,26 @@ jobs:
             https://api.github.com/repos/last9/homebrew-tap/dispatches \
             -d '{"event_type":"update-last9-mcp","client_payload":{"tag":"v${{ steps.version_change.outputs.new_version }}"}}'
 
+  publish-npm:
+    needs: tag-and-release
+    if: needs.tag-and-release.outputs.version_changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+
   publish-docker:
     needs: tag-and-release
     if: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,7 +117,21 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Get version from package.json
+        id: get_version
+        run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+
+      - name: Check if version already published
+        id: npm_check
+        run: |
+          if npm view @last9/mcp-server@${{ steps.get_version.outputs.version }} version 2>/dev/null | grep -qF "${{ steps.get_version.outputs.version }}"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish to npm
+        if: steps.npm_check.outputs.exists == 'false'
         run: npm publish --access public --provenance
 
   publish-docker:


### PR DESCRIPTION
## Summary
- Add `publish-npm` job triggered on version change (same condition as GoReleaser)
- Uses npm provenance (OIDC `id-token: write`) — no `NPM_TOKEN` secret needed
- Runs after `tag-and-release` so GitHub release assets exist before npm consumers install

## Pre-requisite
Trusted publisher already configured on npmjs.com for `@last9/mcp-server` pointing to this repo + `release.yaml`.

## Test plan
- [ ] Bump version in `package.json`, merge to main, verify `publish-npm` job runs and package appears on npm

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated npm package publishing now occurs when package versions change, ensuring timely distribution of new releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->