### PR TITLE
ci(npm): switch to NPM_TOKEN auth, drop OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - "release-**"
+    tags:
+      - "v*"
 
 jobs:
   test:
@@ -101,11 +103,11 @@ jobs:
             -d '{"event_type":"update-last9-mcp","client_payload":{"tag":"v${{ steps.version_change.outputs.new_version }}"}}'
 
   publish-npm:
-    needs: tag-and-release
-    if: needs.tag-and-release.outputs.version_changed == 'true'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -131,9 +133,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.npm_check.outputs.exists == 'false'
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
 
   publish-docker:
     needs: tag-and-release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -132,7 +131,9 @@ jobs:
 
       - name: Publish to npm
         if: steps.npm_check.outputs.exists == 'false'
-        run: npm publish --access public --provenance
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-docker:
     needs: tag-and-release


### PR DESCRIPTION
## Summary
- OIDC trusted publishing consistently fails with 404 for `@last9/mcp-server` (scoped org package)
- Provenance to sigstore succeeds but npm rejects the OIDC token — likely an org-level restriction
- Switch to `NPM_TOKEN` (Automation token) which is reliable for scoped org packages

## Pre-requisite
Add `NPM_TOKEN` secret to repo: GitHub → Settings → Secrets → Actions → New repository secret

## Test plan
- [ ] Add `NPM_TOKEN` secret, merge this PR, then re-run the `publish-npm` job from run #25031199080

🤖 Generated with [Claude Code](https://claude.ai/code)