### PR TITLE
fix: correct trace Duration unit guidance to nanoseconds

### DIFF
--- a/internal/prompts/descriptions/get_traces.md
+++ b/internal/prompts/descriptions/get_traces.md
@@ -287,15 +287,22 @@ Call `get_trace_attributes` to discover available fields and get their exact `fi
 
 ### Example 4: Span Duration Filter (FILTER ONLY - NO AGGREGATION)
 
+**CRITICAL: `Duration` is in NANOSECONDS.** Convert the user's unit before filtering:
+- milliseconds → multiply by 1,000,000 (1000ms = `1000000000`)
+- seconds → multiply by 1,000,000,000 (1s = `1000000000`)
+- microseconds → multiply by 1,000 (500µs = `500000`)
+
+Filtering `Duration > "1000"` means 1000 **nanoseconds** (1µs), which matches nearly every span — never use the raw millisecond number.
+
 **Natural Language:** "Get slow spans taking more than 1000ms"
-**JSON:**
+**JSON:** (1000ms = 1000000000ns)
 
 ```json
 [{
   "type": "filter",
   "query": {
     "$and": [
-      {"$gt": ["Duration", "1000"]}
+      {"$gt": ["Duration", "1000000000"]}
     ]
   }
 }]


### PR DESCRIPTION
## Summary

The `get_traces` duration filter example taught the model the wrong unit. `Duration` is stored in **nanoseconds**, but the example mapped "1000ms" to `Duration > "1000"` — which is 1 microsecond, matching nearly every span.

## Proof (live data, 120-min window)

"Show spans slower than 1000ms":

| Filter | Spans matched | % of baseline |
|---|---|---|
| Baseline (no filter) | 352,121 | 100% |
| **Old example** `Duration > 1000` | 357,916 | ~100% (everything) |
| **Correct** `Duration > 1000000000` | 1,919 | ~0.5% |

The AI's "slow spans" answer returned essentially every span — a silent correctness failure that mismatches the dashboard's duration filter.

## Fix

`get_traces.md`:
- Example now uses `1000000000` ns for 1000ms
- Adds explicit conversion note: **Duration is nanoseconds** (ms ×1,000,000 · s ×1,000,000,000 · µs ×1,000)

## Evals (separate repo: last9-mcp-evals)

Added/strengthened `trace_query` cases — verified they **fail** against the old doc and **pass** against the fix:
- `tq-004` strengthened: asserts `5000000000` for "5 seconds"
- `tq-020` (1000ms), `tq-021` (250ms), `tq-022` (2s) added

Result: 4 fail on old doc → all 22 pass on fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)