### PR TITLE
chore: release v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tool improvements (#51).
 
+[0.7.4]: https://github.com/last9/last9-mcp-server/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/last9/last9-mcp-server/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/last9/last9-mcp-server/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/last9/last9-mcp-server/compare/v0.7.0...v0.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-05-27
+
+### Added
+
+- `get_trace_attribute_values` tool for retrieving values of trace attributes (#150).
+
+### Changed
+
+- Tool calls now run as parallel chunked requests with adaptive parallelism and chunk sizing (#151).
+- `get_service_logs` now exposes its enhanced description (#152).
+
+### Fixed
+
+- Corrected traces/logs sanitizer behavior (#150).
+
 ## [0.7.3] - 2026-05-25
 
 ### Changed
@@ -54,31 +69,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0] - 2026-04-19
 
 ### Added
+
 - Per-query datasource selection for Prometheus tools (#129).
 
 ### Fixed
+
 - Exception investigation now calls `get_service_traces` instead of `get_traces` (#122).
 
 ### Changed
+
 - Rewrote README to cover all current tools with a cleaner structure (#128).
 
 ## [0.5.1] - 2026-03-02
 
 ### Fixed
+
 - Use `[]map[string]interface{}` for `logjson_query` and `tracejson_query` schema (#93).
 
 ## [0.5.0] - 2026-02-28
 
 ### Added
+
 - Max response time metric support in APM tools (#76).
 - Increased max lookback window from 24h to 14 days.
 
 ### Fixed
+
 - Correct curl testing examples to use MCP session handshake.
 - Docs for hosted MCP, token type, Windows binary; telemetry disabled by default (#86).
 - Note Claude Desktop does not support hosted HTTP MCP yet; revert to STDIO.
 
 ### Changed
+
 - Bumped `go.opentelemetry.io/otel/sdk` to 1.40.0 (#91).
 - Bumped `github.com/modelcontextprotocol/go-sdk` (#90).
 - Updated README for v0.5.0 release (#92).
@@ -86,10 +108,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0] - 2026-02-17
 
 ### Added
+
 - Deep link generation across handlers (dashboards, exceptions, service logs, AI assistant tools).
 - Cluster parameter in dashboard deep links.
 
 ### Fixed
+
 - Broken MCP tools (#73).
 - Exception filter simplification and nested response handling.
 - Exception attribute detection in traces.
@@ -99,31 +123,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified `lookback_minutes` and time parameter defaults in docs (#74).
 
 ### Changed
+
 - Improved tool descriptions (#78).
 - Reverted "disable mutating tools by default until RBAC" — re-enabled.
 
 ## [0.3.0] - 2026-01-12
 
 ### Added
+
 - Trace tools (#60).
 - Refresh token support (#61).
 
 ### Changed
+
 - Simplified authentication and cleanup (#64).
 - Removed `and` condition from `get_trace_attributes`.
 
 ## [0.2.0] - 2025-11-03
 
 ### Added
+
 - `get_traces` tool with trace ID and service name support (#58).
 - `service_name` and `deployment_environment` filters in exceptions tool (#57).
 - Docker image build for release branches (#54).
 - Migration to official MCP SDK with telemetry (#46).
 
 ### Fixed
+
 - Empty response from queries (#53, #55).
 
 ### Changed
+
 - Tool improvements (#51).
 
 [0.7.3]: https://github.com/last9/last9-mcp-server/compare/v0.7.2...v0.7.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
## Release v0.7.4

Patch release. Bumps `package.json` version `0.7.3` → `0.7.4`, which triggers the automated release pipeline on merge.

### Changes since v0.7.3
- ENG-914: parallel chunked tool calls + adaptive parallelism & sizing (frontend parity) (#151)
- fix: wire get_service_logs enhanced description (ENG-1199) (#152)
- ENG-925: fix traces/logs sanitizer correctness and add get_trace_attribute_values (#150)

### Release checklist (auto on merge to main)
- [ ] `tag-and-release` — git tag `v0.7.4` + GoReleaser
- [ ] `publish-docker` — Docker image push (`v0.7.4`, `latest`)
- [ ] `publish-npm` — `@last9/mcp-server@0.7.4` via OIDC
- [ ] homebrew-tap dispatch — formula PR auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)