### PR TITLE
ENG-925: fix traces/logs sanitizer correctness and add get_trace_attribute_values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.rtk
 last9-mcp
 config.txt
 

--- a/internal/alerting/entity_alert_rules.go
+++ b/internal/alerting/entity_alert_rules.go
@@ -24,7 +24,7 @@ including the actual PromQL queries behind each indicator.
 
 Input:
 - entity_id (required): UUID of the entity / alert group (from the Entity ID field in get_alert_config output)
-- severity (optional): filter rules by severity (e.g. "breach", "warn")
+- severity (optional): filter rules by severity (e.g. "breach", "threat")
 
 Output per rule (expression-focused; basic metadata such as state/severity/timestamps is in get_alert_config):
 - id, rule_name

--- a/internal/auth/token_manager.go
+++ b/internal/auth/token_manager.go
@@ -23,6 +23,16 @@ var (
 	httpClientOnce sync.Once
 )
 
+// HTTPError is returned when an HTTP request receives a non-200 response.
+// Callers can use errors.As to inspect the StatusCode directly.
+type HTTPError struct {
+	StatusCode int
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("unexpected status code: %d", e.StatusCode)
+}
+
 type TokenManager struct {
 	AccessToken  string
 	RefreshToken string
@@ -136,7 +146,7 @@ func RefreshAccessToken(ctx context.Context, client *http.Client, refreshToken s
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		return "", &HTTPError{StatusCode: resp.StatusCode}
 	}
 
 	var result struct {

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -5,9 +5,10 @@ import "time"
 // API Endpoints
 const (
 	// Traces API endpoints
-	EndpointTracesQueryRange = "/cat/api/traces/v2/query_range/json"
-	EndpointTracesSeries     = "/cat/api/traces/v2/series/json"
-	EndpointTraceDetails     = "/cat/api/traces/%s"
+	EndpointTracesQueryRange  = "/cat/api/traces/v2/query_range/json"
+	EndpointTracesSeries      = "/cat/api/traces/v2/series/json"
+	EndpointTraceDetails      = "/cat/api/traces/%s"
+	EndpointTraceTagValues    = "/cat/api/traces/v2/label/json/%s/values"
 
 	// Logs API endpoints
 	EndpointLogsQueryRange = "/logs/api/v2/query_range/json"

--- a/internal/dashboards/integration_test.go
+++ b/internal/dashboards/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -121,6 +122,9 @@ func TestGetDashboardHandler_Integration(t *testing.T) {
 
 func TestDashboardCRUD_Integration(t *testing.T) {
 	cfg := utils.SetupTestConfigOrSkip(t)
+	if os.Getenv("LAST9_DELETE_TOKEN") == "" {
+		t.Skip("Skipping CRUD test: LAST9_DELETE_TOKEN not set (required for delete permission)")
+	}
 	deleteCfg := utils.SetupTestConfigWithTokenOrSkip(t, "LAST9_DELETE_TOKEN", cfg)
 	client := http.DefaultClient
 	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)

--- a/internal/dashboards/integration_test.go
+++ b/internal/dashboards/integration_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -122,9 +121,6 @@ func TestGetDashboardHandler_Integration(t *testing.T) {
 
 func TestDashboardCRUD_Integration(t *testing.T) {
 	cfg := utils.SetupTestConfigOrSkip(t)
-	if os.Getenv("LAST9_DELETE_TOKEN") == "" {
-		t.Skip("Skipping CRUD test: LAST9_DELETE_TOKEN not set (required for delete permission)")
-	}
 	deleteCfg := utils.SetupTestConfigWithTokenOrSkip(t, "LAST9_DELETE_TOKEN", cfg)
 	client := http.DefaultClient
 	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)

--- a/internal/prompts/descriptions/get_alert_config.md
+++ b/internal/prompts/descriptions/get_alert_config.md
@@ -8,7 +8,7 @@ Select the correct JSON arguments to call the `get_alert_config` tool, which ret
 
 - `rule_id` (string): **Exact** match on alert rule ID (UUID). Use when the user provides a specific rule ID.
 - `rule_name` (string): Case-insensitive substring match on rule name.
-- `severity` (string): Exact case-insensitive match. Values: `breach`, `threat`, `warning`, etc.
+- `severity` (string): Exact case-insensitive match. Values: `breach`, `threat`.
 - `rule_type` (string): Derived rule type. Values: `static` or `anomaly`.
 - `alert_group_name` (string): Case-insensitive substring match on alert group name.
 - `alert_group_type` (string): Case-insensitive substring match on alert group type.

--- a/internal/prompts/descriptions/get_logs.md
+++ b/internal/prompts/descriptions/get_logs.md
@@ -45,8 +45,8 @@ These are instructions for constructing a natural language logs analytics querie
 - Never emit bare dotted field references such as `service.name`, `http.status_code`, or `k8s.namespace.name`.
 - Use `ServiceName` for service filters and grouping, not `service.name`.
 - Use `attributes['field.name']` for log attributes.
-- Use `resource_attributes['field.name']` for resource attributes, including Kubernetes metadata like `k8s.namespace.name`.
-- If you are not sure whether a field exists or whether environment is stored on `attributes[...]` vs `resource_attributes[...]`, use `get_log_attributes` first or broaden the query instead of guessing.
+- Use `resources['field.name']` for resource attributes, including Kubernetes metadata like `k8s.namespace.name`.
+- If you are not sure whether a field exists or whether environment is stored on `attributes[...]` vs `resources[...]`, use `get_log_attributes` first or broaden the query instead of guessing.
 
 The JSON pipeline format supports filtering, parsing, aggregation on log data.
 
@@ -90,19 +90,46 @@ The JSON pipeline format supports filtering, parsing, aggregation on log data.
   "query": {
     "$and": [...],        // AND multiple conditions
     "$or": [...],         // OR multiple conditions
-    "$eq": [field, value],     // Equals. value must be a string
-    "$neq": [field, value],    // Not equals. value must be a string
-    "$gt": [field, value],     // Greater than. value must be a string containing a number
-    "$lt": [field, value],     // Less than. value must be a string containing a number
-    "$gte": [field, value],    // Greater than or equal. value must be a string containing a number
-    "$lte": [field, value],    // Less than or equal. value must be a string containing a number
-    "$contains": [field, text], // Contains text
-    "$notcontains": [field, text], // Doesn't contain text
-    "$regex": [field, pattern], // Regex match
-    "$notregex": [field, pattern], // Regex not match
-    "$not": [condition]        // Negation
+    "$not": [condition],  // Negation
+
+    // Equality
+    "$eq":   [field, value],  // Equals (case-sensitive)
+    "$neq":  [field, value],  // Not equals (case-sensitive)
+    "$ieq":  [field, value],  // Case-insensitive equals
+    "$ineq": [field, value],  // Case-insensitive not equals
+
+    // Numeric comparison — value must be a string containing a number
+    "$gt":  [field, value],   // Greater than
+    "$lt":  [field, value],   // Less than
+    "$gte": [field, value],   // Greater than or equal
+    "$lte": [field, value],   // Less than or equal
+
+    // Substring search
+    "$contains":    [field, text],  // Contains substring (case-sensitive)
+    "$notcontains": [field, text],  // Does not contain (case-sensitive)
+    "$icontains":   [field, text],  // Case-insensitive contains
+    "$inotcontains": [field, text], // Case-insensitive does not contain
+
+    // Word-boundary search — PREFER over $contains for Body text search
+    "$containsWords":    [field, word],  // Field contains the word (word-boundary aware)
+    "$icontainsWords":   [field, word],  // Case-insensitive word-boundary match
+
+    // Regex
+    "$regex":    [field, pattern],  // Regex match
+    "$notregex": [field, pattern],  // Regex not match
+    "$iregex":   [field, pattern],  // Case-insensitive regex match
+    "$inotregex": [field, pattern]  // Case-insensitive regex not match
   }
 }
+```
+
+**Word-boundary search patterns — use these instead of `$contains` for Body searches:**
+```json
+// Contains ALL words — multiple $containsWords conditions in $and:
+{"$and": [{"$containsWords": ["Body", "timeout"]}, {"$containsWords": ["Body", "database"]}]}
+
+// Contains ANY word — multiple $containsWords conditions in $or:
+{"$or": [{"$containsWords": ["Body", "timeout"]}, {"$containsWords": ["Body", "error"]}]}
 ```
 
 ### Parse Operations:
@@ -166,21 +193,21 @@ Note that regex parsing operators also work as regex filters
 ### Standard Log Fields:
 
 - **Body**: Log message content
-- **ServiceName**: Service name. Always prefer this over similar looking attributes in `attributes` or `resource_attributes` given below
+- **ServiceName**: Service name. Always prefer this over similar looking attributes in `attributes` or `resources` given below
 - **SeverityText**: Log level (DEBUG, INFO, WARN, ERROR, FATAL)
 - **Timestamp**: Log timestamp
 - **attributes['field_name']**: Log/span attributes (OpenTelemetry semantic conventions)
-- **resource_attributes['field_name']**: Resource attributes (prefixed with `resource_`)
+- **resources['field_name']**: Resource attributes (prefixed with `resource_`)
 
 ### Invalid Field Reference Patterns:
 
 - **Never use bare dotted refs** like `service.name`, `deployment.environment`, or `k8s.namespace.name`
 - **Correct service alias**: `service.name` → `ServiceName`
-- **Correct Kubernetes alias**: `k8s.namespace.name` → `resource_attributes['k8s.namespace.name']`
-- **Correct Kubernetes alias**: `k8s.deployment.name` → `resource_attributes['k8s.deployment.name']`
+- **Correct Kubernetes alias**: `k8s.namespace.name` → `resources['k8s.namespace.name']`
+- **Correct Kubernetes alias**: `k8s.deployment.name` → `resources['k8s.deployment.name']`
 
 ### Custom Fields for user's environment:
-In addition to standard labels, the list of available customer-specific attribute labels is below. In the query, the following rule should be applied to get the attribute from the field name - if the field matches the pattern with `resource_fieldname` the attribute is `resource_attributes['fieldname']`. Otherwise it is `attributes['fieldname']`.
+In addition to standard labels, the list of available customer-specific attribute labels is below. In the query, the following rule should be applied to get the attribute from the field name - if the field matches the pattern with `resource_fieldname` the attribute is `resources['fieldname']`. Otherwise it is `attributes['fieldname']`.
 Any attribute used in the query should either be a standard attribute or available in the list below
 {{labels}}
 
@@ -303,8 +330,8 @@ These are examples of pipeline json structure and available stages and functions
     }
   ],
   "groupby": {
-    "resource_attributes['k8s.namespace.name']": "namespace",
-    "resource_attributes['k8s.deployment.name']": "deployment"
+    "resources['k8s.namespace.name']": "namespace",
+    "resources['k8s.deployment.name']": "deployment"
   }
 }]
 ```
@@ -510,7 +537,7 @@ These are examples of pipeline json structure and available stages and functions
   "query": {
     "$and": [
       {"$contains": ["Body", "restart"]},
-      {"$neq": ["resource_attributes['k8s.pod.name']", ""]}
+      {"$neq": ["resources['k8s.pod.name']", ""]}
     ]
   }
 }, {
@@ -522,8 +549,8 @@ These are examples of pipeline json structure and available stages and functions
     }
   ],
   "groupby": {
-    "resource_attributes['k8s.namespace.name']": "namespace",
-    "resource_attributes['k8s.deployment.name']": "deployment"
+    "resources['k8s.namespace.name']": "namespace",
+    "resources['k8s.deployment.name']": "deployment"
   }
 }]
 ```
@@ -619,11 +646,11 @@ These are examples of pipeline json structure and available stages and functions
 ## Translation Rules:
 
 1. **Always return valid JSON array** containing operation objects
-2. **Use proper field references**: Body, ServiceName, attributes['field'], resource_attributes['field']; never emit bare dotted refs.
+2. **Use proper field references**: Body, ServiceName, attributes['field'], resources['field']; never emit bare dotted refs.
 3. **Chain operations logically**: filter → parse → aggregate
 4. **For time-based queries**, use window_aggregate with appropriate time units.
 5. **For existence checks**, use $neq operator
-6. **For text searches**, use $contains operator
+6. **For text searches**, use `$containsWords` on `Body` (word-boundary aware, higher precision); use `$contains` for attribute substring matches
 7. **CRITICAL: When user query has no explicit logical operators (and/or), always wrap filter conditions in $and array, even for single conditions**
 8. **Group multiple conditions** with $and or $or as appropriate when explicitly specified
 10. **Use an attribute only if it exists in the standard or custom fields**. Otherwise fallback to a regex filter with field name and value eg, ".*fieldname.*[:=].*value.*"
@@ -631,7 +658,8 @@ These are examples of pipeline json structure and available stages and functions
 ## Common Natural Language Patterns:
 
 ### Basic Filter Patterns:
-- "where X contains Y" → `{"$contains": [field, value]}`
+- "where X contains Y" (Body field) → `{"$containsWords": ["Body", value]}` (word-boundary)
+- "where X contains Y" (attribute field) → `{"$contains": [field, value]}`
 - "where X equals/is Y" → `{"$eq": [field, value]}`
 - "where X is greater than Y" → `{"$gt": [field, value]}`
 - "where X exists" → `{"$neq": [field, ""]}`

--- a/internal/prompts/descriptions/get_logs.md
+++ b/internal/prompts/descriptions/get_logs.md
@@ -244,7 +244,7 @@ To find the appropriate field name, try partial matches or matching fields which
 - "Get timeout logs" → DON'T ADD: `{"type": "aggregate"}`
 
 ### ✅ CORRECT Examples:
-- "Show me errors" → ONLY: `[{"type": "filter", "query": {"$contains": ["Body", "error"]}}]`
+- "Show me errors" → ONLY: `[{"type": "filter", "query": {"$containsWords": ["Body", "error"]}}]`
 - "How many errors?" → ADD: `[{"type": "filter"}, {"type": "aggregate"}]`
 
 ## Translation Examples (Ordered by Complexity):
@@ -257,7 +257,7 @@ These are examples of pipeline json structure and available stages and functions
   "type": "filter",
   "query": {
     "$and": [
-      {"$contains": ["Body", "error"]}
+      {"$containsWords": ["Body", "error"]}
     ]
   }
 }]
@@ -272,7 +272,7 @@ These are examples of pipeline json structure and available stages and functions
   "query": {
     "$and": [
       {"$eq": ["ServiceName", "auth"]},
-      {"$contains": ["Body", "error"]}
+      {"$containsWords": ["Body", "error"]}
     ]
   }
 }]
@@ -389,7 +389,7 @@ These are examples of pipeline json structure and available stages and functions
   "type": "filter",
   "query": {
     "$and": [
-      {"$contains": ["Body", "error"]}
+      {"$containsWords": ["Body", "error"]}
     ]
   }
 }, {
@@ -457,7 +457,7 @@ These are examples of pipeline json structure and available stages and functions
     "query": {
       "$and": [
         {"$eq": ["attributes['job']", "mysql"]},
-        {"$contains": ["Body", "error"]}
+        {"$containsWords": ["Body", "error"]}
       ]
     }
   },
@@ -536,7 +536,7 @@ These are examples of pipeline json structure and available stages and functions
   "type": "filter",
   "query": {
     "$and": [
-      {"$contains": ["Body", "restart"]},
+      {"$containsWords": ["Body", "restart"]},
       {"$neq": ["resources['k8s.pod.name']", ""]}
     ]
   }
@@ -566,8 +566,8 @@ These are examples of pipeline json structure and available stages and functions
       {"$eq": ["attributes['messaging.system']", "kafka"]},
       {"$gt": ["attributes['duration']", "500"]},
       {"$or": [
-        {"$contains": ["Body", "failed"]},
-        {"$contains": ["Body", "error"]},
+        {"$containsWords": ["Body", "failed"]},
+        {"$containsWords": ["Body", "error"]},
         {"$gte": ["attributes['http.status_code']", "400"]}
       ]}
     ]
@@ -738,11 +738,11 @@ Example interactions showing CORRECT default behavior:
   "type": "filter",
   "query": {
     "$or": [
-      {"$contains": ["Body", "login"]},
-      {"$contains": ["Body", "logout"]},
-      {"$contains": ["Body", "auth"]},
-      {"$contains": ["Body", "authentication"]},
-      {"$contains": ["Body", "failed"]},
+      {"$containsWords": ["Body", "login"]},
+      {"$containsWords": ["Body", "logout"]},
+      {"$containsWords": ["Body", "auth"]},
+      {"$containsWords": ["Body", "authentication"]},
+      {"$containsWords": ["Body", "failed"]},
       {"$eq": ["attributes['http.status_code']", "401"]}
     ]
   }
@@ -756,11 +756,11 @@ Example interactions showing CORRECT default behavior:
   "query": {
     "$and": [
       {"$or": [
-        {"$contains": ["Body", "login"]},
-        {"$contains": ["Body", "logout"]},
-        {"$contains": ["Body", "auth"]},
-        {"$contains": ["Body", "authentication"]},
-        {"$contains": ["Body", "failed"]},
+        {"$containsWords": ["Body", "login"]},
+        {"$containsWords": ["Body", "logout"]},
+        {"$containsWords": ["Body", "auth"]},
+        {"$containsWords": ["Body", "authentication"]},
+        {"$containsWords": ["Body", "failed"]},
         {"$eq": ["attributes['http.status_code']", "401"]}
       ]}
     ]

--- a/internal/prompts/descriptions/get_traces.md
+++ b/internal/prompts/descriptions/get_traces.md
@@ -159,10 +159,10 @@ Note that regexp parsing operators also work as regexp filters
 
 `get_trace_attributes` returns a JSON array. Each entry has a `filter_field` — use it verbatim in filter conditions. Never transform or guess field syntax.
 
-```
+```json
 {
   "name": "resource_department",
-  "filter_field": "resources['department']",   ← use this exactly
+  "filter_field": "resources['department']",
   "hint": "Example: {\"$eq\": [\"resources['department']\", \"engineering\"]}"
 }
 ```
