### PR TITLE
feat: resolve indicator PromQL inline in alert config tools

### DIFF
--- a/internal/alerting/alert_config.go
+++ b/internal/alerting/alert_config.go
@@ -73,6 +73,75 @@ func validateGetAlertConfigArgs(args GetAlertConfigArgs) error {
 	return nil
 }
 
+type kpiResponse struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Definition struct {
+		Query string `json:"query"`
+		Unit  string `json:"unit"`
+	} `json:"definition"`
+}
+
+func fetchKPI(
+	ctx context.Context,
+	client *http.Client,
+	cfg models.Config,
+	entityID, kpiID string,
+) (kpiResponse, error) {
+	url := fmt.Sprintf("%s%s", cfg.APIBaseURL, fmt.Sprintf(constants.EndpointEntityKPI, entityID, kpiID))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return kpiResponse{}, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set(constants.HeaderAccept, constants.HeaderAcceptJSON)
+	httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+cfg.TokenManager.GetAccessToken(ctx))
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return kpiResponse{}, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return kpiResponse{}, fmt.Errorf("API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return kpiResponse{}, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var kpi kpiResponse
+	if err := json.Unmarshal(body, &kpi); err != nil {
+		return kpiResponse{}, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return kpi, nil
+}
+
+func resolveAlertConfigKPIs(
+	ctx context.Context,
+	client *http.Client,
+	cfg models.Config,
+	alertConfig AlertConfigResponse,
+) {
+	for i := range alertConfig {
+		rule := &alertConfig[i]
+		for indicatorName, arg := range rule.ExpressionArgs {
+			kpi, err := fetchKPI(ctx, client, cfg, rule.EntityID, arg.ID)
+			if err != nil {
+				arg.LookupError = err.Error()
+			} else {
+				arg.PromQL = kpi.Definition.Query
+				arg.Unit = kpi.Definition.Unit
+			}
+			rule.ExpressionArgs[indicatorName] = arg
+		}
+	}
+}
+
 func fetchAlertConfig(
 	ctx context.Context,
 	client *http.Client,
@@ -421,6 +490,35 @@ func formatAlertConfigResponse(alertConfig AlertConfigResponse) string {
 		formattedResponse += fmt.Sprintf("  ID: %s\n", rule.ID)
 		formattedResponse += fmt.Sprintf("  Rule Name: %s\n", rule.RuleName)
 		formattedResponse += fmt.Sprintf("  Primary Indicator: %s\n", rule.PrimaryIndicator)
+		if rule.Expression != "" {
+			formattedResponse += fmt.Sprintf("  Expression: %s\n", rule.Expression)
+		}
+		if rule.Condition != "" {
+			formattedResponse += fmt.Sprintf("  Condition: %s\n", rule.Condition)
+		}
+		if rule.AlertCondition != "" {
+			formattedResponse += fmt.Sprintf("  Alert Condition: %s\n", rule.AlertCondition)
+		}
+		if rule.EvalWindow > 0 {
+			formattedResponse += fmt.Sprintf("  Eval Window: %d minutes\n", rule.EvalWindow)
+		}
+		if len(rule.ExpressionArgs) > 0 {
+			formattedResponse += "  Indicators:\n"
+			for indicatorName, arg := range rule.ExpressionArgs {
+				formattedResponse += fmt.Sprintf("    %s (KPI ID: %s)\n", indicatorName, arg.ID)
+				if arg.LookupError != "" {
+					formattedResponse += fmt.Sprintf("      PromQL: [lookup failed: %s]\n", arg.LookupError)
+				} else if arg.PromQL != "" {
+					formattedResponse += fmt.Sprintf("      PromQL: %s\n", arg.PromQL)
+					if arg.Unit != "" {
+						formattedResponse += fmt.Sprintf("      Unit: %s\n", arg.Unit)
+					}
+				}
+				for k, v := range arg.Variables {
+					formattedResponse += fmt.Sprintf("      Variable %s: %s\n", k, v)
+				}
+			}
+		}
 		formattedResponse += fmt.Sprintf("  State: %s\n", rule.State)
 		formattedResponse += fmt.Sprintf("  Severity: %s\n", rule.Severity)
 		formattedResponse += fmt.Sprintf("  Algorithm: %s\n", rule.Algorithm)

--- a/internal/alerting/alert_config.go
+++ b/internal/alerting/alert_config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -73,13 +74,15 @@ func validateGetAlertConfigArgs(args GetAlertConfigArgs) error {
 	return nil
 }
 
+type kpiDefinition struct {
+	Query string `json:"query"`
+	Unit  string `json:"unit"`
+}
+
 type kpiResponse struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	Definition struct {
-		Query string `json:"query"`
-		Unit  string `json:"unit"`
-	} `json:"definition"`
+	ID         string        `json:"id"`
+	Name       string        `json:"name"`
+	Definition kpiDefinition `json:"definition"`
 }
 
 func fetchKPI(
@@ -88,8 +91,8 @@ func fetchKPI(
 	cfg models.Config,
 	entityID, kpiID string,
 ) (kpiResponse, error) {
-	url := fmt.Sprintf("%s%s", cfg.APIBaseURL, fmt.Sprintf(constants.EndpointEntityKPI, entityID, kpiID))
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	fullURL := cfg.APIBaseURL + fmt.Sprintf(constants.EndpointEntityKPI, entityID, kpiID)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
 	if err != nil {
 		return kpiResponse{}, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -127,15 +130,36 @@ func resolveAlertConfigKPIs(
 	cfg models.Config,
 	alertConfig AlertConfigResponse,
 ) {
+	// Cache KPI results by "entityID/kpiID" to avoid redundant fetches when
+	// multiple rules share the same KPI (common across entity-scoped rules).
+	type kpiCacheKey struct{ entityID, kpiID string }
+	cache := make(map[kpiCacheKey]kpiResponse)
+	errCache := make(map[kpiCacheKey]string)
+
 	for i := range alertConfig {
 		rule := &alertConfig[i]
 		for indicatorName, arg := range rule.ExpressionArgs {
-			kpi, err := fetchKPI(ctx, client, cfg, rule.EntityID, arg.ID)
-			if err != nil {
-				arg.LookupError = err.Error()
-			} else {
+			if ctx.Err() != nil {
+				arg.LookupError = "context cancelled"
+				rule.ExpressionArgs[indicatorName] = arg
+				continue
+			}
+			key := kpiCacheKey{rule.EntityID, arg.ID}
+			if errMsg, ok := errCache[key]; ok {
+				arg.LookupError = errMsg
+			} else if kpi, ok := cache[key]; ok {
 				arg.PromQL = kpi.Definition.Query
 				arg.Unit = kpi.Definition.Unit
+			} else {
+				kpi, err := fetchKPI(ctx, client, cfg, rule.EntityID, arg.ID)
+				if err != nil {
+					errCache[key] = err.Error()
+					arg.LookupError = err.Error()
+				} else {
+					cache[key] = kpi
+					arg.PromQL = kpi.Definition.Query
+					arg.Unit = kpi.Definition.Unit
+				}
 			}
 			rule.ExpressionArgs[indicatorName] = arg
 		}
@@ -504,7 +528,13 @@ func formatAlertConfigResponse(alertConfig AlertConfigResponse) string {
 		}
 		if len(rule.ExpressionArgs) > 0 {
 			formattedResponse += "  Indicators:\n"
-			for indicatorName, arg := range rule.ExpressionArgs {
+			indicatorNames := make([]string, 0, len(rule.ExpressionArgs))
+			for name := range rule.ExpressionArgs {
+				indicatorNames = append(indicatorNames, name)
+			}
+			sort.Strings(indicatorNames)
+			for _, indicatorName := range indicatorNames {
+				arg := rule.ExpressionArgs[indicatorName]
 				formattedResponse += fmt.Sprintf("    %s (KPI ID: %s)\n", indicatorName, arg.ID)
 				if arg.LookupError != "" {
 					formattedResponse += fmt.Sprintf("      PromQL: [lookup failed: %s]\n", arg.LookupError)
@@ -514,8 +544,13 @@ func formatAlertConfigResponse(alertConfig AlertConfigResponse) string {
 						formattedResponse += fmt.Sprintf("      Unit: %s\n", arg.Unit)
 					}
 				}
-				for k, v := range arg.Variables {
-					formattedResponse += fmt.Sprintf("      Variable %s: %s\n", k, v)
+				varKeys := make([]string, 0, len(arg.Variables))
+				for k := range arg.Variables {
+					varKeys = append(varKeys, k)
+				}
+				sort.Strings(varKeys)
+				for _, k := range varKeys {
+					formattedResponse += fmt.Sprintf("      Variable %s: %s\n", k, arg.Variables[k])
 				}
 			}
 		}
@@ -531,8 +566,13 @@ func formatAlertConfigResponse(alertConfig AlertConfigResponse) string {
 
 		if len(rule.Properties) > 0 {
 			formattedResponse += "  Properties:\n"
-			for k, v := range rule.Properties {
-				formattedResponse += fmt.Sprintf("    %s: %v\n", k, v)
+			propKeys := make([]string, 0, len(rule.Properties))
+			for k := range rule.Properties {
+				propKeys = append(propKeys, k)
+			}
+			sort.Strings(propKeys)
+			for _, k := range propKeys {
+				formattedResponse += fmt.Sprintf("    %s: %v\n", k, rule.Properties[k])
 			}
 		}
 

--- a/internal/alerting/alert_config_handler_test.go
+++ b/internal/alerting/alert_config_handler_test.go
@@ -25,6 +25,7 @@ type alertConfigTestServerState struct {
 	entityLookupStatus int
 	entityLookupCalls  int
 	lastEntityRequest  filterAlertGroupEntitiesRequest
+	kpiResponses       map[string]kpiResponse // kpiID → response (empty = 404)
 }
 
 func TestGetAlertConfigHandler_RuleOnlyFilters(t *testing.T) {
@@ -363,9 +364,98 @@ func newAlertConfigTestServer(
 			}
 			_, _ = w.Write([]byte(`{"error":"entity lookup failed"}`))
 		default:
+			// KPI lookup: /entities/{entity_id}/kpis/{kpi_id}
+			if strings.HasPrefix(r.URL.Path, "/entities/") && strings.Contains(r.URL.Path, "/kpis/") {
+				parts := strings.Split(r.URL.Path, "/")
+				// path: ["", "entities", entityID, "kpis", kpiID]
+				if len(parts) == 5 {
+					kpiID := parts[4]
+					if kpi, ok := state.kpiResponses[kpiID]; ok {
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusOK)
+						_ = json.NewEncoder(w).Encode(kpi)
+						return
+					}
+				}
+			}
 			http.NotFound(w, r)
 		}
 	}))
+}
+
+func TestGetAlertConfigHandler_KPIResolution(t *testing.T) {
+	kpiID := "kpi-uuid-1"
+	rules := AlertConfigResponse{
+		{
+			ID:               "rule-kpi",
+			OrganizationID:   "org-1",
+			EntityID:         "entity-1",
+			PrimaryIndicator: "p99_latency",
+			Expression:       "p99_latency",
+			Condition:        "expr > 500",
+			State:            "active",
+			Severity:         "breach",
+			Algorithm:        "static_threshold",
+			RuleName:         "High P99",
+			ExpressionArgs: map[string]AlertRuleExpressionArg{
+				"p99_latency": {ID: kpiID},
+			},
+		},
+	}
+
+	t.Run("KPI resolved successfully", func(t *testing.T) {
+		state := alertConfigTestServerState{
+			alertRules:       rules,
+			entityGroups:     sampleAlertGroupEntities(),
+			alertRulesStatus: http.StatusOK,
+			kpiResponses: map[string]kpiResponse{
+				kpiID: {
+					ID:   kpiID,
+					Name: "p99_latency",
+					Definition: struct {
+						Query string `json:"query"`
+						Unit  string `json:"unit"`
+					}{
+						Query: `histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m]))`,
+						Unit:  "seconds",
+					},
+				},
+			},
+		}
+
+		text, _, err := executeGetAlertConfig(t, &state, GetAlertConfigArgs{})
+		if err != nil {
+			t.Fatalf("handler returned error: %v", err)
+		}
+
+		if !strings.Contains(text, "histogram_quantile") {
+			t.Fatalf("expected PromQL in response, got:\n%s", text)
+		}
+		if !strings.Contains(text, "Unit: seconds") {
+			t.Fatalf("expected unit in response, got:\n%s", text)
+		}
+	})
+
+	t.Run("KPI lookup failure shows note", func(t *testing.T) {
+		state := alertConfigTestServerState{
+			alertRules:       rules,
+			entityGroups:     sampleAlertGroupEntities(),
+			alertRulesStatus: http.StatusOK,
+			kpiResponses:     map[string]kpiResponse{}, // kpiID not registered → 404
+		}
+
+		text, _, err := executeGetAlertConfig(t, &state, GetAlertConfigArgs{})
+		if err != nil {
+			t.Fatalf("handler should succeed even with KPI lookup failure, got: %v", err)
+		}
+
+		if !strings.Contains(text, "lookup failed") {
+			t.Fatalf("expected lookup failure note in response, got:\n%s", text)
+		}
+		if !strings.Contains(text, "rule-kpi") {
+			t.Fatalf("expected rule still present despite KPI failure, got:\n%s", text)
+		}
+	})
 }
 
 func sampleAlertConfigRules() AlertConfigResponse {

--- a/internal/alerting/alert_config_handler_test.go
+++ b/internal/alerting/alert_config_handler_test.go
@@ -412,10 +412,7 @@ func TestGetAlertConfigHandler_KPIResolution(t *testing.T) {
 				kpiID: {
 					ID:   kpiID,
 					Name: "p99_latency",
-					Definition: struct {
-						Query string `json:"query"`
-						Unit  string `json:"unit"`
-					}{
+					Definition: kpiDefinition{
 						Query: `histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m]))`,
 						Unit:  "seconds",
 					},
@@ -454,6 +451,60 @@ func TestGetAlertConfigHandler_KPIResolution(t *testing.T) {
 		}
 		if !strings.Contains(text, "rule-kpi") {
 			t.Fatalf("expected rule still present despite KPI failure, got:\n%s", text)
+		}
+	})
+
+	t.Run("partial failure: one indicator resolves, one fails", func(t *testing.T) {
+		kpiID2 := "kpi-uuid-2"
+		multiRules := AlertConfigResponse{
+			{
+				ID:               "rule-multi",
+				OrganizationID:   "org-1",
+				EntityID:         "entity-1",
+				PrimaryIndicator: "errors_total",
+				Expression:       "errors_total / requests_total",
+				Condition:        "expr > 0.05",
+				State:            "active",
+				Severity:         "breach",
+				Algorithm:        "static_threshold",
+				RuleName:         "High error rate",
+				ExpressionArgs: map[string]AlertRuleExpressionArg{
+					"errors_total":   {ID: kpiID},   // registered → resolves
+					"requests_total": {ID: kpiID2},  // not registered → 404
+				},
+			},
+		}
+
+		state := alertConfigTestServerState{
+			alertRules:       multiRules,
+			entityGroups:     sampleAlertGroupEntities(),
+			alertRulesStatus: http.StatusOK,
+			kpiResponses: map[string]kpiResponse{
+				kpiID: {
+					ID:   kpiID,
+					Name: "errors_total",
+					Definition: kpiDefinition{
+						Query: `sum(rate(http_errors_total[5m]))`,
+						Unit:  "count",
+					},
+				},
+				// kpiID2 intentionally absent → 404
+			},
+		}
+
+		text, _, err := executeGetAlertConfig(t, &state, GetAlertConfigArgs{})
+		if err != nil {
+			t.Fatalf("handler should succeed with partial KPI failure, got: %v", err)
+		}
+
+		if !strings.Contains(text, "http_errors_total") {
+			t.Fatalf("expected resolved PromQL for errors_total, got:\n%s", text)
+		}
+		if !strings.Contains(text, "lookup failed") {
+			t.Fatalf("expected lookup failure note for requests_total, got:\n%s", text)
+		}
+		if !strings.Contains(text, "rule-multi") {
+			t.Fatalf("expected rule present despite partial failure, got:\n%s", text)
 		}
 	})
 }

--- a/internal/alerting/alerts.go
+++ b/internal/alerting/alerts.go
@@ -104,8 +104,9 @@ type AlertInstance struct {
 
 const GetAlertConfigDescription = `
 	Get alert configurations (alert rules) from Last9.
-	Returns configured alert rules and supports both typed filters and free-text search.
-	Uses the datasource configured in the server config (or default if not specified).
+	Returns configured alert rules with metadata and supports both typed filters and free-text search.
+	Use this tool first to discover rules and entity IDs, then call get_entity_alert_rules with an
+	entity_id to get the full expression logic and resolved PromQL for that entity's rules.
 
 	Optional filters:
 	- rule_id: Exact match on alert rule ID
@@ -117,16 +118,12 @@ const GetAlertConfigDescription = `
 	- alert_group_type: Case-insensitive substring match on alert group type
 	- data_source_name: Case-insensitive substring match on alert group data source name
 	- tags: Array of case-insensitive substring matches; all provided tags must match
-	
+
 	Each alert rule includes:
 	- id: Unique identifier for the alert rule
 	- name: Human-readable name of the alert
 	- primary_indicator: Name of the primary KPI (metric) being monitored
-	- expression: Indicator expression template (e.g. "p99_latency" or "errors / total")
-	- condition: Threshold expression applied to the evaluated result (e.g. "expr > 200")
-	- alert_condition: Firing condition over the eval window (e.g. "count_true(result) > 10")
-	- eval_window: Evaluation window in minutes
-	- expression_args: Maps each indicator name to its KPI binding, including the resolved PromQL query and unit
+	- entity_id: Use this with get_entity_alert_rules to fetch the full PromQL for this entity's rules
 	- state: Current state of the alert rule (active, inactive, etc.)
 	- severity: Alert severity level
 	- algorithm: Detection algorithm (static_threshold, high_spike, inc_trend, etc.)

--- a/internal/alerting/alerts.go
+++ b/internal/alerting/alerts.go
@@ -17,24 +17,39 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// AlertRuleExpressionArg holds indicator binding for an alert rule.
+// PromQL, Unit, and LookupError are resolved at query time and not part of the API response.
+type AlertRuleExpressionArg struct {
+	ID          string            `json:"id"`
+	Variables   map[string]string `json:"variables"`
+	PromQL      string            `json:"-"`
+	Unit        string            `json:"-"`
+	LookupError string            `json:"-"`
+}
+
 // AlertRule represents an alert configuration from Last9 API
 type AlertRule struct {
-	ID                           string                 `json:"id"`
-	OrganizationID               string                 `json:"organization_id"`
-	EntityID                     string                 `json:"entity_id"`
-	PrimaryIndicator             string                 `json:"primary_indicator"`
-	CreatedAt                    int64                  `json:"created_at"`
-	UpdatedAt                    int64                  `json:"updated_at"`
-	DeletedAt                    *int64                 `json:"deleted_at"`
-	ErrorSince                   *int64                 `json:"error_since"`
-	State                        string                 `json:"state"`
-	ExternalRef                  string                 `json:"external_ref"`
-	Severity                     string                 `json:"severity"`
-	Algorithm                    string                 `json:"algorithm"`
-	RuleName                     string                 `json:"rule_name"`
-	MuteUntil                    int64                  `json:"mute_until"`
-	Properties                   map[string]interface{} `json:"properties"`
-	GroupTimeseriesNotifications bool                   `json:"group_timeseries_notifications"`
+	ID                           string                            `json:"id"`
+	OrganizationID               string                            `json:"organization_id"`
+	EntityID                     string                            `json:"entity_id"`
+	PrimaryIndicator             string                            `json:"primary_indicator"`
+	Expression                   string                            `json:"expression,omitempty"`
+	Condition                    string                            `json:"condition,omitempty"`
+	AlertCondition               string                            `json:"alert_condition,omitempty"`
+	EvalWindow                   int64                             `json:"eval_window,omitempty"`
+	ExpressionArgs               map[string]AlertRuleExpressionArg `json:"expression_args,omitempty"`
+	CreatedAt                    int64                             `json:"created_at"`
+	UpdatedAt                    int64                             `json:"updated_at"`
+	DeletedAt                    *int64                            `json:"deleted_at"`
+	ErrorSince                   *int64                            `json:"error_since"`
+	State                        string                            `json:"state"`
+	ExternalRef                  string                            `json:"external_ref"`
+	Severity                     string                            `json:"severity"`
+	Algorithm                    string                            `json:"algorithm"`
+	RuleName                     string                            `json:"rule_name"`
+	MuteUntil                    int64                             `json:"mute_until"`
+	Properties                   map[string]interface{}            `json:"properties"`
+	GroupTimeseriesNotifications bool                              `json:"group_timeseries_notifications"`
 }
 
 // Alert represents an active alert instance
@@ -106,15 +121,15 @@ const GetAlertConfigDescription = `
 	Each alert rule includes:
 	- id: Unique identifier for the alert rule
 	- name: Human-readable name of the alert
-	- description: Detailed description of what the alert monitors
+	- primary_indicator: Name of the primary KPI (metric) being monitored
+	- expression: Indicator expression template (e.g. "p99_latency" or "errors / total")
+	- condition: Threshold expression applied to the evaluated result (e.g. "expr > 200")
+	- alert_condition: Firing condition over the eval window (e.g. "count_true(result) > 10")
+	- eval_window: Evaluation window in minutes
+	- indicator_kpi_ids: Maps each indicator name to its KPI definition ID (look up KPI to get raw PromQL)
 	- state: Current state of the alert rule (active, inactive, etc.)
-	- severity: Alert severity level (critical, warning, info)
-	- query: PromQL query used for the alert condition
-	- for: Duration threshold before alert fires
-	- labels: Key-value pairs for alert routing and grouping
-	- annotations: Additional metadata and descriptions
-	- group_name: Alert group this rule belongs to
-	- condition: Alert condition configuration (thresholds, operators)
+	- severity: Alert severity level
+	- algorithm: Detection algorithm (static_threshold, high_spike, inc_trend, etc.)
 	- created_at: When the alert rule was created
 	- updated_at: When the alert rule was last modified
 `
@@ -181,6 +196,8 @@ func NewGetAlertConfigHandler(client *http.Client, cfg models.Config) func(conte
 				args,
 			)
 		}
+
+		resolveAlertConfigKPIs(ctx, client, cfg, filteredAlertConfig)
 
 		formattedResponse := formatAlertConfigResponse(filteredAlertConfig)
 

--- a/internal/alerting/alerts.go
+++ b/internal/alerting/alerts.go
@@ -105,8 +105,8 @@ type AlertInstance struct {
 const GetAlertConfigDescription = `
 	Get alert configurations (alert rules) from Last9.
 	Returns configured alert rules with metadata and supports both typed filters and free-text search.
-	Use this tool first to discover rules and entity IDs, then call get_entity_alert_rules with an
-	entity_id to get the full expression logic and resolved PromQL for that entity's rules.
+	Use this tool first to discover rules and entity IDs, then if required, use get_entity_alert_rules
+	with an entity_id to get the PromQL for the indicator and other details of the alert group (entity) of the alert rule.
 
 	Optional filters:
 	- rule_id: Exact match on alert rule ID

--- a/internal/alerting/alerts.go
+++ b/internal/alerting/alerts.go
@@ -126,7 +126,7 @@ const GetAlertConfigDescription = `
 	- condition: Threshold expression applied to the evaluated result (e.g. "expr > 200")
 	- alert_condition: Firing condition over the eval window (e.g. "count_true(result) > 10")
 	- eval_window: Evaluation window in minutes
-	- indicator_kpi_ids: Maps each indicator name to its KPI definition ID (look up KPI to get raw PromQL)
+	- expression_args: Maps each indicator name to its KPI binding, including the resolved PromQL query and unit
 	- state: Current state of the alert rule (active, inactive, etc.)
 	- severity: Alert severity level
 	- algorithm: Detection algorithm (static_threshold, high_spike, inc_trend, etc.)

--- a/internal/alerting/entity_alert_rules.go
+++ b/internal/alerting/entity_alert_rules.go
@@ -1,0 +1,118 @@
+package alerting
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"last9-mcp/internal/constants"
+	"last9-mcp/internal/deeplink"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const GetEntityAlertRulesDescription = `Fetches all alert rules for a specific entity (alert group) with full detail:
+expression, condition, eval window, and resolved PromQL for each indicator.
+
+Use this tool when you need the complete alert rule configuration for a known entity,
+including the actual PromQL queries behind each indicator. The org-wide get_alert_config
+tool omits expression_args and PromQL; this tool includes them.
+
+Input:
+- entity_id (required): UUID of the entity / alert group
+- severity (optional): filter rules by severity (e.g. "breach", "warn")
+
+Output per rule:
+- id, rule_name, primary_indicator, state, severity, algorithm
+- expression, condition, alert_condition, eval_window
+- indicators: each indicator name with resolved PromQL, unit, and variables
+- created_at, updated_at`
+
+// GetEntityAlertRulesArgs holds the input arguments for get_entity_alert_rules.
+type GetEntityAlertRulesArgs struct {
+	EntityID string `json:"entity_id"`
+	Severity string `json:"severity,omitempty"`
+}
+
+// NewGetEntityAlertRulesHandler returns the MCP tool handler for get_entity_alert_rules.
+func NewGetEntityAlertRulesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetEntityAlertRulesArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args GetEntityAlertRulesArgs) (*mcp.CallToolResult, any, error) {
+		entityID := strings.TrimSpace(args.EntityID)
+		if entityID == "" {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "entity_id is required"}},
+				IsError: true,
+			}, nil, nil
+		}
+
+		rules, err := fetchEntityAlertRules(ctx, client, cfg, entityID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to fetch entity alert rules: %w", err)
+		}
+
+		if severity := strings.TrimSpace(args.Severity); severity != "" {
+			filtered := make(AlertConfigResponse, 0, len(rules))
+			for _, r := range rules {
+				if strings.EqualFold(r.Severity, severity) {
+					filtered = append(filtered, r)
+				}
+			}
+			rules = filtered
+		}
+
+		resolveAlertConfigKPIs(ctx, client, cfg, rules)
+
+		dlBuilder := deeplink.NewBuilder(cfg.OrgSlug, cfg.ClusterID)
+		dashboardURL := dlBuilder.BuildAlertingGroupsLink()
+
+		return &mcp.CallToolResult{
+			Meta: deeplink.ToMeta(dashboardURL),
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: formatAlertConfigResponse(rules)},
+			},
+		}, nil, nil
+	}
+}
+
+func fetchEntityAlertRules(
+	ctx context.Context,
+	client *http.Client,
+	cfg models.Config,
+	entityID string,
+) (AlertConfigResponse, error) {
+	fullURL := cfg.APIBaseURL + fmt.Sprintf(constants.EndpointEntityAlertRules, entityID)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set(constants.HeaderAccept, constants.HeaderAcceptJSON)
+	httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+cfg.TokenManager.GetAccessToken(ctx))
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var rules AlertConfigResponse
+	if err := json.Unmarshal(body, &rules); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return rules, nil
+}

--- a/internal/alerting/entity_alert_rules.go
+++ b/internal/alerting/entity_alert_rules.go
@@ -109,10 +109,12 @@ func fetchEntityAlertRules(
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	var rules AlertConfigResponse
-	if err := json.Unmarshal(body, &rules); err != nil {
+	var wrapper struct {
+		Rules AlertConfigResponse `json:"rules"`
+	}
+	if err := json.Unmarshal(body, &wrapper); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	return rules, nil
+	return wrapper.Rules, nil
 }

--- a/internal/alerting/entity_alert_rules.go
+++ b/internal/alerting/entity_alert_rules.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
 	"last9-mcp/internal/constants"
@@ -15,22 +16,19 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const GetEntityAlertRulesDescription = `Fetches all alert rules for a specific entity (alert group) with full detail:
-expression, condition, eval window, and resolved PromQL for each indicator.
+const GetEntityAlertRulesDescription = `Fetches alert rule expressions and resolved PromQL for a specific entity.
 
-Use this tool when you need the complete alert rule configuration for a known entity,
-including the actual PromQL queries behind each indicator. The org-wide get_alert_config
-tool omits expression_args and PromQL; this tool includes them.
+Use after get_alert_config to drill into the actual queries behind each alert rule.
+The org-wide tool shows basic metadata; this tool shows the expression logic and PromQL.
 
 Input:
-- entity_id (required): UUID of the entity / alert group
+- entity_id (required): UUID of the entity / alert group (from get_alert_config Entity ID field)
 - severity (optional): filter rules by severity (e.g. "breach", "warn")
 
-Output per rule:
-- id, rule_name, primary_indicator, state, severity, algorithm
+Output per rule (expression-focused; basic metadata available from get_alert_config):
+- id, rule_name
 - expression, condition, alert_condition, eval_window
-- indicators: each indicator name with resolved PromQL, unit, and variables
-- created_at, updated_at`
+- indicators: each indicator name with resolved PromQL and unit`
 
 // GetEntityAlertRulesArgs holds the input arguments for get_entity_alert_rules.
 type GetEntityAlertRulesArgs struct {
@@ -72,7 +70,7 @@ func NewGetEntityAlertRulesHandler(client *http.Client, cfg models.Config) func(
 		return &mcp.CallToolResult{
 			Meta: deeplink.ToMeta(dashboardURL),
 			Content: []mcp.Content{
-				&mcp.TextContent{Text: formatAlertConfigResponse(rules)},
+				&mcp.TextContent{Text: formatEntityAlertRulesResponse(rules)},
 			},
 		}, nil, nil
 	}
@@ -117,4 +115,58 @@ func fetchEntityAlertRules(
 	}
 
 	return wrapper.Rules, nil
+}
+
+// formatEntityAlertRulesResponse formats entity-scoped rules showing only
+// expression/indicator fields. Basic metadata (state, severity, timestamps, etc.)
+// is omitted because callers already have it from get_alert_config.
+func formatEntityAlertRulesResponse(rules AlertConfigResponse) string {
+	out := fmt.Sprintf("Found %d alert rules for entity:\n\n", len(rules))
+	for i, rule := range rules {
+		out += fmt.Sprintf("Rule %d:\n", i+1)
+		out += fmt.Sprintf("  ID: %s\n", rule.ID)
+		out += fmt.Sprintf("  Rule Name: %s\n", rule.RuleName)
+		if rule.Expression != "" {
+			out += fmt.Sprintf("  Expression: %s\n", rule.Expression)
+		}
+		if rule.Condition != "" {
+			out += fmt.Sprintf("  Condition: %s\n", rule.Condition)
+		}
+		if rule.AlertCondition != "" {
+			out += fmt.Sprintf("  Alert Condition: %s\n", rule.AlertCondition)
+		}
+		if rule.EvalWindow > 0 {
+			out += fmt.Sprintf("  Eval Window: %d minutes\n", rule.EvalWindow)
+		}
+		if len(rule.ExpressionArgs) > 0 {
+			out += "  Indicators:\n"
+			indicatorNames := make([]string, 0, len(rule.ExpressionArgs))
+			for name := range rule.ExpressionArgs {
+				indicatorNames = append(indicatorNames, name)
+			}
+			sort.Strings(indicatorNames)
+			for _, name := range indicatorNames {
+				arg := rule.ExpressionArgs[name]
+				out += fmt.Sprintf("    %s (KPI ID: %s)\n", name, arg.ID)
+				if arg.LookupError != "" {
+					out += fmt.Sprintf("      PromQL: [lookup failed: %s]\n", arg.LookupError)
+				} else if arg.PromQL != "" {
+					out += fmt.Sprintf("      PromQL: %s\n", arg.PromQL)
+					if arg.Unit != "" {
+						out += fmt.Sprintf("      Unit: %s\n", arg.Unit)
+					}
+				}
+				varKeys := make([]string, 0, len(arg.Variables))
+				for k := range arg.Variables {
+					varKeys = append(varKeys, k)
+				}
+				sort.Strings(varKeys)
+				for _, k := range varKeys {
+					out += fmt.Sprintf("      Variable %s: %s\n", k, arg.Variables[k])
+				}
+			}
+		}
+		out += "\n"
+	}
+	return out
 }

--- a/internal/alerting/entity_alert_rules.go
+++ b/internal/alerting/entity_alert_rules.go
@@ -16,16 +16,17 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const GetEntityAlertRulesDescription = `Fetches alert rule expressions and resolved PromQL for a specific entity.
+const GetEntityAlertRulesDescription = `Fetches the expression logic and resolved PromQL for all alert rules on a specific entity.
 
-Use after get_alert_config to drill into the actual queries behind each alert rule.
-The org-wide tool shows basic metadata; this tool shows the expression logic and PromQL.
+Companion to get_alert_config: call get_alert_config first to discover rules and find the
+entity_id, then call this tool with that entity_id to get the full alert configuration
+including the actual PromQL queries behind each indicator.
 
 Input:
-- entity_id (required): UUID of the entity / alert group (from get_alert_config Entity ID field)
+- entity_id (required): UUID of the entity / alert group (from the Entity ID field in get_alert_config output)
 - severity (optional): filter rules by severity (e.g. "breach", "warn")
 
-Output per rule (expression-focused; basic metadata available from get_alert_config):
+Output per rule (expression-focused; basic metadata such as state/severity/timestamps is in get_alert_config):
 - id, rule_name
 - expression, condition, alert_condition, eval_window
 - indicators: each indicator name with resolved PromQL and unit`

--- a/internal/alerting/entity_alert_rules_test.go
+++ b/internal/alerting/entity_alert_rules_test.go
@@ -151,6 +151,10 @@ func TestGetEntityAlertRulesHandler_ReturnsRules(t *testing.T) {
 	if !strings.Contains(text, "rule-1") || !strings.Contains(text, "rule-2") {
 		t.Fatalf("expected both rule IDs in response, got:\n%s", text)
 	}
+	// Basic metadata fields are intentionally omitted — covered by get_alert_config.
+	if strings.Contains(text, "State:") || strings.Contains(text, "Severity:") || strings.Contains(text, "Algorithm:") {
+		t.Fatalf("expected basic metadata fields absent from focused output, got:\n%s", text)
+	}
 }
 
 func TestGetEntityAlertRulesHandler_SeverityFilter(t *testing.T) {
@@ -177,6 +181,9 @@ func TestGetEntityAlertRulesHandler_SeverityFilter(t *testing.T) {
 	}
 	if strings.Contains(text, "rule-2") {
 		t.Fatalf("severity filter let warn rule through, got:\n%s", text)
+	}
+	if strings.Contains(text, "Severity:") {
+		t.Fatalf("severity field should not appear in focused output, got:\n%s", text)
 	}
 }
 

--- a/internal/alerting/entity_alert_rules_test.go
+++ b/internal/alerting/entity_alert_rules_test.go
@@ -40,7 +40,10 @@ func newEntityAlertRulesTestServer(t *testing.T, state *entityAlertRulesTestServ
 				w.WriteHeader(status)
 				if status == http.StatusOK {
 					rules := state.rulesByEntityID[entityID]
-					_ = json.NewEncoder(w).Encode(rules)
+					_ = json.NewEncoder(w).Encode(struct {
+						Rules        AlertConfigResponse `json:"rules"`
+						SnoozedUntil int                 `json:"snoozed_until"`
+					}{Rules: rules})
 					return
 				}
 				_, _ = w.Write([]byte(`{"error":"entity alert rules failed"}`))

--- a/internal/alerting/entity_alert_rules_test.go
+++ b/internal/alerting/entity_alert_rules_test.go
@@ -1,0 +1,258 @@
+package alerting
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type entityAlertRulesTestServerState struct {
+	rulesByEntityID map[string]AlertConfigResponse // entityID → rules
+	kpiResponses    map[string]kpiResponse          // kpiID → response (absent = 404)
+	entityStatus    int                             // default 200
+}
+
+func newEntityAlertRulesTestServer(t *testing.T, state *entityAlertRulesTestServerState) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// /entities/{entityID}/alert-rules
+		if strings.HasPrefix(r.URL.Path, "/entities/") && strings.HasSuffix(r.URL.Path, "/alert-rules") {
+			parts := strings.Split(r.URL.Path, "/")
+			// ["", "entities", entityID, "alert-rules"]
+			if len(parts) == 4 {
+				entityID := parts[2]
+				status := state.entityStatus
+				if status == 0 {
+					status = http.StatusOK
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				if status == http.StatusOK {
+					rules := state.rulesByEntityID[entityID]
+					_ = json.NewEncoder(w).Encode(rules)
+					return
+				}
+				_, _ = w.Write([]byte(`{"error":"entity alert rules failed"}`))
+				return
+			}
+		}
+
+		// /entities/{entityID}/kpis/{kpiID}
+		if strings.HasPrefix(r.URL.Path, "/entities/") && strings.Contains(r.URL.Path, "/kpis/") {
+			parts := strings.Split(r.URL.Path, "/")
+			// ["", "entities", entityID, "kpis", kpiID]
+			if len(parts) == 5 {
+				kpiID := parts[4]
+				if kpi, ok := state.kpiResponses[kpiID]; ok {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(kpi)
+					return
+				}
+			}
+		}
+
+		http.NotFound(w, r)
+	}))
+}
+
+func executeGetEntityAlertRules(
+	t *testing.T,
+	state *entityAlertRulesTestServerState,
+	args GetEntityAlertRulesArgs,
+) (string, *mcp.CallToolResult, error) {
+	t.Helper()
+
+	server := newEntityAlertRulesTestServer(t, state)
+	defer server.Close()
+
+	cfg := models.Config{
+		APIBaseURL: server.URL,
+		OrgSlug:    "last9",
+		ClusterID:  "cluster-1",
+	}
+	cfg.TokenManager = &auth.TokenManager{
+		AccessToken: "test-access-token",
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+	}
+
+	handler := NewGetEntityAlertRulesHandler(server.Client(), cfg)
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		return "", result, err
+	}
+
+	return utils.GetTextContent(t, result), result, nil
+}
+
+func TestGetEntityAlertRulesHandler_MissingEntityID(t *testing.T) {
+	state := &entityAlertRulesTestServerState{}
+	text, result, err := executeGetEntityAlertRules(t, state, GetEntityAlertRulesArgs{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected IsError=true for missing entity_id")
+	}
+	if !strings.Contains(text, "entity_id is required") {
+		t.Fatalf("expected error message, got: %s", text)
+	}
+}
+
+func TestGetEntityAlertRulesHandler_ReturnsRules(t *testing.T) {
+	entityID := "entity-abc"
+	rules := AlertConfigResponse{
+		{
+			ID:               "rule-1",
+			EntityID:         entityID,
+			PrimaryIndicator: "throughput",
+			State:            "active",
+			Severity:         "breach",
+			Algorithm:        "static_threshold",
+			RuleName:         "High Throughput",
+		},
+		{
+			ID:               "rule-2",
+			EntityID:         entityID,
+			PrimaryIndicator: "error_rate",
+			State:            "active",
+			Severity:         "warn",
+			Algorithm:        "static_threshold",
+			RuleName:         "Error Rate",
+		},
+	}
+
+	state := &entityAlertRulesTestServerState{
+		rulesByEntityID: map[string]AlertConfigResponse{entityID: rules},
+	}
+
+	text, _, err := executeGetEntityAlertRules(t, state, GetEntityAlertRulesArgs{EntityID: entityID})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	if !strings.Contains(text, "Found 2 alert rules") {
+		t.Fatalf("expected 2 rules in response, got:\n%s", text)
+	}
+	if !strings.Contains(text, "rule-1") || !strings.Contains(text, "rule-2") {
+		t.Fatalf("expected both rule IDs in response, got:\n%s", text)
+	}
+}
+
+func TestGetEntityAlertRulesHandler_SeverityFilter(t *testing.T) {
+	entityID := "entity-abc"
+	rules := AlertConfigResponse{
+		{ID: "rule-1", EntityID: entityID, Severity: "breach", State: "active", Algorithm: "static_threshold"},
+		{ID: "rule-2", EntityID: entityID, Severity: "warn", State: "active", Algorithm: "static_threshold"},
+	}
+
+	state := &entityAlertRulesTestServerState{
+		rulesByEntityID: map[string]AlertConfigResponse{entityID: rules},
+	}
+
+	text, _, err := executeGetEntityAlertRules(t, state, GetEntityAlertRulesArgs{
+		EntityID: entityID,
+		Severity: "breach",
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+
+	if !strings.Contains(text, "Found 1 alert rules") {
+		t.Fatalf("expected 1 rule after severity filter, got:\n%s", text)
+	}
+	if strings.Contains(text, "rule-2") {
+		t.Fatalf("severity filter let warn rule through, got:\n%s", text)
+	}
+}
+
+func TestGetEntityAlertRulesHandler_KPIResolution(t *testing.T) {
+	entityID := "entity-abc"
+	kpiID := "kpi-uuid-1"
+	rules := AlertConfigResponse{
+		{
+			ID:               "rule-1",
+			EntityID:         entityID,
+			PrimaryIndicator: "p99_latency",
+			Expression:       "p99_latency",
+			Condition:        "expr > 500",
+			State:            "active",
+			Severity:         "breach",
+			Algorithm:        "static_threshold",
+			RuleName:         "High P99",
+			ExpressionArgs: map[string]AlertRuleExpressionArg{
+				"p99_latency": {ID: kpiID},
+			},
+		},
+	}
+
+	t.Run("PromQL resolved", func(t *testing.T) {
+		state := &entityAlertRulesTestServerState{
+			rulesByEntityID: map[string]AlertConfigResponse{entityID: rules},
+			kpiResponses: map[string]kpiResponse{
+				kpiID: {
+					ID:   kpiID,
+					Name: "p99_latency",
+					Definition: kpiDefinition{
+						Query: `histogram_quantile(0.99, rate(http_request_duration_seconds_bucket[5m]))`,
+						Unit:  "seconds",
+					},
+				},
+			},
+		}
+
+		text, _, err := executeGetEntityAlertRules(t, state, GetEntityAlertRulesArgs{EntityID: entityID})
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if !strings.Contains(text, "histogram_quantile") {
+			t.Fatalf("expected PromQL in response, got:\n%s", text)
+		}
+		if !strings.Contains(text, "Unit: seconds") {
+			t.Fatalf("expected unit in response, got:\n%s", text)
+		}
+	})
+
+	t.Run("KPI 404 shows lookup failure", func(t *testing.T) {
+		state := &entityAlertRulesTestServerState{
+			rulesByEntityID: map[string]AlertConfigResponse{entityID: rules},
+			kpiResponses:    map[string]kpiResponse{}, // no KPIs → 404
+		}
+
+		text, _, err := executeGetEntityAlertRules(t, state, GetEntityAlertRulesArgs{EntityID: entityID})
+		if err != nil {
+			t.Fatalf("handler should succeed with KPI failure: %v", err)
+		}
+		if !strings.Contains(text, "lookup failed") {
+			t.Fatalf("expected lookup failure note, got:\n%s", text)
+		}
+		if !strings.Contains(text, "rule-1") {
+			t.Fatalf("rule should still appear on KPI failure, got:\n%s", text)
+		}
+	})
+}
+
+func TestGetEntityAlertRulesHandler_APIError(t *testing.T) {
+	state := &entityAlertRulesTestServerState{
+		entityStatus: http.StatusInternalServerError,
+	}
+
+	_, _, err := executeGetEntityAlertRules(t, state, GetEntityAlertRulesArgs{EntityID: "entity-abc"})
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("%d", http.StatusInternalServerError)) {
+		t.Fatalf("expected 500 in error, got: %v", err)
+	}
+}

--- a/internal/alerting/integration_test.go
+++ b/internal/alerting/integration_test.go
@@ -146,6 +146,10 @@ func TestGetEntityAlertRulesHandler_Integration(t *testing.T) {
 	if !strings.Contains(text, "ID:") {
 		t.Fatalf("expected at least one rule with 'ID:' in response, got:\n%s", text)
 	}
+	// Basic metadata fields are omitted from this focused tool.
+	if strings.Contains(text, "State:") || strings.Contains(text, "Severity:") {
+		t.Fatalf("basic metadata fields should be absent from entity alert rules output, got:\n%s", text)
+	}
 
 	// If any indicators present, each must have PromQL or a lookup failure note.
 	// Split on "Indicators:" — each block runs from one marker to the next, containing

--- a/internal/alerting/integration_test.go
+++ b/internal/alerting/integration_test.go
@@ -27,6 +27,7 @@ func TestGetAlertConfigHandler_Integration_Basic(t *testing.T) {
 	}
 
 	text := utils.GetTextContent(t, result)
+	t.Logf("response:\n%s", text)
 
 	if !strings.Contains(text, "Found") {
 		t.Fatalf("expected 'Found N alert rules' in response, got:\n%s", text)
@@ -59,6 +60,7 @@ func TestGetAlertConfigHandler_Integration_KPIResolution(t *testing.T) {
 	}
 
 	text := utils.GetTextContent(t, result)
+	t.Logf("response:\n%s", text)
 
 	if strings.Contains(text, "Found 0 alert rules") {
 		t.Skip("no alert rules in org; skipping KPI resolution assertions")
@@ -76,18 +78,8 @@ func TestGetAlertConfigHandler_Integration_KPIResolution(t *testing.T) {
 	// lookup failure note — never a silent empty field.
 	indicatorBlocks := strings.Split(text, "Indicators:")
 	for _, block := range indicatorBlocks[1:] { // skip text before first "Indicators:"
-		// Take only up to the next top-level field (two-space indent = rule field).
-		endIdx := strings.Index(block, "\n  ")
-		if endIdx == -1 {
-			endIdx = len(block)
-		}
-		indicatorSection := block[:endIdx]
-
-		hasPromQL := strings.Contains(indicatorSection, "PromQL:")
-		hasLookupFailed := strings.Contains(indicatorSection, "lookup failed")
-
-		if !hasPromQL && !hasLookupFailed {
-			t.Fatalf("indicator block has neither PromQL nor lookup failure note:\n%s", indicatorSection)
+		if !strings.Contains(block, "PromQL:") && !strings.Contains(block, "lookup failed") {
+			t.Fatalf("indicator block has neither PromQL nor lookup failure note:\n%s", block)
 		}
 	}
 }
@@ -105,6 +97,7 @@ func TestGetAlertConfigHandler_Integration_SeverityFilter(t *testing.T) {
 	}
 
 	text := utils.GetTextContent(t, result)
+	t.Logf("response:\n%s", text)
 
 	// Every rule in response must have severity breach (case-insensitive).
 	for _, line := range strings.Split(text, "\n") {
@@ -113,6 +106,56 @@ func TestGetAlertConfigHandler_Integration_SeverityFilter(t *testing.T) {
 			severity := strings.TrimSpace(strings.TrimPrefix(trimmed, "Severity:"))
 			if !strings.EqualFold(severity, "breach") {
 				t.Fatalf("severity filter returned non-breach rule with severity %q", severity)
+			}
+		}
+	}
+}
+
+func TestGetEntityAlertRulesHandler_Integration(t *testing.T) {
+	cfg := utils.SetupTestConfigOrSkip(t)
+
+	// First fetch the org-wide list to get a real entity ID.
+	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)
+	defer cancel()
+
+	rules, err := fetchAlertConfig(ctx, http.DefaultClient, *cfg)
+	if err != nil {
+		t.Skipf("could not fetch org alert config: %v", err)
+	}
+	if len(rules) == 0 {
+		t.Skip("no alert rules in org; skipping")
+	}
+
+	entityID := rules[0].EntityID
+	if entityID == "" {
+		t.Skip("first rule has no entity_id; skipping")
+	}
+
+	handler := NewGetEntityAlertRulesHandler(http.DefaultClient, *cfg)
+	result, _, err := handler(ctx, &mcp.CallToolRequest{}, GetEntityAlertRulesArgs{EntityID: entityID})
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+
+	text := utils.GetTextContent(t, result)
+	t.Logf("entity_id=%s response:\n%s", entityID, text)
+
+	if !strings.Contains(text, "Found") {
+		t.Fatalf("expected 'Found N alert rules' in response, got:\n%s", text)
+	}
+	if !strings.Contains(text, "ID:") {
+		t.Fatalf("expected at least one rule with 'ID:' in response, got:\n%s", text)
+	}
+
+	// If any indicators present, each must have PromQL or a lookup failure note.
+	// Split on "Indicators:" — each block runs from one marker to the next, containing
+	// that rule's indicator sub-section followed by the next rule's fields.
+	// No truncation needed: "PromQL:" and "lookup failed" only appear inside indicators.
+	if strings.Contains(text, "Indicators:") {
+		indicatorBlocks := strings.Split(text, "Indicators:")
+		for _, block := range indicatorBlocks[1:] {
+			if !strings.Contains(block, "PromQL:") && !strings.Contains(block, "lookup failed") {
+				t.Fatalf("indicator block has neither PromQL nor lookup failure note:\n%s", block)
 			}
 		}
 	}

--- a/internal/alerting/integration_test.go
+++ b/internal/alerting/integration_test.go
@@ -1,0 +1,119 @@
+package alerting
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const integrationTestTimeout = 30 * time.Second
+
+func TestGetAlertConfigHandler_Integration_Basic(t *testing.T) {
+	cfg := utils.SetupTestConfigOrSkip(t)
+	handler := NewGetAlertConfigHandler(http.DefaultClient, *cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)
+	defer cancel()
+
+	result, _, err := handler(ctx, &mcp.CallToolRequest{}, GetAlertConfigArgs{})
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+
+	text := utils.GetTextContent(t, result)
+
+	if !strings.Contains(text, "Found") {
+		t.Fatalf("expected 'Found N alert rules' in response, got:\n%s", text)
+	}
+
+	// If no rules exist, skip the deeper assertions.
+	if strings.Contains(text, "Found 0 alert rules") {
+		t.Skip("no alert rules in org; skipping field assertions")
+	}
+
+	// Every rule must have at minimum an ID and state.
+	if !strings.Contains(text, "ID:") {
+		t.Fatalf("expected at least one rule with 'ID:' in response, got:\n%s", text)
+	}
+	if !strings.Contains(text, "State:") {
+		t.Fatalf("expected 'State:' in response, got:\n%s", text)
+	}
+}
+
+func TestGetAlertConfigHandler_Integration_KPIResolution(t *testing.T) {
+	cfg := utils.SetupTestConfigOrSkip(t)
+	handler := NewGetAlertConfigHandler(http.DefaultClient, *cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)
+	defer cancel()
+
+	result, _, err := handler(ctx, &mcp.CallToolRequest{}, GetAlertConfigArgs{})
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+
+	text := utils.GetTextContent(t, result)
+
+	if strings.Contains(text, "Found 0 alert rules") {
+		t.Skip("no alert rules in org; skipping KPI resolution assertions")
+	}
+
+	// At least one rule should have expression_args (static threshold rules created
+	// via the API or Terraform all have them). If we see "Indicators:" in the output
+	// we know resolution ran. If no rule has indicators, that is also valid (all
+	// Grafana-synced rules) — we just skip rather than fail.
+	if !strings.Contains(text, "Indicators:") {
+		t.Skip("no rules with expression_args found; skipping KPI resolution check")
+	}
+
+	// For every rule that has indicators, there must be either a PromQL line or a
+	// lookup failure note — never a silent empty field.
+	indicatorBlocks := strings.Split(text, "Indicators:")
+	for _, block := range indicatorBlocks[1:] { // skip text before first "Indicators:"
+		// Take only up to the next top-level field (two-space indent = rule field).
+		endIdx := strings.Index(block, "\n  ")
+		if endIdx == -1 {
+			endIdx = len(block)
+		}
+		indicatorSection := block[:endIdx]
+
+		hasPromQL := strings.Contains(indicatorSection, "PromQL:")
+		hasLookupFailed := strings.Contains(indicatorSection, "lookup failed")
+
+		if !hasPromQL && !hasLookupFailed {
+			t.Fatalf("indicator block has neither PromQL nor lookup failure note:\n%s", indicatorSection)
+		}
+	}
+}
+
+func TestGetAlertConfigHandler_Integration_SeverityFilter(t *testing.T) {
+	cfg := utils.SetupTestConfigOrSkip(t)
+	handler := NewGetAlertConfigHandler(http.DefaultClient, *cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)
+	defer cancel()
+
+	result, _, err := handler(ctx, &mcp.CallToolRequest{}, GetAlertConfigArgs{Severity: "breach"})
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+
+	text := utils.GetTextContent(t, result)
+
+	// Every rule in response must have severity breach (case-insensitive).
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "Severity:") {
+			severity := strings.TrimSpace(strings.TrimPrefix(trimmed, "Severity:"))
+			if !strings.EqualFold(severity, "breach") {
+				t.Fatalf("severity filter returned non-breach rule with severity %q", severity)
+			}
+		}
+	}
+}

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -27,6 +27,7 @@ const (
 	EndpointAlertsMonitor        = "/alerts/monitor"
 	EndpointEntitiesList         = "/entities/list"
 	EndpointEntityKPI            = "/entities/%s/kpis/%s"
+	EndpointEntityAlertRules     = "/entities/%s/alert-rules"
 	EndpointNotificationSettings = "/notification_settings"
 	// EndpointSuggest returns fuzzy entity-name suggestions for the did_you_mean tool.
 	EndpointSuggest = "/suggest"

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -26,6 +26,7 @@ const (
 	EndpointAlertRules           = "/alert-rules"
 	EndpointAlertsMonitor        = "/alerts/monitor"
 	EndpointEntitiesList         = "/entities/list"
+	EndpointEntityKPI            = "/entities/%s/kpis/%s"
 	EndpointNotificationSettings = "/notification_settings"
 	// EndpointSuggest returns fuzzy entity-name suggestions for the did_you_mean tool.
 	EndpointSuggest = "/suggest"

--- a/internal/utils/test_helpers.go
+++ b/internal/utils/test_helpers.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -18,7 +19,22 @@ var loadTestEnvOnce sync.Once
 
 func loadTestEnv() {
 	loadTestEnvOnce.Do(func() {
-		_ = godotenv.Load()
+		dir, err := os.Getwd()
+		if err != nil {
+			return
+		}
+		for {
+			candidate := filepath.Join(dir, ".env")
+			if _, err := os.Stat(candidate); err == nil {
+				_ = godotenv.Load(candidate)
+				return
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
 	})
 }
 

--- a/tools.go
+++ b/tools.go
@@ -145,6 +145,12 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCa
 		Description: alerting.GetAlertConfigDescription,
 	}, alerting.NewGetAlertConfigHandler(client, cfg))
 
+	// Register entity alert rules tool (entity-scoped, includes expression_args and resolved PromQL)
+	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+		Name:        "get_entity_alert_rules",
+		Description: alerting.GetEntityAlertRulesDescription,
+	}, alerting.NewGetEntityAlertRulesHandler(client, cfg))
+
 	// Register alerts tool
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
 		Name:        "get_alerts",


### PR DESCRIPTION
## Summary

- `get_alert_config` now resolves each rule's `expression_args` indicators to their actual PromQL queries via `GET /entities/{id}/kpis/{id}`, with result caching by `(entityID, kpiID)` to avoid redundant fetches
- New `get_entity_alert_rules` tool fetches entity-scoped alert rules (which includes `expression_args` in the SQL query, unlike the org-wide endpoint) and resolves PromQL inline
- `loadTestEnv()` walks up the directory tree to find `.env` at the project root
- Formatted output is deterministic: indicator names, variable keys, and property keys are sorted before rendering

## Background

The org-wide `GET /alert-rules` endpoint omits `expression_args` from its SQL SELECT. The entity-scoped `GET /entities/{id}/alert-rules` includes it. The new tool uses the entity-scoped endpoint; the existing tool's KPI resolution now triggers when rules do have `expression_args` populated (e.g. rules fetched after switching to entity-scoped calls).

## Test plan

- [ ] Unit tests: `go test ./internal/alerting/...` — all pass
- [ ] Integration tests (requires `.env`): `go test -run Integration ./internal/alerting/` — verified live against org, 7 rules returned with resolved PromQL for entity `0466b646`
- [ ] No secrets in diff — verified with `git diff` grep scan
- [ ] Deterministic output verified: sorted map iteration in formatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)