### PR TITLE
fix: enforce attribute discovery before filtering in get_logs descriptions

### DIFF
--- a/internal/prompts/descriptions/get_logs.md
+++ b/internal/prompts/descriptions/get_logs.md
@@ -49,17 +49,34 @@ These are instructions for constructing a natural language logs analytics querie
 - If the user says "physical index X" or just "index X", use `physical_index:X`.
 - Do not guess or invent an `index`; omit it entirely when the user did not specify one.
 
-**CRITICAL DEFAULT TIME RULE:**
-- **ALWAYS use lookback_minutes: 5 when no time range is specified**
-- **NEVER use 60 minutes unless explicitly requested**
-- **Default means 5 minutes, not 60 minutes**
+**CRITICAL ATTRIBUTE DISCOVERY RULES:**
+- **ALWAYS call `get_log_attributes` BEFORE building a filter on any attribute you did not observe in a previous result.**
+- Do NOT guess attribute names. Attributes like `hook_event`, `http.status_code`, `env`, `region` may or may not exist — verify first.
+- The only fields you may use without discovery are: `ServiceName`, `Body`, `Timestamp`, `SeverityText`.
+
+❌ WRONG — guessing attribute name without discovery:
+```json
+// User asks: "logs from my-service with hook event Stop"
+// Bad: assumes 'Stop' is in Body, or guesses attribute name
+[{"type": "filter", "query": {"$contains": ["Body", "Stop"]}}]
+```
+
+✅ CORRECT — discover first, then filter:
+```
+Step 1: call get_log_attributes(service="my-service")
+        → see "hook_event" in the returned attributes list
+Step 2: call get_logs with:
+[{"type": "filter", "query": {"$and": [
+  {"$eq": ["ServiceName", "my-service"]},
+  {"$eq": ["attributes['hook_event']", "Stop"]}
+]}}]
+```
 
 **CRITICAL FIELD REFERENCE RULES:**
 - Never emit bare dotted field references such as `service.name`, `http.status_code`, or `k8s.namespace.name`.
 - Use `ServiceName` for service filters and grouping, not `service.name`.
 - Use `attributes['field.name']` for log attributes.
 - Use `resources['field.name']` for resource attributes, including Kubernetes metadata like `k8s.namespace.name`.
-- If you are not sure whether a field exists or whether environment is stored on `attributes[...]` vs `resources[...]`, use `get_log_attributes` first or broaden the query instead of guessing.
 
 The JSON pipeline format supports filtering, parsing, aggregation on log data.
 

--- a/internal/prompts/descriptions/get_service_logs.md
+++ b/internal/prompts/descriptions/get_service_logs.md
@@ -75,7 +75,7 @@ Use `get_logs` instead:
 
 ```json
 {
-  "service": "l9alert-pinelabs",
+  "service": "my-service",
   "start_time_iso": "2026-03-31T07:16:38.000Z",
   "end_time_iso": "2026-04-01T07:16:38.907Z",
   "limit": 100,


### PR DESCRIPTION
## Summary

- Replaces the vague "CRITICAL DEFAULT TIME RULE" block in `get_logs.md` with a "CRITICAL ATTRIBUTE DISCOVERY RULES" section — mandates calling `get_log_attributes` before filtering on any attribute not already seen in a prior result
- Adds wrong/correct examples illustrating the discover-then-filter pattern
- Removes a customer-specific service name from the `get_service_logs.md` example, replacing it with a generic placeholder

## Test plan

- [ ] Review updated `get_logs.md` attribute discovery rules and examples
- [ ] Confirm `get_service_logs.md` example no longer contains customer name

🤖 Generated with [Claude Code](https://claude.com/claude-code)