### PR TITLE
chore: release v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-06-01
+
+### Fixed
+
+- Log attribute discovery now always uses `/v1/labels`, and the environment filter uses the correct key (#156).
+
 ## [0.7.4] - 2026-05-27
 
 ### Added
@@ -156,6 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tool improvements (#51).
 
+[0.7.5]: https://github.com/last9/last9-mcp-server/compare/v0.7.4...v0.7.5
 [0.7.4]: https://github.com/last9/last9-mcp-server/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/last9/last9-mcp-server/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/last9/last9-mcp-server/compare/v0.7.1...v0.7.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
## Release v0.7.5

Patch release. Bumps `package.json` version `0.7.4` → `0.7.5`, which triggers the automated release pipeline on merge.

### Changes since v0.7.4
- fix: always use /v1/labels for log attribute discovery + correct env filter key (#156)

### Release pipeline (auto on merge)
- [ ] `tag-and-release` — git tag `v0.7.5` + GoReleaser (Linux/macOS/Windows tarballs)
- [ ] `publish-docker` — push image to docker-registry.last9.io + ECR (`v0.7.5`, `latest`)
- [ ] `publish-npm` — publish `@last9/mcp-server@0.7.5` via OIDC trusted publishing
- [ ] homebrew-tap dispatch — auto-merge formula PR in `last9/homebrew-tap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)