### PR TITLE
chore: release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-05-20
+
 ### Added
 
 - MCP tools for dashboard CRUD: `list_dashboards`, `get_dashboard`, `create_dashboard`, `update_dashboard`, `delete_dashboard`.
@@ -118,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Tool improvements (#51).
 
+[0.7.2]: https://github.com/last9/last9-mcp-server/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/last9/last9-mcp-server/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/last9/last9-mcp-server/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/last9/last9-mcp-server/compare/v0.5.1...v0.6.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
## Changes since v0.7.1

- `0a232b0` ENG-1167: Add 7 MCP tools for dashboard CRUD and template-based creation (#146)
- `a58746e` chore: remove dead code and verify CI (#145)
- `de38dc4` ci: remove last9 docker registry, keep ECR only (#144)

## Release checklist

- [ ] GoReleaser — Linux/macOS/Windows tarballs on GitHub Releases
- [ ] Docker — image pushed to ECR with `v0.7.2` and `latest` tags
- [ ] npm — `@last9/mcp-server@0.7.2` published
- [ ] homebrew-tap — formula PR opened and auto-merged