@@ -198,6 +198,7 @@ Note that regexp parsing operators also work as regexp filters
   - `"ERROR"` ✗ wrong → `"STATUS_CODE_ERROR"` ✓ correct
 
 ### Custom Fields for user's environment:
+
 Call `get_trace_attributes` to discover available fields and get their exact `filter_field`. Use `filter_field` directly — do not transform it.
 
 **IMPORTANT**: For filtering, if a field is not available from `get_trace_attributes`, fall back to a regexp-based filter / parser instead of using conditions on attributes.

--- a/internal/prompts/descriptions/get_traces.md
+++ b/internal/prompts/descriptions/get_traces.md
@@ -155,31 +155,52 @@ Note that regexp parsing operators also work as regexp filters
 
 ## Field Reference Format:
 
-### Standard Trace Fields:
+### ALWAYS call get_trace_attributes before filtering on resource or span attributes
 
-- **TraceId**: Trace identifier — use for filtering or searching by trace ID
-- **SpanId**: Span identifier — use for filtering or searching by span ID
-- **ServiceName**: Service name. Always prefer this over similar looking attributes in `attributes` or `resources` given below
-- **SpanName**: Name of the span
-- **SpanKind**: Span kind. Valid values: `SPAN_KIND_CLIENT`, `SPAN_KIND_SERVER`, `SPAN_KIND_PRODUCER`, `SPAN_KIND_CONSUMER`, `SPAN_KIND_INTERNAL`
-  - CORRECT: `{"$eq": ["SpanKind", "SPAN_KIND_SERVER"]}` ← always use full prefix
-  - WRONG:   `{"$eq": ["SpanKind", "SERVER"]}` ← will return no results
-- **StatusCode**: Span status code. Valid values: `STATUS_CODE_OK`, `STATUS_CODE_ERROR`, `STATUS_CODE_UNSET`
-  - CORRECT: `{"$eq": ["StatusCode", "STATUS_CODE_ERROR"]}` ← always use full prefix
-  - WRONG:   `{"$eq": ["StatusCode", "ERROR"]}` ← will return no results
-- **StatusMessage**: Status message
-- **Timestamp**: Trace timestamp
-- **Duration**: Span duration
-- **attributes['field_name']**: Span attributes (OpenTelemetry semantic conventions)
-- **resources['field_name']**: Resource attributes (prefixed with `resource_`), extract field name by stripping resource_
+`get_trace_attributes` returns a JSON array. Each entry has a `filter_field` — use it verbatim in filter conditions. Never transform or guess field syntax.
+
+```
+{
+  "name": "resource_department",
+  "filter_field": "resources['department']",   ← use this exactly
+  "hint": "Example: {\"$eq\": [\"resources['department']\", \"engineering\"]}"
+}
+```
+
+### Field mapping priority (canonical rules — same as the frontend):
+
+| Raw API name              | filter_field to use in tracejson           |
+|---------------------------|--------------------------------------------|
+| `resource_service.name`   | `ServiceName`                              |
+| `service.name`            | `ServiceName`                              |
+| `resource_<key>`          | `resources['<key>']`                       |
+| `event_<key>`             | `events['<key>']`                          |
+| Top-level fields (below)  | field name as-is                           |
+| `grpc.status_code`        | `attributes['rpc.grpc.status_code']`       |
+| anything else             | `attributes['<raw>']`                      |
+
+**Top-level fields** (no bracket syntax needed):
+`TraceId`, `SpanId`, `ServiceName`, `SpanName`, `SpanKind`, `StatusCode`, `StatusMessage`, `Duration`, `Timestamp`, `ParentSpanId`, `TraceState`
+
+### CRITICAL — field syntax rules:
+
+- Use **single quotes** inside brackets: `resources['key']` ✓ — `resources["key"]` ✗
+- **Never** use the flat `resource_` prefix in a filter: `resource_department` ✗ → `resources['department']` ✓
+- **Never** use dot notation: `ResourceAttributes.department` ✗ → `resources['department']` ✓
+- **Never** use dot notation: `SpanAttributes.http.method` ✗ → `attributes['http.method']` ✓
+- **ServiceName** is top-level — never `resources['service.name']` ✗
+
+### Standard top-level field values:
+
+- **SpanKind** — full OTel prefix required: `SPAN_KIND_SERVER`, `SPAN_KIND_CLIENT`, `SPAN_KIND_INTERNAL`, `SPAN_KIND_CONSUMER`, `SPAN_KIND_PRODUCER`
+  - `"SERVER"` ✗ wrong → `"SPAN_KIND_SERVER"` ✓ correct
+- **StatusCode** — full OTel prefix required: `STATUS_CODE_OK`, `STATUS_CODE_ERROR`, `STATUS_CODE_UNSET`
+  - `"ERROR"` ✗ wrong → `"STATUS_CODE_ERROR"` ✓ correct
 
 ### Custom Fields for user's environment:
