### PR TITLE
ci: remove last9 docker registry, keep ECR only

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,9 +144,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    env:
-      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -166,67 +163,6 @@ jobs:
         run: |
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Check Docker secrets
-        id: check_secrets
-        run: |
-          if [[ -n "$DOCKER_USERNAME" && -n "$DOCKER_PASSWORD" ]]; then
-            echo "has_docker_secrets=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_docker_secrets=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Login to Docker Registry
-        if: steps.check_secrets.outputs.has_docker_secrets == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: docker-registry.last9.io
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
-
-      - name: Build and Push Docker Image (Release Branch)
-        if: |
-          steps.check_secrets.outputs.has_docker_secrets == 'true' &&
-          github.event_name == 'push' &&
-          startsWith(github.ref, 'refs/heads/release-')
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          tags: |
-            docker-registry.last9.io/last9/last9-mcp-server:${{ steps.extract_branch.outputs.branch_name }}
-            docker-registry.last9.io/last9/last9-mcp-server:${{ steps.extract_branch.outputs.branch_name }}-v${{ steps.get_version.outputs.version }}
-          build-args: |
-            VERSION=${{ steps.get_version.outputs.version }}
-            COMMIT=${{ github.sha }}
-            BUILD_TIME=${{ steps.build_time.outputs.build_time }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
-
-      - name: Build and Push Docker Image (Main Branch)
-        if: |
-          steps.check_secrets.outputs.has_docker_secrets == 'true' &&
-          needs.tag-and-release.outputs.version_changed == 'true'
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          tags: |
-            docker-registry.last9.io/last9/last9-mcp-server:v${{ needs.tag-and-release.outputs.new_version }}
-            docker-registry.last9.io/last9/last9-mcp-server:latest
-          build-args: |
-            VERSION=${{ needs.tag-and-release.outputs.new_version }}
-            COMMIT=${{ github.sha }}
-            BUILD_TIME=${{ steps.build_time.outputs.build_time }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary
- Drop `docker-registry.last9.io` login + push steps from `publish-docker` job
- Remove `DOCKER_USERNAME`/`DOCKER_PASSWORD` env, buildx setup, secrets check
- ECR-only path retained for both release-branch push and main-branch version bump

## Test plan
- [ ] Workflow YAML parses (verified locally via diff)
- [ ] Next release-branch push pushes only to ECR
- [ ] Next version bump on main pushes only to ECR

🤖 Generated with [Claude Code](https://claude.com/claude-code)