### PR TITLE
fix: derive default API host from token aud claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Default API host now derived from access token `aud` claim instead of hardcoded `app.last9.io`. Set `LAST9_API_HOST` to override.
+- Drop rule endpoints now use the unified API host (previously routed to token `aud` host independently).
+- `cfg.ActionURL` field retained for struct compatibility but no longer consumed internally.
+
+### Fixed
+- Startup `failed to refresh access token: ... 400 Bad Request` when token `aud` host did not match the hardcoded default. Error message also corrected to `failed to populate API config`.
+
 ## [0.6.0] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
 - Default API host now derived from access token `aud` claim instead of hardcoded `app.last9.io`. Set `LAST9_API_HOST` to override.
 - Drop rule endpoints now use the unified API host (previously routed to token `aud` host independently).
 - `cfg.ActionURL` field retained for struct compatibility but no longer consumed internally.
 
 ### Fixed
+
 - Startup `failed to refresh access token: ... 400 Bad Request` when token `aud` host did not match the hardcoded default. Error message also corrected to `failed to populate API config`.
 
 ## [0.6.0] - 2026-04-19

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -22,16 +22,13 @@ const (
 	// Organization and configuration endpoints
 	EndpointDatasources          = "/datasources"
 	EndpointOAuthAccessToken     = "/api/v4/oauth/access_token"
-	EndpointLogsSettingsRouting  = "/api/v4/organizations/%s/logs_settings/routing"
+	EndpointLogsSettingsRouting  = "/logs_settings/routing"
 	EndpointAlertRules           = "/alert-rules"
 	EndpointAlertsMonitor        = "/alerts/monitor"
 	EndpointEntitiesList         = "/entities/list"
 	EndpointNotificationSettings = "/notification_settings"
 	// EndpointSuggest returns fuzzy entity-name suggestions for the did_you_mean tool.
 	EndpointSuggest = "/suggest"
-
-	// API Base URL
-	APIBaseHost = "app.last9.io"
 
 	// DefaultHTTPTimeout is the fixed timeout used for outbound API calls and HTTP server read/write operations.
 	DefaultHTTPTimeout = 3 * time.Minute

--- a/internal/telemetry/logs/drop_rule.go
+++ b/internal/telemetry/logs/drop_rule.go
@@ -25,7 +25,7 @@ func NewGetDropRulesHandler(client *http.Client, cfg models.Config) func(context
 		accessToken := cfg.TokenManager.GetAccessToken(ctx)
 
 		// Build request URL with query parameters
-		u, err := url.Parse(cfg.ActionURL + fmt.Sprintf(constants.EndpointLogsSettingsRouting, cfg.OrgSlug))
+		u, err := url.Parse(cfg.APIBaseURL + constants.EndpointLogsSettingsRouting)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse URL: %w", err)
 		}
@@ -96,7 +96,7 @@ func NewAddDropRuleHandler(client *http.Client, cfg models.Config) func(context.
 		accessToken := cfg.TokenManager.GetAccessToken(ctx)
 
 		// Build request URL
-		u, err := url.Parse(cfg.ActionURL + fmt.Sprintf(constants.EndpointLogsSettingsRouting, cfg.OrgSlug))
+		u, err := url.Parse(cfg.APIBaseURL + constants.EndpointLogsSettingsRouting)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse URL: %w", err)
 		}

--- a/internal/telemetry/logs/drop_rule.go
+++ b/internal/telemetry/logs/drop_rule.go
@@ -24,17 +24,11 @@ func NewGetDropRulesHandler(client *http.Client, cfg models.Config) func(context
 	return func(ctx context.Context, req *mcp.CallToolRequest, args GetDropRulesArgs) (*mcp.CallToolResult, any, error) {
 		accessToken := cfg.TokenManager.GetAccessToken(ctx)
 
-		// Build request URL with query parameters
 		u, err := url.Parse(cfg.APIBaseURL + constants.EndpointLogsSettingsRouting)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse URL: %w", err)
 		}
 
-		q := u.Query()
-
-		u.RawQuery = q.Encode()
-
-		// Create request
 		httpReq, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create request: %w", err)
@@ -92,10 +86,8 @@ type AddDropRuleArgs struct {
 // NewAddDropRuleHandler creates a handler for adding new drop rules for logs
 func NewAddDropRuleHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, AddDropRuleArgs) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, args AddDropRuleArgs) (*mcp.CallToolResult, any, error) {
-		// First refresh the access token
 		accessToken := cfg.TokenManager.GetAccessToken(ctx)
 
-		// Build request URL
 		u, err := url.Parse(cfg.APIBaseURL + constants.EndpointLogsSettingsRouting)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse URL: %w", err)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -411,10 +411,16 @@ func PopulateAPICfg(cfg *models.Config) error {
 
 	client := last9mcp.WithHTTPTracing(&http.Client{Timeout: constants.DefaultHTTPTimeout})
 
-	// Use configured API host or default
 	apiHost := cfg.APIHost
 	if apiHost == "" {
-		apiHost = constants.APIBaseHost
+		audURL, parseErr := url.Parse(actionURL)
+		if parseErr != nil {
+			return fmt.Errorf("failed to derive API host from token aud: %w", parseErr)
+		}
+		if audURL.Host == "" {
+			return errors.New("failed to derive API host from token aud: empty host")
+		}
+		apiHost = audURL.Host
 	}
 	cfg.APIBaseURL = fmt.Sprintf("https://%s/api/v4/organizations/%s", apiHost, cfg.OrgSlug)
 	req, err := http.NewRequestWithContext(context.Background(), "GET", cfg.APIBaseURL+constants.EndpointDatasources, nil)

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 
 	cfg.TokenManager = tokenManager
 	if err := utils.PopulateAPICfg(&cfg); err != nil {
-		log.Fatalf("failed to refresh access token: %v", err)
+		log.Fatalf("failed to populate API config: %v", err)
 	}
 
 	if cfg.DisableTelemetry {


### PR DESCRIPTION
## Summary

- Hardcoded `app.last9.io` default in `PopulateAPICfg` caused startup failure (`400 Bad Request` from `/datasources`) for any deployment whose token issuer points elsewhere. Default API host now derives from access token `aud` claim. `LAST9_API_HOST` env still overrides.
- Drop rule endpoints unified to `cfg.APIBaseURL` (previously routed via `cfg.ActionURL` independently). `cfg.ActionURL` field retained for struct compatibility but no longer consumed.
- Log prefix corrected: `failed to refresh access token` → `failed to populate API config` (refresh already succeeded by the time `PopulateAPICfg` runs).

## Behavior change matrix

| `LAST9_API_HOST` | Token `aud` host | Before | After |
|---|---|---|---|
| unset | `app.last9.io` | works | works |
| unset | other (e.g. gamma) | **400 fail** | works (fixed) |
| set | any | override wins | override wins |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/utils/... ./internal/telemetry/logs/... ./internal/auth/...` — 93 tests pass
- [ ] Deploy to k8s — confirm pod no longer crashes on startup
- [ ] Verify drop rule endpoints reachable via unified API host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * API host is now derived from access token configuration, with an environment-variable override supported
  * Log drop rule endpoints unified to use a single consistent API host

* **Fixed**
  * Improved error handling during API configuration initialization to avoid startup failures
  * Startup error text clarified to “failed to populate API config” for clearer diagnostics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->