-In addition to standard labels, the list of available customer-specific attribute labels is below. In the query, the following rule should be applied to get the attribute from the field name - if the field matches the pattern with `resource_fieldname` the attribute is `resources['fieldname']`. Otherwise it is `attributes['fieldname']`.
-Any attribute used in the query should either be a standard attribute or available from get_trace_attributes
+Call `get_trace_attributes` to discover available fields and get their exact `filter_field`. Use `filter_field` directly — do not transform it.
 
-To find the appropriate field name, try partial matches or matching fields which have similar meaning from the above list.
-
-**IMPORTANT**:  For filtering, if a field is not available in the list above, fall back to a regexp-based filter / parser instead of using conditions on attributes
+**IMPORTANT**: For filtering, if a field is not available from `get_trace_attributes`, fall back to a regexp-based filter / parser instead of using conditions on attributes.
 
 ## Query Analysis Patterns:
 
@@ -320,6 +341,52 @@ To find the appropriate field name, try partial matches or matching fields which
   "groupby": {"ServiceName": "service"}
 }]
 ```
+
+### Example 7: Resource Attribute Filter — Wrong vs Correct
+
+**Natural Language:** "Find traces from the engineering department"
+
+❌ WRONG — flat resource_ prefix, will be rejected:
+```json
+[{
+  "type": "filter",
+  "query": {
+    "$eq": ["resource_department", "engineering"]
+  }
+}]
+```
+
+✅ CORRECT — call get_trace_attributes first to get filter_field, then use it:
+```json
+[{
+  "type": "filter",
+  "query": {
+    "$eq": ["resources['department']", "engineering"]
+  }
+}]
+```
+
+### Example 8: Combined Resource + Span Attribute + Status Filter
+
+**Natural Language:** "Find error traces from the payments service with HTTP POST requests"
+
+**Step 1:** Call `get_trace_attributes` to verify filter_fields for `resource_department`, `http.method`, etc.
+
+**Step 2:** Build the filter using the returned filter_field values:
+```json
+[{
+  "type": "filter",
+  "query": {
+    "$and": [
+      {"$eq": ["ServiceName", "payments"]},
+      {"$eq": ["StatusCode", "STATUS_CODE_ERROR"]},
+      {"$eq": ["attributes['http.request.method']", "POST"]}
+    ]
+  }
+}]
+```
+
+Note: `ServiceName` is a top-level field — never `resources['service.name']`. `http.request.method` maps to `attributes['http.request.method']` as returned by `get_trace_attributes`.
 
 ## Translation Rules:
 

--- a/internal/telemetry/logs/description.go
+++ b/internal/telemetry/logs/description.go
@@ -22,7 +22,7 @@ const GetLogsDescription = `
 	Field reference rules:
 	- Use ServiceName for service filters/grouping. Do not use bare service.name.
 	- Use attributes['field'] for log attributes.
-	- Use resource_attributes['field'] for resource attributes such as Kubernetes metadata.
+	- Use resources['field'] for resource attributes such as Kubernetes metadata.
 	- Bare dotted field references are rejected unless they are normalized aliases like service.name or k8s.*.
 
 	The logjson_query supports:

