### PR TITLE
chore: release v0.7.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,6 +100,26 @@ jobs:
             https://api.github.com/repos/last9/homebrew-tap/dispatches \
             -d '{"event_type":"update-last9-mcp","client_payload":{"tag":"v${{ steps.version_change.outputs.new_version }}"}}'
 
+  publish-npm:
+    needs: tag-and-release
+    if: needs.tag-and-release.outputs.version_changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+
   publish-docker:
     needs: tag-and-release
     if: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
## Summary

Bump version 0.6.0 → 0.7.0.

## Changes since v0.6.0

- **ENG-916**: Add `service.version` tracking and tenant identity across all deployments (#137)
- **fix(promql)**: Anchor range/labels queries on end time, not start time (#138)
- **fix(apm)**: Use correct `service_name` label in `get_service_environments` filter (#133)
- **fix**: `add_drop_rule` missing context in HTTP request (#134)
- **fix(get_logs)**: Reject non-canonical filter shapes instead of silently dropping (#131)
- **feat**: Improve trace query reliability: validation, schema, and service env filter (#123)
- **chore**: Upgrade mcp-go-sdk to v0.1.2 (#135)
- **chore**: Bump OTel dependencies (#136)

## Merge order

> **Merge PR #139 (ci: automate npm publish) before this PR** so the release pipeline includes automated npm publishing.

## Post-merge checklist

- [ ] GoReleaser creates GitHub release with tarballs
- [ ] Docker images pushed to `docker-registry.last9.io` and ECR
- [ ] `@last9/mcp-server` published to npm (automated via #139)
- [ ] homebrew-tap formula PR created and auto-merged

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->