--- a/internal/telemetry/logs/query_sanitize.go
+++ b/internal/telemetry/logs/query_sanitize.go
@@ -7,28 +7,33 @@ import (
 )
 
 var (
-	logAttributeFieldRefPattern         = regexp.MustCompile(`^attributes\[(?:'[^'\[\]]+'|"[^"\[\]]+")\]$`)
-	logResourceAttributeFieldRefPattern = regexp.MustCompile(`^resource_attributes\[(?:'[^'\[\]]+'|"[^"\[\]]+")\]$`)
-	logKubernetesAliasPattern           = regexp.MustCompile(`^k8s(?:\.[A-Za-z0-9_/-]+)+$`)
-	logSimpleFieldRefPattern            = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	logAttributeFieldRefPattern  = regexp.MustCompile(`^attributes\['[^'\[\]]+'\]$`)
+	logResourceFieldRefPattern   = regexp.MustCompile(`^resources\['[^'\[\]]+'\]$`)
+	logKubernetesAliasPattern    = regexp.MustCompile(`^k8s(?:\.[A-Za-z0-9_/-]+)+$`)
+	logSimpleFieldRefPattern     = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 )
 
 var logFilterFieldOperators = map[string]int{
-	"$contains":     0,
-	"$eq":           0,
-	"$gt":           0,
-	"$gte":          0,
-	"$icontains":    0,
-	"$ieq":          0,
-	"$iregex":       0,
-	"$lt":           0,
-	"$lte":          0,
-	"$neq":          0,
-	"$notcontains":  0,
-	"$noticontains": 0,
-	"$notiregex":    0,
-	"$notregex":     0,
-	"$regex":        0,
+	"$contains":        0,
+	"$containsWords":   0,
+	"$eq":              0,
+	"$gt":              0,
+	"$gte":             0,
+	"$icontains":       0,
+	"$icontainsWords":  0,
+	"$ieq":             0,
+	"$ineq":            0,
+	"$inotcontains":    0,
+	"$inotcontainsWords": 0,
+	"$inotregex":       0,
+	"$iregex":          0,
+	"$lt":              0,
+	"$lte":             0,
+	"$neq":             0,
+	"$notcontains":     0,
+	"$notcontainsWords": 0,
+	"$notregex":        0,
+	"$regex":           0,
 }
 
 var logFilterLogicalOperators = map[string]struct{}{
@@ -110,7 +115,7 @@ func sanitizeLogCondition(value interface{}, path string) (interface{}, error) {
 
 			if _, isLogicalOperator := logFilterLogicalOperators[key]; !isLogicalOperator {
 				return nil, fmt.Errorf(
-					"invalid filter condition key %q at %s: keys must be operators ($eq, $neq, $gt, $gte, $lt, $lte, $contains, $notcontains, $icontains, $noticontains, $regex, $notregex, $iregex, $notiregex, $ieq) or logical operators ($and, $or, $not); use the form {%q: [field, value]} — for example {\"$eq\": [\"ServiceName\", \"checkout\"]} — and call get_log_attributes if you need the exact field name",
+					"invalid filter condition key %q at %s: keys must be operators ($eq, $neq, $ieq, $ineq, $gt, $gte, $lt, $lte, $contains, $notcontains, $icontains, $inotcontains, $containsWords, $notcontainsWords, $icontainsWords, $inotcontainsWords, $regex, $notregex, $iregex, $inotregex) or logical operators ($and, $or, $not); use the form {%q: [field, value]} — for example {\"$eq\": [\"ServiceName\", \"checkout\"]} — and call get_log_attributes if you need the exact field name",
 					key,
 					path,
 					"$eq",
@@ -267,15 +272,27 @@ func sanitizeLogFieldRef(fieldRef, path string) (string, error) {
 	switch {
 	case trimmed == "service.name":
 		return "ServiceName", nil
+	case strings.HasPrefix(trimmed, `attributes["`) || strings.HasPrefix(trimmed, `resources["`):
+		corrected := strings.ReplaceAll(trimmed, `"`, "'")
+		return "", fmt.Errorf(
+			"invalid log field reference %q at %s: use single quotes — %q; call get_log_attributes if you need the exact field name",
+			trimmed, path, corrected,
+		)
 	case logKubernetesAliasPattern.MatchString(trimmed):
-		return fmt.Sprintf("resource_attributes['%s']", trimmed), nil
+		return fmt.Sprintf("resources['%s']", trimmed), nil
 	case isCanonicalLogFieldRef(trimmed):
 		return trimmed, nil
+	case strings.HasPrefix(trimmed, "resource_"):
+		stripped := trimmed[len("resource_"):]
+		return "", fmt.Errorf(
+			"invalid log field reference %q at %s: use resources['%s'] instead of the flat resource_ prefix; call get_log_attributes if you need the exact field name",
+			trimmed, path, stripped,
+		)
 	case logSimpleFieldRefPattern.MatchString(trimmed):
 		return trimmed, nil
 	default:
 		return "", fmt.Errorf(
-			"invalid log field reference %q at %s: use ServiceName, attributes['field'], or resource_attributes['field']; call get_log_attributes if you need the exact field name",
+			"invalid log field reference %q at %s: use ServiceName, attributes['field'], or resources['field']; call get_log_attributes if you need the exact field name",
 			trimmed,
 			path,
 		)
@@ -289,5 +306,5 @@ func isCanonicalLogFieldRef(fieldRef string) bool {
 	}
 
 	return logAttributeFieldRefPattern.MatchString(fieldRef) ||
-		logResourceAttributeFieldRefPattern.MatchString(fieldRef)
+		logResourceFieldRefPattern.MatchString(fieldRef)
 }

--- a/internal/telemetry/logs/query_sanitize_test.go
+++ b/internal/telemetry/logs/query_sanitize_test.go
@@ -57,16 +57,16 @@ func TestSanitizeLogJSONQueryNormalizesSafeAliases(t *testing.T) {
 	}
 
 	podCondition := andConditions[1].(map[string]interface{})["$neq"].([]interface{})
-	if got := podCondition[0]; got != "resource_attributes['k8s.pod.name']" {
+	if got := podCondition[0]; got != "resources['k8s.pod.name']" {
 		t.Fatalf("expected k8s.pod.name to normalize, got %#v", got)
 	}
 
 	groupBy := sanitized[1]["groupby"].(map[string]interface{})
-	if _, ok := groupBy["resource_attributes['k8s.namespace.name']"]; !ok {
-		t.Fatalf("expected namespace groupby to use resource_attributes syntax, got %#v", groupBy)
+	if _, ok := groupBy["resources['k8s.namespace.name']"]; !ok {
+		t.Fatalf("expected namespace groupby to use resources syntax, got %#v", groupBy)
 	}
-	if _, ok := groupBy["resource_attributes['k8s.deployment.name']"]; !ok {
-		t.Fatalf("expected deployment groupby to use resource_attributes syntax, got %#v", groupBy)
+	if _, ok := groupBy["resources['k8s.deployment.name']"]; !ok {
+		t.Fatalf("expected deployment groupby to use resources syntax, got %#v", groupBy)
 	}
 	if _, ok := groupBy["ServiceName"]; !ok {
 		t.Fatalf("expected canonical ServiceName groupby to be preserved, got %#v", groupBy)
@@ -86,7 +86,7 @@ func TestSanitizeLogJSONQueryPreservesCanonicalRefs(t *testing.T) {
 						"$gte": []interface{}{"attributes['http.status_code']", "500"},
 					},
 					map[string]interface{}{
-						"$neq": []interface{}{"resource_attributes['k8s.namespace.name']", ""},
+						"$neq": []interface{}{"resources['k8s.namespace.name']", ""},
 					},
 				},
 			},
@@ -259,6 +259,349 @@ func TestSanitizeLogJSONQueryRejectsGroupByCollisions(t *testing.T) {
 	}
 }
 
+func TestSanitizeLogJSONQueryRejectsDoubleQuotedBracketSyntax(t *testing.T) {
+	tests := []struct {
+		name        string
+		fieldRef    string
+		wantHint    string
+	}{
+		{
+			name:     "attributes double-quoted",
+			fieldRef: `attributes["http.method"]`,
+			wantHint: `attributes['http.method']`,
+		},
+		{
+			name:     "resources double-quoted",
+			fieldRef: `resources["k8s.namespace.name"]`,
+			wantHint: `resources['k8s.namespace.name']`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := sanitizeLogJSONQuery([]map[string]interface{}{
+				{
+					"type": "filter",
+					"query": map[string]interface{}{
+						"$and": []interface{}{
+							map[string]interface{}{
+								"$eq": []interface{}{tt.fieldRef, "value"},
+							},
+						},
+					},
+				},
+			})
+			if err == nil {
+				t.Fatalf("expected error for double-quoted field ref %q, got nil", tt.fieldRef)
+			}
+			if !strings.Contains(err.Error(), "single quotes") {
+				t.Errorf("expected error to mention single quotes, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantHint) {
+				t.Errorf("expected error to contain corrected form %q, got: %v", tt.wantHint, err)
+			}
+		})
+	}
+}
+
+func TestSanitizeLogJSONQueryRejectsFlatResourcePrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		fieldRef string
+		wantKey  string
+	}{
+		{
+			name:     "resource_department",
+			fieldRef: "resource_department",
+			wantKey:  "resources['department']",
+		},
+		{
+			name:     "resource_env",
+			fieldRef: "resource_env",
+			wantKey:  "resources['env']",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := sanitizeLogJSONQuery([]map[string]interface{}{
+				{
+					"type": "filter",
+					"query": map[string]interface{}{
+						"$and": []interface{}{
+							map[string]interface{}{
+								"$eq": []interface{}{tt.fieldRef, "value"},
+							},
+						},
+					},
+				},
+			})
+			if err == nil {
+				t.Fatalf("expected error for flat resource_ prefix %q, got nil", tt.fieldRef)
+			}
+			if !strings.Contains(err.Error(), tt.wantKey) {
+				t.Errorf("expected error to contain %q, got: %v", tt.wantKey, err)
+			}
+			if !strings.Contains(err.Error(), "get_log_attributes") {
+				t.Errorf("expected error to point to get_log_attributes, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestSanitizeLogJSONQueryPreservesTopLevelFields(t *testing.T) {
+	for _, field := range []string{"Body", "SeverityText", "Timestamp"} {
+		t.Run(field, func(t *testing.T) {
+			sanitized, err := sanitizeLogJSONQuery([]map[string]interface{}{
+				{
+					"type": "filter",
+					"query": map[string]interface{}{
+						"$neq": []interface{}{field, ""},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("expected %q to pass unchanged, got error: %v", field, err)
+			}
+			args := sanitized[0]["query"].(map[string]interface{})["$neq"].([]interface{})
+			if got := args[0]; got != field {
+				t.Errorf("expected %q to be preserved unchanged, got %#v", field, got)
+			}
+		})
+	}
+}
+
+func TestSanitizeLogJSONQueryAcceptsAllValidOperators(t *testing.T) {
+	tests := []struct {
+		name   string
+		stages []map[string]interface{}
+	}{
+		{
+			name: "case-insensitive equality operators",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$and": []interface{}{
+						map[string]interface{}{"$ieq": []interface{}{"ServiceName", "API"}},
+						map[string]interface{}{"$ineq": []interface{}{"ServiceName", "nginx"}},
+					},
+				}},
+			},
+		},
+		{
+			name: "case-insensitive contains operators",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$and": []interface{}{
+						map[string]interface{}{"$icontains": []interface{}{"Body", "error"}},
+						map[string]interface{}{"$inotcontains": []interface{}{"Body", "debug"}},
+					},
+				}},
+			},
+		},
+		{
+			name: "word-boundary operators",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$and": []interface{}{
+						map[string]interface{}{"$containsWords": []interface{}{"Body", "timeout"}},
+						map[string]interface{}{"$icontainsWords": []interface{}{"Body", "error"}},
+						map[string]interface{}{"$notcontainsWords": []interface{}{"Body", "debug"}},
+						map[string]interface{}{"$inotcontainsWords": []interface{}{"Body", "trace"}},
+					},
+				}},
+			},
+		},
+		{
+			name: "case-insensitive regex operators",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$and": []interface{}{
+						map[string]interface{}{"$iregex": []interface{}{"Body", ".*error.*"}},
+						map[string]interface{}{"$inotregex": []interface{}{"Body", ".*debug.*"}},
+					},
+				}},
+			},
+		},
+		{
+			name: "numeric comparison operators",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$and": []interface{}{
+						map[string]interface{}{"$gt": []interface{}{"attributes['http.status_code']", "400"}},
+						map[string]interface{}{"$lte": []interface{}{"attributes['http.status_code']", "599"}},
+					},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := sanitizeLogJSONQuery(tt.stages); err != nil {
+				t.Errorf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestSanitizeLogJSONQueryNormalizesInsideOrAndNot(t *testing.T) {
+	t.Run("service.name inside $or normalizes to ServiceName", func(t *testing.T) {
+		sanitized, err := sanitizeLogJSONQuery([]map[string]interface{}{
+			{
+				"type": "filter",
+				"query": map[string]interface{}{
+					"$or": []interface{}{
+						map[string]interface{}{"$eq": []interface{}{"service.name", "checkout"}},
+						map[string]interface{}{"$eq": []interface{}{"service.name", "payments"}},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		orConds := sanitized[0]["query"].(map[string]interface{})["$or"].([]interface{})
+		first := orConds[0].(map[string]interface{})["$eq"].([]interface{})
+		if got := first[0]; got != "ServiceName" {
+			t.Errorf("expected service.name inside $or to normalize to ServiceName, got %#v", got)
+		}
+	})
+
+	t.Run("k8s alias inside $not normalizes", func(t *testing.T) {
+		sanitized, err := sanitizeLogJSONQuery([]map[string]interface{}{
+			{
+				"type": "filter",
+				"query": map[string]interface{}{
+					"$not": map[string]interface{}{
+						"$eq": []interface{}{"k8s.pod.name", ""},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		notCond := sanitized[0]["query"].(map[string]interface{})["$not"].(map[string]interface{})
+		args := notCond["$eq"].([]interface{})
+		if got := args[0]; got != "resources['k8s.pod.name']" {
+			t.Errorf("expected k8s alias inside $not to normalize, got %#v", got)
+		}
+	})
+
+	t.Run("resource_ prefix inside $or is rejected", func(t *testing.T) {
+		_, err := sanitizeLogJSONQuery([]map[string]interface{}{
+			{
+				"type": "filter",
+				"query": map[string]interface{}{
+					"$or": []interface{}{
+						map[string]interface{}{"$eq": []interface{}{"resource_env", "prod"}},
+					},
+				},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error for resource_ prefix inside $or, got nil")
+		}
+		if !strings.Contains(err.Error(), "resources['env']") {
+			t.Errorf("expected error to mention resources['env'], got: %v", err)
+		}
+	})
+
+	t.Run("double-quoted field inside $not is rejected", func(t *testing.T) {
+		_, err := sanitizeLogJSONQuery([]map[string]interface{}{
+			{
+				"type": "filter",
+				"query": map[string]interface{}{
+					"$not": map[string]interface{}{
+						"$eq": []interface{}{`attributes["env"]`, "prod"},
+					},
+				},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error for double-quoted field inside $not, got nil")
+		}
+		if !strings.Contains(err.Error(), "single quotes") {
+			t.Errorf("expected error to mention single quotes, got: %v", err)
+		}
+	})
+}
+
+func TestSanitizeLogJSONQueryNormalizesK8sAliasInAggregateFunctionArgs(t *testing.T) {
+	t.Run("k8s alias in $avg arg is normalized", func(t *testing.T) {
+		sanitized, err := sanitizeLogJSONQuery([]map[string]interface{}{
+			{
+				"type": "aggregate",
+				"aggregates": []interface{}{
+					map[string]interface{}{
+						"function": map[string]interface{}{
+							"$avg": []interface{}{"k8s.namespace.name"},
+						},
+						"as": "avg_ns",
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		aggs := sanitized[0]["aggregates"].([]interface{})
+		fn := aggs[0].(map[string]interface{})["function"].(map[string]interface{})
+		args := fn["$avg"].([]interface{})
+		if got := args[0]; got != "resources['k8s.namespace.name']" {
+			t.Errorf("expected k8s alias in $avg to normalize, got %#v", got)
+		}
+	})
+
+	t.Run("$quantile field arg at index 1 is normalized", func(t *testing.T) {
+		sanitized, err := sanitizeLogJSONQuery([]map[string]interface{}{
+			{
+				"type": "aggregate",
+				"aggregates": []interface{}{
+					map[string]interface{}{
+						"function": map[string]interface{}{
+							"$quantile": []interface{}{0.95, "k8s.cluster.name"},
+						},
+						"as": "p95",
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		aggs := sanitized[0]["aggregates"].([]interface{})
+		fn := aggs[0].(map[string]interface{})["function"].(map[string]interface{})
+		args := fn["$quantile"].([]interface{})
+		if got := args[1]; got != "resources['k8s.cluster.name']" {
+			t.Errorf("expected k8s alias at $quantile[1] to normalize, got %#v", got)
+		}
+		if got := args[0]; got != 0.95 {
+			t.Errorf("expected $quantile[0] percentile to be unchanged, got %#v", got)
+		}
+	})
+
+	t.Run("resource_ prefix in $sum arg is rejected", func(t *testing.T) {
+		_, err := sanitizeLogJSONQuery([]map[string]interface{}{
+			{
+				"type": "aggregate",
+				"aggregates": []interface{}{
+					map[string]interface{}{
+						"function": map[string]interface{}{
+							"$sum": []interface{}{"resource_bytes"},
+						},
+						"as": "total_bytes",
+					},
+				},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error for resource_ prefix in aggregate function arg, got nil")
+		}
+		if !strings.Contains(err.Error(), "resources['bytes']") {
+			t.Errorf("expected error to mention resources['bytes'], got: %v", err)
+		}
+	})
+}
+
 func TestGetLogsHandlerNormalizesAliasesBeforeAPICall(t *testing.T) {
 	requestCount := 0
 	handlerErr := make(chan error, 1)
@@ -318,7 +661,7 @@ func TestGetLogsHandlerNormalizesAliasesBeforeAPICall(t *testing.T) {
 			recordHandlerErr(fmt.Errorf("expected second pipeline stage groupby map, got %T", body.Pipeline[1]["groupby"]))
 			return
 		}
-		if _, ok := groupBy["resource_attributes['k8s.namespace.name']"]; !ok {
+		if _, ok := groupBy["resources['k8s.namespace.name']"]; !ok {
 			recordHandlerErr(fmt.Errorf("expected groupby to include normalized k8s namespace key, got %#v", groupBy))
 			return
 		}

--- a/internal/telemetry/traces/attribute_values.go
+++ b/internal/telemetry/traces/attribute_values.go
@@ -1,11 +1,13 @@
 package traces
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"last9-mcp/internal/constants"
 	"last9-mcp/internal/models"
@@ -50,23 +52,35 @@ func NewGetTraceAttributeValuesHandler(client *http.Client, cfg models.Config) f
 		if rawTagName == "" {
 			return nil, nil, fmt.Errorf("tag_name cannot be blank")
 		}
-		apiURL := cfg.APIBaseURL + fmt.Sprintf(constants.EndpointTraceTagValues, url.PathEscape(rawTagName))
-
 		region := cfg.Region
 		if args.Region != "" {
 			region = args.Region
 		}
-		if region != "" {
-			q := url.Values{}
-			q.Set("region", region)
-			apiURL += "?" + q.Encode()
+
+		now := time.Now()
+		q := url.Values{}
+		q.Set("region", region)
+		q.Set("start", fmt.Sprintf("%d", now.Add(-15*time.Minute).Unix()))
+		q.Set("end", fmt.Sprintf("%d", now.Unix()))
+		apiURL := cfg.APIBaseURL + fmt.Sprintf(constants.EndpointTraceTagValues, url.PathEscape(rawTagName)) + "?" + q.Encode()
+
+		// The label-values endpoint requires a POST with a pipeline body (same as series).
+		pipeline := map[string]interface{}{
+			"pipeline": []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{}},
+			},
+		}
+		bodyBytes, err := json.Marshal(pipeline)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal request body: %v", err)
 		}
 
-		httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewBuffer(bodyBytes))
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create request: %v", err)
 		}
 		httpReq.Header.Set(constants.HeaderAccept, constants.HeaderAcceptJSON)
+		httpReq.Header.Set(constants.HeaderContentType, constants.HeaderContentTypeJSON)
 		httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+cfg.TokenManager.GetAccessToken(ctx))
 		httpReq.Header.Set(constants.HeaderUserAgent, constants.UserAgentLast9MCP)
 

--- a/internal/telemetry/traces/attribute_values.go
+++ b/internal/telemetry/traces/attribute_values.go
@@ -47,7 +47,10 @@ func NewGetTraceAttributeValuesHandler(client *http.Client, cfg models.Config) f
 		}
 
 		rawTagName := normalizeTagName(args.TagName)
-		apiURL := fmt.Sprintf("%s%s", cfg.APIBaseURL, fmt.Sprintf(constants.EndpointTraceTagValues, rawTagName))
+		if rawTagName == "" {
+			return nil, nil, fmt.Errorf("tag_name cannot be blank")
+		}
+		apiURL := cfg.APIBaseURL + fmt.Sprintf(constants.EndpointTraceTagValues, url.PathEscape(rawTagName))
 
 		region := cfg.Region
 		if args.Region != "" {
@@ -82,6 +85,9 @@ func NewGetTraceAttributeValuesHandler(client *http.Client, cfg models.Config) f
 		var apiResp traceTagValuesAPIResponse
 		if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
 			return nil, nil, fmt.Errorf("failed to decode response: %v", err)
+		}
+		if apiResp.Status != "success" {
+			return nil, nil, fmt.Errorf("API returned non-success status: %s", apiResp.Status)
 		}
 
 		attr := enrichAttribute(rawTagName)

--- a/internal/telemetry/traces/attribute_values.go
+++ b/internal/telemetry/traces/attribute_values.go
@@ -1,0 +1,122 @@
+package traces
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"last9-mcp/internal/constants"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const GetTraceAttributeValuesDescription = `
+Fetches the distinct values for a single trace attribute/tag.
+
+Use this after get_trace_attributes to see what values exist for a given field —
+for example, all deployment environments, team names, or HTTP methods.
+
+Accepts the tag name in any of these forms:
+  - raw API name:    resource_department, event_exception.type
+  - filter syntax:  resources['department'], events['exception.type'], or attributes['http.method']
+
+Returns the canonical filter_field ready to use in a get_traces tracejson query,
+plus an example condition.
+`
+
+// GetTraceAttributeValuesArgs is the input for get_trace_attribute_values.
+type GetTraceAttributeValuesArgs struct {
+	TagName string `json:"tag_name" jsonschema:"required,The attribute name from get_trace_attributes (e.g. resource_department or attributes['http.method'])"`
+	Region  string `json:"region,omitempty" jsonschema:"Region to query (optional). Defaults to configured region."`
+}
+
+// traceTagValuesAPIResponse is the raw API shape.
+type traceTagValuesAPIResponse struct {
+	Data   []string `json:"data"`
+	Status string   `json:"status"`
+}
+
+// NewGetTraceAttributeValuesHandler creates a handler for fetching distinct values of a trace tag.
+func NewGetTraceAttributeValuesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetTraceAttributeValuesArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args GetTraceAttributeValuesArgs) (*mcp.CallToolResult, any, error) {
+		if args.TagName == "" {
+			return nil, nil, fmt.Errorf("tag_name is required")
+		}
+
+		rawTagName := normalizeTagName(args.TagName)
+		apiURL := fmt.Sprintf("%s%s", cfg.APIBaseURL, fmt.Sprintf(constants.EndpointTraceTagValues, rawTagName))
+
+		region := cfg.Region
+		if args.Region != "" {
+			region = args.Region
+		}
+		if region != "" {
+			q := url.Values{}
+			q.Set("region", region)
+			apiURL += "?" + q.Encode()
+		}
+
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create request: %v", err)
+		}
+		httpReq.Header.Set(constants.HeaderAccept, constants.HeaderAcceptJSON)
+		httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+cfg.TokenManager.GetAccessToken(ctx))
+		httpReq.Header.Set(constants.HeaderUserAgent, constants.UserAgentLast9MCP)
+
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to execute request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			var errBody map[string]interface{}
+			json.NewDecoder(resp.Body).Decode(&errBody)
+			return nil, nil, fmt.Errorf("API returned status %d: %v", resp.StatusCode, errBody)
+		}
+
+		var apiResp traceTagValuesAPIResponse
+		if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+			return nil, nil, fmt.Errorf("failed to decode response: %v", err)
+		}
+
+		attr := enrichAttribute(rawTagName)
+
+		type result struct {
+			TagName     string   `json:"tag_name"`
+			FilterField string   `json:"filter_field"`
+			Values      []string `json:"values"`
+			Hint        string   `json:"hint"`
+		}
+
+		values := apiResp.Data
+		if values == nil {
+			values = []string{}
+		}
+
+		out, err := json.Marshal(result{
+			TagName:     rawTagName,
+			FilterField: attr.FilterField,
+			Values:      values,
+			Hint:        fmt.Sprintf(`Use filter_field in a tracejson condition. Example: {"$eq": ["%s", "%s"]}`, attr.FilterField, firstOrPlaceholder(values)),
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal result: %v", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(out)}},
+		}, nil, nil
+	}
+}
+
+func firstOrPlaceholder(values []string) string {
+	if len(values) > 0 {
+		return values[0]
+	}
+	return "value"
+}

--- a/internal/telemetry/traces/attribute_values_test.go
+++ b/internal/telemetry/traces/attribute_values_test.go
@@ -1,0 +1,111 @@
+package traces
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func newTestCfg(serverURL string) models.Config {
+	return models.Config{
+		APIBaseURL: serverURL,
+		TokenManager: &auth.TokenManager{
+			AccessToken: "test-token",
+			ExpiresAt:   time.Now().Add(24 * time.Hour),
+		},
+	}
+}
+
+func TestGetTraceAttributeValuesHandler_EmptyTagName(t *testing.T) {
+	handler := NewGetTraceAttributeValuesHandler(http.DefaultClient, models.Config{})
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTraceAttributeValuesArgs{TagName: ""})
+	if err == nil {
+		t.Fatal("expected error for empty tag_name, got nil")
+	}
+	if !strings.Contains(err.Error(), "tag_name is required") {
+		t.Errorf("expected 'tag_name is required', got: %v", err)
+	}
+}
+
+func TestGetTraceAttributeValuesHandler_WhitespaceOnlyTagName(t *testing.T) {
+	// After normalizeTagName("   ") the result is "", which should be rejected.
+	handler := NewGetTraceAttributeValuesHandler(http.DefaultClient, models.Config{})
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTraceAttributeValuesArgs{TagName: "   "})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only tag_name, got nil")
+	}
+	if !strings.Contains(err.Error(), "blank") {
+		t.Errorf("expected 'cannot be blank', got: %v", err)
+	}
+}
+
+func TestGetTraceAttributeValuesHandler_NonSuccessAPIStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"status":"error","data":null}`)
+	}))
+	defer server.Close()
+
+	handler := NewGetTraceAttributeValuesHandler(server.Client(), newTestCfg(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTraceAttributeValuesArgs{TagName: "http.method"})
+	if err == nil {
+		t.Fatal("expected error for non-success API status, got nil")
+	}
+	if !strings.Contains(err.Error(), "non-success status") {
+		t.Errorf("expected non-success status error, got: %v", err)
+	}
+}
+
+func TestGetTraceAttributeValuesHandler_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "http.method") {
+			t.Errorf("expected tag name in path, got: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"status":"success","data":["GET","POST","PUT"]}`)
+	}))
+	defer server.Close()
+
+	handler := NewGetTraceAttributeValuesHandler(server.Client(), newTestCfg(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTraceAttributeValuesArgs{TagName: "http.method"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil || len(result.Content) == 0 {
+		t.Fatal("expected non-empty result content")
+	}
+	text := result.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(text, "GET") {
+		t.Errorf("expected values in response, got: %s", text)
+	}
+	if !strings.Contains(text, `attributes['http.method']`) {
+		t.Errorf("expected filter_field in response, got: %s", text)
+	}
+}
+
+func TestGetTraceAttributeValuesHandler_ResourceTagNormalized(t *testing.T) {
+	// resources['department'] should be normalized to resource_department in the path.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "resource_department") {
+			t.Errorf("expected resource_department in path, got: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"status":"success","data":["engineering","platform"]}`)
+	}))
+	defer server.Close()
+
+	handler := NewGetTraceAttributeValuesHandler(server.Client(), newTestCfg(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTraceAttributeValuesArgs{TagName: "resources['department']"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/telemetry/traces/attribute_values_test.go
+++ b/internal/telemetry/traces/attribute_values_test.go
@@ -2,6 +2,7 @@ package traces
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -67,6 +68,27 @@ func TestGetTraceAttributeValuesHandler_NonSuccessAPIStatus(t *testing.T) {
 
 func TestGetTraceAttributeValuesHandler_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Must be POST with pipeline body.
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %q", ct)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("expected valid JSON body, got: %v", err)
+		}
+		if _, ok := body["pipeline"]; !ok {
+			t.Errorf("expected 'pipeline' key in body, got: %v", body)
+		}
+		// region, start, end must be query params.
+		if r.URL.Query().Get("start") == "" {
+			t.Errorf("expected start query param")
+		}
+		if r.URL.Query().Get("end") == "" {
+			t.Errorf("expected end query param")
+		}
 		if !strings.Contains(r.URL.Path, "http.method") {
 			t.Errorf("expected tag name in path, got: %s", r.URL.Path)
 		}
@@ -93,8 +115,11 @@ func TestGetTraceAttributeValuesHandler_Success(t *testing.T) {
 }
 
 func TestGetTraceAttributeValuesHandler_ResourceTagNormalized(t *testing.T) {
-	// resources['department'] should be normalized to resource_department in the path.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		// resources['department'] normalizes to resource_department in the URL path.
 		if !strings.Contains(r.URL.Path, "resource_department") {
 			t.Errorf("expected resource_department in path, got: %s", r.URL.Path)
 		}

--- a/internal/telemetry/traces/attributes.go
+++ b/internal/telemetry/traces/attributes.go
@@ -19,28 +19,44 @@ import (
 
 // GetTraceAttributesDescription describes the trace attributes tool
 const GetTraceAttributesDescription = `
-Fetches available trace attributes (series) for a specified time window.
-This tool queries the Last9 traces API to retrieve all available attribute names
-that can be used for filtering and querying traces within the specified time range.
+Fetches available trace attributes for a specified time window and returns each
+one enriched with the exact filter_field string to use in a get_traces query.
 
-The attributes returned are field names that exist in traces during the specified
-time window, which can then be used in trace queries and filters.
+Call this before building a tracejson filter whenever you need to filter by a
+resource attribute or span attribute — never guess the filter_field syntax.
+
+Returns a JSON array sorted by name. Each entry has:
+  - name:          raw attribute name as returned by the API (e.g. "resource_department")
+  - semantic_name: human-readable name with prefix stripped (e.g. "department")
+  - type:          "toplevel" | "resource" | "span"
+  - filter_field:  exact string to use in a tracejson $eq/$contains/etc. condition
+                   (e.g. "resources['department']", "attributes['http.method']", "ServiceName")
+  - hint:          ready-made example condition using filter_field
+
+Use filter_field directly — do not transform it further.
 
 Defaults to the last 15 minutes if no time window is provided.
-
-Returns an alphabetically sorted list of all available trace attributes.
 
 Time format rules:
 - Prefer lookback_minutes for relative windows.
 - Use start_time_iso/end_time_iso for absolute windows.
 - start_time_iso/end_time_iso accept RFC3339/ISO8601 (e.g. 2026-02-09T15:04:05Z).
-- Legacy format YYYY-MM-DD HH:MM:SS is accepted only for compatibility.
 `
 
 // TraceAttributesResponse represents the API response structure
 type TraceAttributesResponse struct {
 	Data   []map[string]string `json:"data"`
 	Status string              `json:"status"`
+}
+
+// TraceAttribute is an enriched attribute entry returned by get_trace_attributes.
+// filter_field is the exact string to use in a tracejson filter condition.
+type TraceAttribute struct {
+	Name         string `json:"name"`
+	SemanticName string `json:"semantic_name"`
+	Type         string `json:"type"` // "resource", "span", "event", or "toplevel"
+	FilterField  string `json:"filter_field"`
+	Hint         string `json:"hint"`
 }
 
 // GetTraceAttributesArgs represents the input arguments for the get_trace_attributes tool
@@ -222,7 +238,6 @@ func NewGetTraceAttributesHandler(client *http.Client, cfg models.Config) func(c
 			return nil, nil, fmt.Errorf("API returned non-success status: %s", result.Status)
 		}
 
-		// Extract attributes as simple list
 		if len(result.Data) == 0 {
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{
@@ -233,34 +248,30 @@ func NewGetTraceAttributesHandler(client *http.Client, cfg models.Config) func(c
 			}, nil, nil
 		}
 
-		// Extract all attributes into a simple list
-		attributes := []string{}
+		// Build sorted list of raw names then enrich each one.
+		rawNames := make([]string, 0, len(result.Data[0]))
 		for attrName := range result.Data[0] {
-			// Skip empty attribute names
 			if attrName == "" {
 				continue
 			}
-			attributes = append(attributes, attrName)
+			rawNames = append(rawNames, attrName)
+		}
+		sort.Strings(rawNames)
+
+		enriched := make([]TraceAttribute, 0, len(rawNames))
+		for _, name := range rawNames {
+			enriched = append(enriched, enrichAttribute(name))
 		}
 
-		// Sort attributes alphabetically
-		sort.Strings(attributes)
-
-		// Format the response for display
-		summary := fmt.Sprintf("Found %d trace attributes in the time window (%s to %s):\n\n",
-			len(attributes),
-			time.Unix(startTime, 0).Format("2006-01-02 15:04:05"),
-			time.Unix(endTime, 0).Format("2006-01-02 15:04:05"))
-
-		// Build formatted output as simple list
-		for _, attr := range attributes {
-			summary += fmt.Sprintf("%s\n", attr)
+		out, err := json.Marshal(enriched)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal trace attributes: %v", err)
 		}
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{
 				&mcp.TextContent{
-					Text: summary,
+					Text: string(out),
 				},
 			},
 		}, nil, nil

--- a/internal/telemetry/traces/attributes.go
+++ b/internal/telemetry/traces/attributes.go
@@ -28,7 +28,7 @@ resource attribute or span attribute — never guess the filter_field syntax.
 Returns a JSON array sorted by name. Each entry has:
   - name:          raw attribute name as returned by the API (e.g. "resource_department")
   - semantic_name: human-readable name with prefix stripped (e.g. "department")
-  - type:          "toplevel" | "resource" | "span"
+  - type:          "toplevel" | "resource" | "event" | "span"
   - filter_field:  exact string to use in a tracejson $eq/$contains/etc. condition
                    (e.g. "resources['department']", "attributes['http.method']", "ServiceName")
   - hint:          ready-made example condition using filter_field

--- a/internal/telemetry/traces/field_mapping.go
+++ b/internal/telemetry/traces/field_mapping.go
@@ -1,0 +1,129 @@
+package traces
+
+// traceTopLevelFields is the set of first-class trace fields that are used
+// directly by name in tracejson filter conditions (no bracket syntax needed).
+var traceTopLevelFields = map[string]struct{}{
+	"TraceId": {}, "SpanId": {}, "ServiceName": {}, "SpanName": {},
+	"SpanKind": {}, "StatusCode": {}, "StatusMessage": {}, "Duration": {},
+	"Timestamp": {}, "ParentSpanId": {}, "TraceState": {},
+}
+
+// enrichAttribute converts a raw attribute name from the traces series API into
+// a TraceAttribute with an LLM-ready filter_field and usage hint.
+//
+// Priority order mirrors the frontend's mapTracesSeriesFieldName in
+// dashboard/app/src/App/scenes/Traces/utils.ts:
+//  1. resource_service.name / service.name  → ServiceName (top-level special case)
+//  2. resource_* prefix                     → resources['<stripped>']
+//  3. event_* prefix                        → events['<stripped>']
+//  4. Known top-level fields                → use as-is
+//  5. grpc.status_code                      → attributes['rpc.grpc.status_code']
+//  6. Everything else                       → attributes['<raw>']
+func enrichAttribute(raw string) TraceAttribute {
+	// Priority 1
+	if raw == "resource_service.name" || raw == "service.name" {
+		return TraceAttribute{
+			Name:         raw,
+			SemanticName: "service.name",
+			Type:         "toplevel",
+			FilterField:  "ServiceName",
+			Hint:         `Example: {"$eq": ["ServiceName", "checkout"]}`,
+		}
+	}
+
+	// Priority 2: resource_* → resources['<stripped>']
+	if len(raw) > 9 && raw[:9] == "resource_" {
+		stripped := raw[9:]
+		filterField := "resources['" + stripped + "']"
+		return TraceAttribute{
+			Name:         raw,
+			SemanticName: stripped,
+			Type:         "resource",
+			FilterField:  filterField,
+			Hint:         `Example: {"$eq": ["` + filterField + `", "value"]}`,
+		}
+	}
+
+	// Priority 3: event_* → events['<stripped>']
+	if len(raw) > 6 && raw[:6] == "event_" {
+		stripped := raw[6:]
+		filterField := "events['" + stripped + "']"
+		return TraceAttribute{
+			Name:         raw,
+			SemanticName: stripped,
+			Type:         "event",
+			FilterField:  filterField,
+			Hint:         `Example: {"$eq": ["` + filterField + `", "value"]}`,
+		}
+	}
+
+	// Priority 4: known top-level fields
+	if _, ok := traceTopLevelFields[raw]; ok {
+		return TraceAttribute{
+			Name:         raw,
+			SemanticName: raw,
+			Type:         "toplevel",
+			FilterField:  raw,
+			Hint:         `Example: {"$eq": ["` + raw + `", "value"]}`,
+		}
+	}
+
+	// Priority 5: grpc.status_code OTel rename
+	if raw == "grpc.status_code" {
+		return TraceAttribute{
+			Name:         raw,
+			SemanticName: raw,
+			Type:         "span",
+			FilterField:  "attributes['rpc.grpc.status_code']",
+			Hint:         `Example: {"$eq": ["attributes['rpc.grpc.status_code']", "0"]}`,
+		}
+	}
+
+	// Priority 6: span attributes
+	filterField := "attributes['" + raw + "']"
+	return TraceAttribute{
+		Name:         raw,
+		SemanticName: raw,
+		Type:         "span",
+		FilterField:  filterField,
+		Hint:         `Example: {"$eq": ["` + filterField + `", "value"]}`,
+	}
+}
+
+// normalizeTagName converts a filter_field syntax string or raw API tag name
+// into the raw API tag name expected by the tag-values endpoint.
+//
+//	resources['department']    → resource_department
+//	events['exception.type']   → event_exception.type
+//	attributes['http.method']  → http.method
+//	resource_department        → resource_department  (pass-through)
+func normalizeTagName(input string) string {
+	t := trimSpace(input)
+	if hasWrapping(t, "resources['", "']") {
+		return "resource_" + t[len("resources['"):len(t)-2]
+	}
+	if hasWrapping(t, "events['", "']") {
+		return "event_" + t[len("events['"):len(t)-2]
+	}
+	if hasWrapping(t, "attributes['", "']") {
+		return t[len("attributes['") : len(t)-2]
+	}
+	return t
+}
+
+func trimSpace(s string) string {
+	start, end := 0, len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
+		end--
+	}
+	return s[start:end]
+}
+
+func hasWrapping(s, prefix, suffix string) bool {
+	return len(s) > len(prefix)+len(suffix) &&
+		s[:len(prefix)] == prefix &&
+		s[len(s)-len(suffix):] == suffix
+}

--- a/internal/telemetry/traces/field_mapping_test.go
+++ b/internal/telemetry/traces/field_mapping_test.go
@@ -1,0 +1,77 @@
+package traces
+
+import "testing"
+
+func TestEnrichAttribute(t *testing.T) {
+	tests := []struct {
+		raw          string
+		wantType     string
+		wantField    string
+		wantSemantic string
+	}{
+		// Priority 1: service.name aliases → ServiceName
+		{"resource_service.name", "toplevel", "ServiceName", "service.name"},
+		{"service.name", "toplevel", "ServiceName", "service.name"},
+		// Priority 2: resource_* → resources['stripped']
+		{"resource_k8s.cluster", "resource", "resources['k8s.cluster']", "k8s.cluster"},
+		{"resource_department", "resource", "resources['department']", "department"},
+		// Priority 3: event_* → events['stripped']
+		{"event_exception.type", "event", "events['exception.type']", "exception.type"},
+		{"event_message", "event", "events['message']", "message"},
+		// Priority 4: known top-level fields
+		{"ServiceName", "toplevel", "ServiceName", "ServiceName"},
+		{"Duration", "toplevel", "Duration", "Duration"},
+		{"StatusCode", "toplevel", "StatusCode", "StatusCode"},
+		{"SpanKind", "toplevel", "SpanKind", "SpanKind"},
+		// Priority 5: grpc.status_code OTel rename
+		{"grpc.status_code", "span", "attributes['rpc.grpc.status_code']", "grpc.status_code"},
+		// Priority 6: span attributes (catch-all)
+		{"http.method", "span", "attributes['http.method']", "http.method"},
+		{"db.statement", "span", "attributes['db.statement']", "db.statement"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got := enrichAttribute(tt.raw)
+			if got.Name != tt.raw {
+				t.Errorf("Name = %q, want %q", got.Name, tt.raw)
+			}
+			if got.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", got.Type, tt.wantType)
+			}
+			if got.FilterField != tt.wantField {
+				t.Errorf("FilterField = %q, want %q", got.FilterField, tt.wantField)
+			}
+			if got.SemanticName != tt.wantSemantic {
+				t.Errorf("SemanticName = %q, want %q", got.SemanticName, tt.wantSemantic)
+			}
+		})
+	}
+}
+
+func TestNormalizeTagName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"resources['department']", "resource_department"},
+		{"events['exception.type']", "event_exception.type"},
+		{"attributes['http.method']", "http.method"},
+		{"resource_department", "resource_department"},
+		{"event_exception.type", "event_exception.type"},
+		{"http.method", "http.method"},
+		{"ServiceName", "ServiceName"},
+		{"  resources['k8s.cluster']  ", "resource_k8s.cluster"},
+		// empty key edge case: wrapping chars only → no stripping (len guard fails)
+		{"resources['']", "resources['']"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeTagName(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeTagName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/telemetry/traces/query_sanitize.go
+++ b/internal/telemetry/traces/query_sanitize.go
@@ -132,8 +132,10 @@ func validateFilterFields(value interface{}, path string) error {
 
 // validateFieldSyntax rejects field references that use incorrect syntax forms.
 func validateFieldSyntax(field, path string) error {
-	// Double-quoted bracket syntax: attributes["..."] or resources["..."]
-	if strings.HasPrefix(field, `attributes["`) || strings.HasPrefix(field, `resources["`) {
+	// Double-quoted bracket syntax: attributes["..."], resources["..."], or events["..."]
+	if strings.HasPrefix(field, `attributes["`) ||
+		strings.HasPrefix(field, `resources["`) ||
+		strings.HasPrefix(field, `events["`) {
 		corrected := strings.ReplaceAll(field, `"`, "'")
 		return fmt.Errorf(
 			"invalid field reference %q at %s: tracejson requires single quotes — use %q instead",

--- a/internal/telemetry/traces/query_sanitize.go
+++ b/internal/telemetry/traces/query_sanitize.go
@@ -1,6 +1,40 @@
 package traces
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+var traceFilterFieldOperators = map[string]struct{}{
+	"$contains":          {},
+	"$containsWords":     {},
+	"$eq":                {},
+	"$exists":            {},
+	"$gt":                {},
+	"$gte":               {},
+	"$icontains":         {},
+	"$icontainsWords":    {},
+	"$ieq":               {},
+	"$ineq":              {},
+	"$inotcontains":      {},
+	"$inotcontainsWords": {},
+	"$inotregex":         {},
+	"$iregex":            {},
+	"$lt":                {},
+	"$lte":               {},
+	"$neq":               {},
+	"$notcontains":       {},
+	"$notcontainsWords":  {},
+	"$notregex":          {},
+	"$notnull":           {},
+	"$regex":             {},
+}
+
+var traceFilterLogicalOperators = map[string]struct{}{
+	"$and": {},
+	"$or":  {},
+	"$not": {},
+}
 
 // sanitizeTraceJSONQuery validates a tracejson_query pipeline before forwarding
 // to the API. It catches common LLM mistakes and returns descriptive errors so
@@ -14,12 +48,143 @@ func sanitizeTraceJSONQuery(stages []map[string]interface{}) error {
 			return err
 		}
 
+		if stageType == "filter" || stageType == "where" {
+			if query, ok := stage["query"]; ok {
+				if err := validateTraceFilterCondition(query, path+".query"); err != nil {
+					return err
+				}
+				if err := validateFilterFields(query, path+".query"); err != nil {
+					return err
+				}
+			}
+		}
+
 		if stageType == "aggregate" {
 			if err := validateAggregateStage(stage, path); err != nil {
 				return err
 			}
 		}
 	}
+	return nil
+}
+
+func validateTraceFilterCondition(value interface{}, path string) error {
+	switch typed := value.(type) {
+	case []interface{}:
+		for i, item := range typed {
+			if err := validateTraceFilterCondition(item, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+	case map[string]interface{}:
+		for key, item := range typed {
+			if _, isField := traceFilterFieldOperators[key]; isField {
+				continue
+			}
+			if _, isLogical := traceFilterLogicalOperators[key]; isLogical {
+				if err := validateTraceFilterCondition(item, path+"."+key); err != nil {
+					return err
+				}
+				continue
+			}
+			return fmt.Errorf(
+				"invalid filter condition key %q at %s: keys must be operators ($eq, $neq, $gt, $gte, $lt, $lte, $contains, $notcontains, $icontains, $inotcontains, $icontainsWords, $inotcontainsWords, $regex, $notregex, $iregex, $inotregex, $ieq, $ineq, $notnull, $exists, $containsWords, $notcontainsWords) or logical operators ($and, $or, $not); use the form {%q: [field, value]} — for example {\"$eq\": [\"ServiceName\", \"checkout\"]}",
+				key,
+				path,
+				"$eq",
+			)
+		}
+	}
+	return nil
+}
+
+// validateFilterFields walks the query tree and checks every string field operand
+// for common LLM mistakes: flat resource_ prefix, double-quoted attribute syntax,
+// and dot-notation field names.
+func validateFilterFields(value interface{}, path string) error {
+	switch typed := value.(type) {
+	case []interface{}:
+		for i, item := range typed {
+			if err := validateFilterFields(item, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+	case map[string]interface{}:
+		for key, item := range typed {
+			if _, isLogical := traceFilterLogicalOperators[key]; isLogical {
+				if err := validateFilterFields(item, path+"."+key); err != nil {
+					return err
+				}
+				continue
+			}
+			// Field operators: args are [field, value] — check first element
+			if args, ok := item.([]interface{}); ok && len(args) > 0 {
+				if fieldStr, ok := args[0].(string); ok {
+					if err := validateFieldSyntax(fieldStr, fmt.Sprintf("%s.%s[0]", path, key)); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// validateFieldSyntax rejects field references that use incorrect syntax forms.
+func validateFieldSyntax(field, path string) error {
+	// Double-quoted bracket syntax: attributes["..."] or resources["..."]
+	if strings.HasPrefix(field, `attributes["`) || strings.HasPrefix(field, `resources["`) {
+		corrected := strings.ReplaceAll(field, `"`, "'")
+		return fmt.Errorf(
+			"invalid field reference %q at %s: tracejson requires single quotes — use %q instead",
+			field, path, corrected,
+		)
+	}
+
+	// Dot-notation: ResourceAttributes.field → resources['field']
+	if strings.HasPrefix(field, "ResourceAttributes.") {
+		stripped := field[len("ResourceAttributes."):]
+		return fmt.Errorf(
+			"invalid field reference %q at %s: use resources['%s'] instead of dot notation",
+			field, path, stripped,
+		)
+	}
+
+	// Dot-notation: SpanAttributes.field → attributes['field']
+	if strings.HasPrefix(field, "SpanAttributes.") {
+		stripped := field[len("SpanAttributes."):]
+		return fmt.Errorf(
+			"invalid field reference %q at %s: use attributes['%s'] instead of dot notation",
+			field, path, stripped,
+		)
+	}
+
+	// Flat resource_ prefix: resource_department → resources['department']
+	if strings.HasPrefix(field, "resource_") {
+		if _, isTopLevel := traceTopLevelFields[field]; !isTopLevel {
+			stripped := field[len("resource_"):]
+			if stripped == "service.name" {
+				return fmt.Errorf(
+					"invalid field reference %q at %s: use \"ServiceName\" instead",
+					field, path,
+				)
+			}
+			return fmt.Errorf(
+				"invalid field reference %q at %s: use resources['%s'] instead of the flat resource_ prefix",
+				field, path, stripped,
+			)
+		}
+	}
+
+	// Flat event_ prefix: event_exception.type → events['exception.type']
+	if strings.HasPrefix(field, "event_") {
+		stripped := field[len("event_"):]
+		return fmt.Errorf(
+			"invalid field reference %q at %s: use events['%s'] instead of the flat event_ prefix",
+			field, path, stripped,
+		)
+	}
+
 	return nil
 }
 

--- a/internal/telemetry/traces/query_sanitize_test.go
+++ b/internal/telemetry/traces/query_sanitize_test.go
@@ -510,8 +510,13 @@ func TestSanitizeTraceJSONQuery_InvalidFieldReferences(t *testing.T) {
 			errContains: `resources['k8s.cluster']`,
 		},
 		{
-			name:        "double-quoted bracket syntax",
+			name:        "double-quoted bracket syntax attributes",
 			field:       `attributes["http.method"]`,
+			errContains: `single quotes`,
+		},
+		{
+			name:        "double-quoted bracket syntax events",
+			field:       `events["exception.type"]`,
 			errContains: `single quotes`,
 		},
 	}

--- a/internal/telemetry/traces/query_sanitize_test.go
+++ b/internal/telemetry/traces/query_sanitize_test.go
@@ -345,6 +345,194 @@ func TestSanitizeTraceJSONQuery_ErrorMessages(t *testing.T) {
 	})
 }
 
+func TestSanitizeTraceJSONQuery_InvalidFilterConditionKeys(t *testing.T) {
+	tests := []struct {
+		name        string
+		stages      []map[string]interface{}
+		errContains string
+	}{
+		{
+			name: "bare service key in filter query",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"service": "gateway-k8s-hydra",
+				}},
+			},
+			errContains: `"service"`,
+		},
+		{
+			name: "bare key mixed with $and",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$and": []interface{}{
+						map[string]interface{}{"$eq": []interface{}{"ServiceName", "api"}},
+					},
+					"service": "gateway-k8s-hydra",
+				}},
+			},
+			errContains: `"service"`,
+		},
+		{
+			name: "bare key nested inside $and",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$and": []interface{}{
+						map[string]interface{}{"service": "gateway-k8s-hydra"},
+					},
+				}},
+			},
+			errContains: `"service"`,
+		},
+		{
+			name: "bare ServiceName key at top level",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"ServiceName": "checkout",
+				}},
+			},
+			errContains: `"ServiceName"`,
+		},
+		{
+			name: "where alias also validates filter conditions",
+			stages: []map[string]interface{}{
+				{"type": "where", "query": map[string]interface{}{
+					"service": "api",
+				}},
+			},
+			errContains: `"service"`,
+		},
+		{
+			name: "bare key nested inside $or",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$or": []interface{}{
+						map[string]interface{}{"status": "error"},
+					},
+				}},
+			},
+			errContains: `"status"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sanitizeTraceJSONQuery(tt.stages)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.errContains)
+			}
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("expected error to contain %q, got: %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
+func TestSanitizeTraceJSONQuery_ValidFilterOperators(t *testing.T) {
+	tests := []struct {
+		name   string
+		stages []map[string]interface{}
+	}{
+		{
+			name: "all comparison operators",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$and": []interface{}{
+						map[string]interface{}{"$gt": []interface{}{"Duration", "1000"}},
+						map[string]interface{}{"$lt": []interface{}{"Duration", "5000"}},
+						map[string]interface{}{"$gte": []interface{}{"Duration", "500"}},
+						map[string]interface{}{"$lte": []interface{}{"Duration", "9000"}},
+						map[string]interface{}{"$neq": []interface{}{"StatusCode", "STATUS_CODE_OK"}},
+					},
+				}},
+			},
+		},
+		{
+			name: "string operators",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$or": []interface{}{
+						map[string]interface{}{"$contains": []interface{}{"SpanName", "checkout"}},
+						map[string]interface{}{"$icontains": []interface{}{"SpanName", "payment"}},
+						map[string]interface{}{"$regex": []interface{}{"SpanName", "^/api/"}},
+						map[string]interface{}{"$ieq": []interface{}{"ServiceName", "API"}},
+					},
+				}},
+			},
+		},
+		{
+			name: "$notnull operator",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$notnull": []interface{}{"TraceId"},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := sanitizeTraceJSONQuery(tt.stages); err != nil {
+				t.Errorf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestSanitizeTraceJSONQuery_InvalidFieldReferences(t *testing.T) {
+	tests := []struct {
+		name        string
+		field       string
+		errContains string
+	}{
+		{
+			name:        "flat resource_ prefix",
+			field:       "resource_k8s.cluster",
+			errContains: `resources['k8s.cluster']`,
+		},
+		{
+			name:        "resource_service.name should suggest ServiceName",
+			field:       "resource_service.name",
+			errContains: `"ServiceName"`,
+		},
+		{
+			name:        "flat event_ prefix",
+			field:       "event_exception.type",
+			errContains: `events['exception.type']`,
+		},
+		{
+			name:        "SpanAttributes dot notation",
+			field:       "SpanAttributes.http.method",
+			errContains: `attributes['http.method']`,
+		},
+		{
+			name:        "ResourceAttributes dot notation",
+			field:       "ResourceAttributes.k8s.cluster",
+			errContains: `resources['k8s.cluster']`,
+		},
+		{
+			name:        "double-quoted bracket syntax",
+			field:       `attributes["http.method"]`,
+			errContains: `single quotes`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sanitizeTraceJSONQuery([]map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{
+					"$eq": []interface{}{tt.field, "value"},
+				}},
+			})
+			if err == nil {
+				t.Fatalf("expected error for field %q, got nil", tt.field)
+			}
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("expected error to contain %q, got: %v", tt.errContains, err)
+			}
+		})
+	}
+}
+
 func TestSanitizeTraceJSONQuery_EdgeCases(t *testing.T) {
 	t.Run("empty pipeline passes", func(t *testing.T) {
 		if err := sanitizeTraceJSONQuery([]map[string]interface{}{}); err != nil {

--- a/internal/telemetry/traces/traces_test.go
+++ b/internal/telemetry/traces/traces_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -325,26 +324,8 @@ func TestExtractExactTraceIDLookup(t *testing.T) {
 
 // Integration test - requires real API credentials
 func TestGetTracesHandler_Integration(t *testing.T) {
-	testRefreshToken := os.Getenv("TEST_REFRESH_TOKEN")
-	if testRefreshToken == "" {
-		t.Skip("Skipping integration test: TEST_REFRESH_TOKEN not set")
-	}
-
-	cfg := models.Config{
-		RefreshToken:   testRefreshToken,
-		DatasourceName: os.Getenv("TEST_DATASOURCE"), // Optional: use specific datasource for testing
-	}
-	// Initialize TokenManager first
-	tokenManager, err := auth.NewTokenManager(testRefreshToken)
-	if err != nil {
-		t.Fatalf("failed to create token manager: %v", err)
-	}
-	cfg.TokenManager = tokenManager
-	if err := utils.PopulateAPICfg(&cfg); err != nil {
-		t.Fatalf("failed to populate API config: %v", err)
-	}
-
-	handler := NewGetTracesHandler(http.DefaultClient, cfg)
+	cfg := utils.SetupTestConfigOrSkip(t)
+	handler := NewGetTracesHandler(http.DefaultClient, *cfg)
 
 	tests := []struct {
 		name  string

--- a/internal/utils/test_helpers.go
+++ b/internal/utils/test_helpers.go
@@ -1,11 +1,15 @@
 package utils
 
 import (
+	"errors"
+	"math/rand/v2"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/joho/godotenv"
 
@@ -16,6 +20,14 @@ import (
 )
 
 var loadTestEnvOnce sync.Once
+
+// sharedTestConfig is initialized exactly once per test process to avoid
+// hammering the token endpoint when many integration tests run in parallel.
+var (
+	sharedTestCfg     *models.Config
+	sharedTestCfgErr  error
+	sharedTestCfgOnce sync.Once
+)
 
 func loadTestEnv() {
 	loadTestEnvOnce.Do(func() {
@@ -50,28 +62,68 @@ func resolveTestRefreshToken() string {
 // It loads .env (if present), then reads TEST_REFRESH_TOKEN or LAST9_REFRESH_TOKEN,
 // and TEST_DATASOURCE from environment variables.
 // Returns an error if no refresh token is set or if PopulateAPICfg fails.
+//
+// The underlying TokenManager is shared across the entire test process so that
+// parallel integration tests do not all race to exchange the refresh token at
+// startup (which would trigger 429 rate-limit errors on the auth endpoint).
 func SetupTestConfig() (*models.Config, error) {
-	testRefreshToken := resolveTestRefreshToken()
-	if testRefreshToken == "" {
-		return nil, &TestConfigError{Message: "TEST_REFRESH_TOKEN or LAST9_REFRESH_TOKEN not set"}
-	}
+	sharedTestCfgOnce.Do(func() {
+		testRefreshToken := resolveTestRefreshToken()
+		if testRefreshToken == "" {
+			sharedTestCfgErr = &TestConfigError{Message: "TEST_REFRESH_TOKEN or LAST9_REFRESH_TOKEN not set"}
+			return
+		}
 
-	cfg := models.Config{
-		RefreshToken:   testRefreshToken,
-		DatasourceName: os.Getenv("TEST_DATASOURCE"), // Automatically reads from environment
-	}
+		cfg := models.Config{
+			RefreshToken:   testRefreshToken,
+			DatasourceName: os.Getenv("TEST_DATASOURCE"),
+		}
 
-	tokenManager, err := auth.NewTokenManager(testRefreshToken)
-	if err != nil {
-		return nil, err
-	}
-	cfg.TokenManager = tokenManager
+		// Retry up to 5 times on 429 (rate limit). All package binaries race to
+		// exchange the refresh token when "go test ./..." starts them in parallel;
+		// a randomised initial delay + exponential back-off avoids a thundering-herd
+		// on the auth endpoint.
+		const maxAttempts = 5
+		// Initial per-binary jitter (0–2 s) staggers the first attempts.
+		time.Sleep(time.Duration(rand.N(2000)) * time.Millisecond)
+		var tokenManager *auth.TokenManager
+		for attempt := range maxAttempts {
+			var err error
+			tokenManager, err = auth.NewTokenManager(testRefreshToken)
+			if err == nil {
+				break
+			}
+			var httpErr *auth.HTTPError
+			if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusTooManyRequests {
+				sharedTestCfgErr = err
+				return
+			}
+			if attempt == maxAttempts-1 {
+				sharedTestCfgErr = &rateLimitExhaustedError{}
+				return
+			}
+			// Exponential back-off: 2s, 4s, 8s, 16s + up to 1 s jitter.
+			backoff := time.Duration(2<<uint(attempt))*time.Second +
+				time.Duration(rand.N(1000))*time.Millisecond
+			time.Sleep(backoff)
+		}
+		cfg.TokenManager = tokenManager
 
-	if err := PopulateAPICfg(&cfg); err != nil {
-		return nil, err
-	}
+		if err := PopulateAPICfg(&cfg); err != nil {
+			sharedTestCfgErr = err
+			return
+		}
 
-	return &cfg, nil
+		sharedTestCfg = &cfg
+	})
+
+	if sharedTestCfgErr != nil {
+		return nil, sharedTestCfgErr
+	}
+	// Return a shallow copy so callers can mutate fields (e.g. DatasourceName)
+	// without affecting other tests.
+	cfgCopy := *sharedTestCfg
+	return &cfgCopy, nil
 }
 
 // TestConfigError represents an error in test configuration setup
@@ -83,13 +135,22 @@ func (e *TestConfigError) Error() string {
 	return e.Message
 }
 
+// rateLimitExhaustedError is returned when token exchange retries are all
+// exhausted due to 429 responses. Tests treat this as a skip, not a failure.
+type rateLimitExhaustedError struct{}
+
+func (e *rateLimitExhaustedError) Error() string {
+	return "auth endpoint rate-limited; token exchange retries exhausted"
+}
+
 // SetupTestConfigOrSkip creates and initializes a test configuration, or skips the test if not configured.
 // This is a convenience wrapper around SetupTestConfig that handles the common skip/fail pattern.
 func SetupTestConfigOrSkip(t *testing.T) *models.Config {
 	t.Helper()
 	cfg, err := SetupTestConfig()
 	if err != nil {
-		if _, ok := err.(*TestConfigError); ok {
+		switch err.(type) {
+		case *TestConfigError, *rateLimitExhaustedError:
 			t.Skipf("Skipping integration test: %v", err)
 		}
 		t.Fatalf("failed to setup test config: %v", err)

--- a/tools.go
+++ b/tools.go
@@ -182,6 +182,12 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCa
 		Description: traces.GetTraceAttributesDescription,
 	}, traces.NewGetTraceAttributesHandler(client, cfg))
 
+	// Register trace attribute values tool
+	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+		Name:        "get_trace_attribute_values",
+		Description: traces.GetTraceAttributeValuesDescription,
+	}, traces.NewGetTraceAttributeValuesHandler(client, cfg))
+
 	// Register change events tool
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
 		Name:        "get_change_events",


### PR DESCRIPTION
## Summary

- **Traces sanitizer**: add `enrichAttribute`/`normalizeTagName` field-mapping layer matching frontend priority rules; new `get_trace_attribute_values` tool; sanitizer now rejects flat `resource_`/`event_` prefixes, dot-notation (`ResourceAttributes.`/`SpanAttributes.`), and double-quoted bracket syntax with actionable correction messages
- **Logs sanitizer**: narrow attribute/resource regexes to single-quote-only; reject flat `resource_*` prefix and double-quoted bracket syntax explicitly; remove non-existent operators (`$noticontains`, `$notiregex`), add correct variants (`$inotcontains`, `$inotregex`, `$ineq`, `$inotcontainsWords`, etc.); fix k8s alias normalization target from `resource_attributes['key']` → `resources['key']`
- **Prompts**: update `get_logs.md` and `get_traces.md` to use `resources['field']` throughout; expand operator reference to all 20 log operators; add `$containsWords` word-boundary guidance; replace traces field reference section with priority table and CRITICAL syntax rules

## Test plan

- [ ] 225 tests pass: `go test ./internal/telemetry/traces/... ./internal/telemetry/logs/...`
- [ ] `TestEnrichAttribute` — 13 cases covering all 6 field-mapping priority branches
- [ ] `TestNormalizeTagName` — 9 cases (resources/events/attributes → raw, pass-throughs, whitespace, empty key)
- [ ] `TestSanitizeTraceJSONQuery_InvalidFilterConditionKeys` — 6 cases
- [ ] `TestSanitizeTraceJSONQuery_ValidFilterOperators` — 3 cases
- [ ] `TestSanitizeTraceJSONQuery_InvalidFieldReferences` — 6 cases (flat prefixes, dot-notation, double-quoted)
- [ ] `TestSanitizeLogJSONQueryRejectsDoubleQuotedBracketSyntax` — 2 cases
- [ ] `TestSanitizeLogJSONQueryRejectsFlatResourcePrefix` — 2 cases
- [ ] `TestSanitizeLogJSONQueryAcceptsAllValidOperators` — 5 groups (ci-equality, ci-contains, word-boundary, ci-regex, numeric)
- [ ] `TestSanitizeLogJSONQueryNormalizesInsideOrAndNot` — 4 subtests
- [ ] `TestSanitizeLogJSONQueryNormalizesK8sAliasInAggregateFunctionArgs` — 3 subtests ($avg, $quantile index-1, $sum rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new tool to fetch distinct values for trace attributes, enabling better attribute discovery for trace filtering.

* **Bug Fixes**
  * Standardized field reference syntax across logs and traces queries (`resources['field']` instead of `resource_attributes['field']`).
  * Updated alert severity parameter to accept `breach` and `threat` values.

* **Documentation**
  * Enhanced guidance on field reference formats for trace and log queries.

* **Tests**
  * Expanded test coverage for query sanitization and field validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/last9/last9-mcp-server/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->