### PR TITLE
feat: alert rule state filters and grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `get_alert_rule_state` tool for historical firing state (1/0) per alert rule over a time range, grouped by `rule_id`. Supports server-side filtering by `alert_group_id`, `rule_name`, `alert_group_name`, `label_filters`, and `state` (#159).
+
 ## [0.7.5] - 2026-06-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Point these at a different datasource/cluster than the default by setting `LAST9
 - **`get_change_events`** — Deployments, config changes, rollbacks. Correlate incidents with what changed
 - **`get_alert_config`** — Alert rule configurations — searchable by name, severity, type, tags
 - **`get_alerts`** — Currently firing alerts within a time window
+- **`get_alert_rule_state`** — Historical firing state (1/0) per alert rule over a time range, grouped by `rule_id`. Filterable by alert group, rule name, label filters, and state.
 - **`get_notification_channels`** — Configured notification channels (Slack, PagerDuty, email, etc.)
 
 ### Custom Dashboards
@@ -580,6 +581,19 @@ Exactly one of `trace_id` or `service_name` is required.
 - `time_iso` (string, optional): Evaluation time in RFC3339.
 - `window` (integer, optional): Lookback in seconds. Default: 900. Range: 60–86400.
 - `lookback_minutes` (integer, optional): Range: 1–1440.
+
+### get_alert_rule_state
+
+- `start_time` (integer, required): Unix epoch start of the range (inclusive).
+- `end_time` (integer, required): Unix epoch end of the range (inclusive).
+- `step` (integer, required): Resolution in seconds between samples. The number of samples `((end_time - start_time) / step + 1)` is capped at 100.
+- `alert_group_id` (string, optional): Filter by alert group ID.
+- `rule_name` (string, optional): Regex filter on rule name.
+- `alert_group_name` (string, optional): Regex filter on alert group name.
+- `label_filters` (string, optional): Comma-separated `key=value` label filters.
+- `state` (string, optional): Filter by state (e.g. `firing`).
+
+Returns a JSON map of `rule_id -> [{timestamp, is_firing}]`. A timestamp at which a rule is absent from the upstream response is reported as `is_firing=0` — this means "not observed as firing", not a confirmed normal state.
 
 ### get_notification_channels
 

--- a/internal/alerting/alert_rule_state.go
+++ b/internal/alerting/alert_rule_state.go
@@ -1,0 +1,163 @@
+package alerting
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"last9-mcp/internal/constants"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const GetAlertRuleStateDescription = `Gets the historical firing state of an alert rule over a specified time range.
+It returns 1 for firing and 0 for not firing at each timestamp.
+Requires an alert_rule_id, start_time (Unix timestamp), end_time (Unix timestamp), and step (resolution in seconds).`
+
+type AlertRuleStateRequest struct {
+	AlertRuleID    string `json:"alert_rule_id,omitempty" jsonschema:"The ID of the alert rule to check (evaluated client-side)"`
+	AlertGroupID   string `json:"alert_group_id,omitempty" jsonschema:"Optional filter by alert group ID"`
+	RuleName       string `json:"rule_name,omitempty" jsonschema:"Optional regex filter by rule name"`
+	AlertGroupName string `json:"alert_group_name,omitempty" jsonschema:"Optional regex filter by alert group name"`
+	LabelFilters   string `json:"label_filters,omitempty" jsonschema:"Optional comma separated key-value label filters"`
+	State          string `json:"state,omitempty" jsonschema:"Optional state filter (e.g. firing)"`
+	StartTime      int64  `json:"start_time" jsonschema:"Start time in unix epoch (required)"`
+	EndTime        int64  `json:"end_time" jsonschema:"End time in unix epoch (required)"`
+	Step           int64  `json:"step" jsonschema:"Resolution step in seconds (required)"`
+}
+
+func NewAlertRuleStateHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, AlertRuleStateRequest) (*mcp.CallToolResult, any, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return func(ctx context.Context, req *mcp.CallToolRequest, args AlertRuleStateRequest) (*mcp.CallToolResult, any, error) {
+		if args.StartTime >= args.EndTime {
+			return nil, nil, fmt.Errorf("start_time must be less than end_time")
+		}
+		if args.Step <= 0 {
+			return nil, nil, fmt.Errorf("step must be greater than 0")
+		}
+
+		// Cap maximum points to prevent excessive API calls
+		points := (args.EndTime - args.StartTime) / args.Step
+		if points > 100 {
+			return nil, nil, fmt.Errorf("time range and step result in too many points (%d). Maximum is 100", points)
+		}
+
+		type Datapoint struct {
+			Timestamp int64 `json:"timestamp"`
+			IsFiring  int   `json:"is_firing"`
+		}
+
+		// results is a map of rule_id -> timestamp -> is_firing
+		results := make(map[string]map[int64]int)
+
+		tokenMgr := cfg.TokenManager
+		var token string
+		if tokenMgr != nil {
+			token = tokenMgr.GetAccessToken(ctx)
+		}
+
+		for t := args.StartTime; t <= args.EndTime; t += args.Step {
+			// Construct query parameters
+			queryParams := url.Values{}
+			queryParams.Set("timestamp", fmt.Sprintf("%d", t))
+			queryParams.Set("window", fmt.Sprintf("%d", args.Step))
+
+			if args.AlertGroupID != "" {
+				queryParams.Set("alert_group_id", args.AlertGroupID)
+			}
+			if args.RuleName != "" {
+				queryParams.Set("rule_name", args.RuleName)
+			}
+			if args.AlertGroupName != "" {
+				queryParams.Set("alert_group_name", args.AlertGroupName)
+			}
+			if args.LabelFilters != "" {
+				queryParams.Set("label_filters", args.LabelFilters)
+			}
+			if args.State != "" {
+				queryParams.Set("state", args.State)
+			}
+
+			// Query the /alerts/monitor API for each timestamp
+			url := fmt.Sprintf("%s/alerts/monitor?%s", cfg.APIBaseURL, queryParams.Encode())
+			
+			httpReq, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to create request for timestamp %d: %w", t, err)
+			}
+
+			httpReq.Header.Set(constants.HeaderAccept, constants.HeaderAcceptJSON)
+			if token != "" {
+				httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+token)
+				httpReq.Header.Set("Authorization", constants.BearerPrefix+token)
+			}
+
+			resp, err := client.Do(httpReq)
+			if err != nil {
+				return nil, nil, fmt.Errorf("API request failed at timestamp %d: %w", t, err)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to read response body at timestamp %d: %w", t, err)
+			}
+
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				return nil, nil, fmt.Errorf("API returned error status %d at timestamp %d: %s", resp.StatusCode, t, string(body))
+			}
+
+			// Parse the alerts response
+			var alertResp AlertsResponse
+			if err := json.Unmarshal(body, &alertResp); err != nil {
+				return nil, nil, fmt.Errorf("failed to unmarshal alerts response at timestamp %d: %w", t, err)
+			}
+
+			for _, rule := range alertResp.AlertRules {
+				// Exact filter by RuleID if the user specifically requested it
+				if args.AlertRuleID != "" && rule.RuleID != args.AlertRuleID {
+					continue
+				}
+
+				if _, exists := results[rule.RuleID]; !exists {
+					results[rule.RuleID] = make(map[int64]int)
+				}
+				
+				if rule.State == "firing" {
+					results[rule.RuleID][t] = 1
+				} else {
+					results[rule.RuleID][t] = 0 // Some rules might explicitly be "normal"/"pending"
+				}
+			}
+		}
+
+		// Construct final continuous timeseries for all seen rules
+		finalResults := make(map[string][]Datapoint)
+		for ruleID, tsMap := range results {
+			var dps []Datapoint
+			for t := args.StartTime; t <= args.EndTime; t += args.Step {
+				isFiring := tsMap[t] // defaults to 0 if no record for that timestamp
+				dps = append(dps, Datapoint{
+					Timestamp: t,
+					IsFiring:  isFiring,
+				})
+			}
+			finalResults[ruleID] = dps
+		}
+
+		formattedBytes, _ := json.MarshalIndent(finalResults, "", "  ")
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: string(formattedBytes),
+				},
+			},
+		}, nil, nil
+	}
+}

--- a/internal/alerting/alert_rule_state.go
+++ b/internal/alerting/alert_rule_state.go
@@ -7,15 +7,31 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+
 	"last9-mcp/internal/constants"
 	"last9-mcp/internal/models"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const GetAlertRuleStateDescription = `Gets the historical firing state of an alert rule over a specified time range.
-It returns 1 for firing and 0 for not firing at each timestamp.
-Requires start_time (Unix timestamp), end_time (Unix timestamp), and step (resolution in seconds).`
+const GetAlertRuleStateDescription = `Gets the historical firing state of alert rules over a specified time range, grouped by rule_id.
+It polls the /alerts/monitor API at each step within the time range and returns 1 for firing and 0 otherwise at each timestamp.
+
+Required parameters:
+- start_time: Unix epoch start of the range (inclusive)
+- end_time: Unix epoch end of the range (inclusive)
+- step: Resolution in seconds between samples
+
+Optional filters forwarded to the upstream API (no client-side filtering is applied):
+- alert_group_id: Filter by alert group ID
+- rule_name: Regex filter on rule name
+- alert_group_name: Regex filter on alert group name
+- label_filters: Comma-separated key=value label filters
+- state: Filter by state (e.g. firing)
+
+Output is a JSON map of rule_id -> [{timestamp, is_firing}]. A timestamp at which a rule is absent from the upstream
+response is reported as is_firing=0; this reflects "not observed as firing" and not necessarily a confirmed normal state.
+The number of samples ((end_time - start_time) / step + 1) is capped at 100.`
 
 type AlertRuleStateRequest struct {
 	AlertGroupID   string `json:"alert_group_id,omitempty" jsonschema:"Optional filter by alert group ID"`
@@ -28,22 +44,31 @@ type AlertRuleStateRequest struct {
 	Step           int64  `json:"step" jsonschema:"Resolution step in seconds (required)"`
 }
 
+const alertRuleStateMaxPoints = 100
+
+func toolErrorResult(msg string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: msg}},
+		IsError: true,
+	}
+}
+
 func NewAlertRuleStateHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, AlertRuleStateRequest) (*mcp.CallToolResult, any, error) {
 	if client == nil {
 		client = http.DefaultClient
 	}
 	return func(ctx context.Context, req *mcp.CallToolRequest, args AlertRuleStateRequest) (*mcp.CallToolResult, any, error) {
 		if args.StartTime >= args.EndTime {
-			return nil, nil, fmt.Errorf("start_time must be less than end_time")
+			return toolErrorResult("start_time must be less than end_time"), nil, nil
 		}
 		if args.Step <= 0 {
-			return nil, nil, fmt.Errorf("step must be greater than 0")
+			return toolErrorResult("step must be greater than 0"), nil, nil
 		}
 
-		// Cap maximum points to prevent excessive API calls
-		points := (args.EndTime - args.StartTime) / args.Step
-		if points > 100 {
-			return nil, nil, fmt.Errorf("time range and step result in too many points (%d). Maximum is 100", points)
+		// Inclusive sample count: t iterates start, start+step, ..., end.
+		points := (args.EndTime-args.StartTime)/args.Step + 1
+		if points > alertRuleStateMaxPoints {
+			return toolErrorResult(fmt.Sprintf("time range and step result in too many points (%d). Maximum is %d", points, alertRuleStateMaxPoints)), nil, nil
 		}
 
 		type Datapoint struct {
@@ -55,13 +80,8 @@ func NewAlertRuleStateHandler(client *http.Client, cfg models.Config) func(conte
 		results := make(map[string]map[int64]int)
 
 		tokenMgr := cfg.TokenManager
-		var token string
-		if tokenMgr != nil {
-			token = tokenMgr.GetAccessToken(ctx)
-		}
 
 		for t := args.StartTime; t <= args.EndTime; t += args.Step {
-			// Construct query parameters
 			queryParams := url.Values{}
 			queryParams.Set("timestamp", fmt.Sprintf("%d", t))
 			queryParams.Set("window", fmt.Sprintf("%d", args.Step))
@@ -82,18 +102,19 @@ func NewAlertRuleStateHandler(client *http.Client, cfg models.Config) func(conte
 				queryParams.Set("state", args.State)
 			}
 
-			// Query the /alerts/monitor API for each timestamp
-			url := fmt.Sprintf("%s/alerts/monitor?%s", cfg.APIBaseURL, queryParams.Encode())
-			
-			httpReq, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+			finalURL := fmt.Sprintf("%s%s?%s", cfg.APIBaseURL, constants.EndpointAlertsMonitor, queryParams.Encode())
+
+			httpReq, err := http.NewRequestWithContext(ctx, "GET", finalURL, nil)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to create request for timestamp %d: %w", t, err)
 			}
 
 			httpReq.Header.Set(constants.HeaderAccept, constants.HeaderAcceptJSON)
-			if token != "" {
-				httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+token)
-				httpReq.Header.Set("Authorization", constants.BearerPrefix+token)
+			if tokenMgr != nil {
+				// Fetch per-iteration so token-manager refresh logic stays in effect for long ranges.
+				if token := tokenMgr.GetAccessToken(ctx); token != "" {
+					httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+token)
+				}
 			}
 
 			resp, err := client.Do(httpReq)
@@ -111,41 +132,40 @@ func NewAlertRuleStateHandler(client *http.Client, cfg models.Config) func(conte
 				return nil, nil, fmt.Errorf("API returned error status %d at timestamp %d: %s", resp.StatusCode, t, string(body))
 			}
 
-			// Parse the alerts response
 			var alertResp AlertsResponse
 			if err := json.Unmarshal(body, &alertResp); err != nil {
 				return nil, nil, fmt.Errorf("failed to unmarshal alerts response at timestamp %d: %w", t, err)
 			}
 
 			for _, rule := range alertResp.AlertRules {
-
 				if _, exists := results[rule.RuleID]; !exists {
 					results[rule.RuleID] = make(map[int64]int)
 				}
-				
 				if rule.State == "firing" {
 					results[rule.RuleID][t] = 1
 				} else {
-					results[rule.RuleID][t] = 0 // Some rules might explicitly be "normal"/"pending"
+					results[rule.RuleID][t] = 0
 				}
 			}
 		}
 
-		// Construct final continuous timeseries for all seen rules
+		// Construct final continuous timeseries for all seen rules. Gaps are zero-filled; see tool description for caveats.
 		finalResults := make(map[string][]Datapoint)
 		for ruleID, tsMap := range results {
 			var dps []Datapoint
 			for t := args.StartTime; t <= args.EndTime; t += args.Step {
-				isFiring := tsMap[t] // defaults to 0 if no record for that timestamp
 				dps = append(dps, Datapoint{
 					Timestamp: t,
-					IsFiring:  isFiring,
+					IsFiring:  tsMap[t],
 				})
 			}
 			finalResults[ruleID] = dps
 		}
 
-		formattedBytes, _ := json.MarshalIndent(finalResults, "", "  ")
+		formattedBytes, err := json.MarshalIndent(finalResults, "", "  ")
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal results: %w", err)
+		}
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{

--- a/internal/alerting/alert_rule_state.go
+++ b/internal/alerting/alert_rule_state.go
@@ -46,13 +46,6 @@ type AlertRuleStateRequest struct {
 
 const alertRuleStateMaxPoints = 100
 
-func toolErrorResult(msg string) *mcp.CallToolResult {
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: msg}},
-		IsError: true,
-	}
-}
-
 func NewAlertRuleStateHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, AlertRuleStateRequest) (*mcp.CallToolResult, any, error) {
 	if client == nil {
 		client = http.DefaultClient

--- a/internal/alerting/alert_rule_state.go
+++ b/internal/alerting/alert_rule_state.go
@@ -15,10 +15,9 @@ import (
 
 const GetAlertRuleStateDescription = `Gets the historical firing state of an alert rule over a specified time range.
 It returns 1 for firing and 0 for not firing at each timestamp.
-Requires an alert_rule_id, start_time (Unix timestamp), end_time (Unix timestamp), and step (resolution in seconds).`
+Requires start_time (Unix timestamp), end_time (Unix timestamp), and step (resolution in seconds).`
 
 type AlertRuleStateRequest struct {
-	AlertRuleID    string `json:"alert_rule_id,omitempty" jsonschema:"The ID of the alert rule to check (evaluated client-side)"`
 	AlertGroupID   string `json:"alert_group_id,omitempty" jsonschema:"Optional filter by alert group ID"`
 	RuleName       string `json:"rule_name,omitempty" jsonschema:"Optional regex filter by rule name"`
 	AlertGroupName string `json:"alert_group_name,omitempty" jsonschema:"Optional regex filter by alert group name"`
@@ -119,10 +118,6 @@ func NewAlertRuleStateHandler(client *http.Client, cfg models.Config) func(conte
 			}
 
 			for _, rule := range alertResp.AlertRules {
-				// Exact filter by RuleID if the user specifically requested it
-				if args.AlertRuleID != "" && rule.RuleID != args.AlertRuleID {
-					continue
-				}
 
 				if _, exists := results[rule.RuleID]; !exists {
 					results[rule.RuleID] = make(map[int64]int)

--- a/internal/alerting/alert_rule_state_test.go
+++ b/internal/alerting/alert_rule_state_test.go
@@ -89,10 +89,9 @@ func TestAlertRuleStateHandler(t *testing.T) {
 
 	t.Run("ValidRequest", func(t *testing.T) {
 		args := AlertRuleStateRequest{
-			AlertRuleID: "test-rule-1",
-			StartTime:   1686072840,
-			EndTime:     1686072900,
-			Step:        60,
+			StartTime: 1718000000,
+			EndTime:   1718000060,
+			Step:      60,
 		}
 		
 		req := &mcp.CallToolRequest{}
@@ -115,9 +114,9 @@ func TestAlertRuleStateHandler(t *testing.T) {
 		if !strings.Contains(textContent.Text, "\"test-rule-1\": [") {
 			t.Errorf("Expected response to contain test-rule-1 key, got: %s", textContent.Text)
 		}
-		// Since we filtered by AlertRuleID, test-rule-2 should not be in the output
-		if strings.Contains(textContent.Text, "\"test-rule-2\": [") {
-			t.Errorf("Expected response to NOT contain test-rule-2 key due to filtering, got: %s", textContent.Text)
+		// Since we removed client-side filtering, test-rule-2 SHOULD be in the output
+		if !strings.Contains(textContent.Text, "\"test-rule-2\": [") {
+			t.Errorf("Expected response to contain test-rule-2 key, got: %s", textContent.Text)
 		}
 
 		// Verify that the response was processed and mapped to IsFiring correctly for test-rule-1
@@ -133,7 +132,9 @@ func TestAlertRuleStateHandler(t *testing.T) {
 		badHandler := NewAlertRuleStateHandler(server.Client(), badCfg)
 
 		args := AlertRuleStateRequest{
-			AlertRuleID: "test-rule",
+			StartTime: 1718000000,
+			EndTime:   1718000060,
+			Step:      60,
 		}
 
 		_, _, err := badHandler(ctx, &mcp.CallToolRequest{}, args)

--- a/internal/alerting/alert_rule_state_test.go
+++ b/internal/alerting/alert_rule_state_test.go
@@ -2,8 +2,11 @@ package alerting
 
 import (
 	"context"
+	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -14,132 +17,259 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func TestAlertRuleStateHandler(t *testing.T) {
-	// Mock server that returns a predefined matrix result simulating Prometheus output
+func newAlertRuleStateTestConfig(serverURL string) models.Config {
+	return models.Config{
+		APIBaseURL: serverURL,
+		OrgSlug:    "test-org",
+		TokenManager: &auth.TokenManager{
+			AccessToken: "mock-token",
+			ExpiresAt:   time.Now().Add(365 * 24 * time.Hour),
+		},
+	}
+}
+
+type alertRuleStateDatapoint struct {
+	Timestamp int64 `json:"timestamp"`
+	IsFiring  int   `json:"is_firing"`
+}
+
+func decodeAlertRuleStateResult(t *testing.T, result *mcp.CallToolResult) map[string][]alertRuleStateDatapoint {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatalf("Expected content in result")
+	}
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("Expected TextContent")
+	}
+	var decoded map[string][]alertRuleStateDatapoint
+	if err := json.Unmarshal([]byte(textContent.Text), &decoded); err != nil {
+		t.Fatalf("Expected JSON output, got error: %v\npayload: %s", err, textContent.Text)
+	}
+	return decoded
+}
+
+func TestAlertRuleStateHandler_GroupsRulesAcrossTimestamps(t *testing.T) {
+	const (
+		startTime = int64(1718000000)
+		endTime   = int64(1718000060)
+		step      = int64(60)
+	)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "GET" {
+		if r.Method != http.MethodGet {
 			t.Errorf("Expected GET request, got %s", r.Method)
 		}
-		if !strings.Contains(r.URL.Path, "/alerts/monitor") {
-			t.Errorf("Expected path to contain /alerts/monitor, got %s", r.URL.Path)
-		}
-		
-		// Assert that query params are correctly set
-		query := r.URL.Query()
-		if query.Get("rule_name") == "" && query.Get("state") == "" {
-			// fallback check if not testing filter passing specifically
+		if !strings.HasSuffix(r.URL.Path, "/alerts/monitor") {
+			t.Errorf("Expected path to end with /alerts/monitor, got %s", r.URL.Path)
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		
-		// Return alerts monitor format
-		mockResponse := `{
-			"timestamp": 1686072840,
-			"window": 60,
-			"alert_rules": [
-				{
-					"rule_id": "test-rule-1",
-					"state": "firing"
-				},
-				{
-					"rule_id": "test-rule-2",
-					"state": "normal"
-				}
-			]
-		}`
-		// Change the response for the second request
-		if strings.Contains(r.URL.RawQuery, "timestamp=1686072900") {
-			mockResponse = `{
-				"timestamp": 1686072900,
+
+		switch r.URL.Query().Get("timestamp") {
+		case "1718000000":
+			w.Write([]byte(`{
+				"timestamp": 1718000000,
 				"window": 60,
 				"alert_rules": [
-					{
-						"rule_id": "test-rule-1",
-						"state": "pending"
-					},
-					{
-						"rule_id": "test-rule-2",
-						"state": "firing"
-					}
+					{"rule_id": "test-rule-1", "state": "firing"},
+					{"rule_id": "test-rule-2", "state": "normal"}
 				]
-			}`
+			}`))
+		case "1718000060":
+			w.Write([]byte(`{
+				"timestamp": 1718000060,
+				"window": 60,
+				"alert_rules": [
+					{"rule_id": "test-rule-1", "state": "pending"},
+					{"rule_id": "test-rule-2", "state": "firing"}
+				]
+			}`))
+		default:
+			t.Errorf("Unexpected timestamp in request: %s", r.URL.Query().Get("timestamp"))
 		}
-		w.Write([]byte(mockResponse))
 	}))
 	defer server.Close()
 
-	cfg := models.Config{
-		APIBaseURL: server.URL,
+	handler := NewAlertRuleStateHandler(server.Client(), newAlertRuleStateTestConfig(server.URL))
+
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AlertRuleStateRequest{
+		StartTime: startTime,
+		EndTime:   endTime,
+		Step:      step,
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("Unexpected IsError result: %+v", result.Content)
 	}
 
-	// Update config to use the test server directly instead of prepending APIBaseURL
-	// The implementation in alert_rule_state.go uses cfg.APIBaseURL + "/api/v4/organizations/" + cfg.OrgSlug
-	cfg.APIBaseURL = server.URL
-	cfg.OrgSlug = "test-org"
+	decoded := decodeAlertRuleStateResult(t, result)
 
-	// Mock token manager if needed (though handler doesn't fail if absent)
-	cfg.TokenManager = &auth.TokenManager{
-		AccessToken: "mock-token",
-		ExpiresAt:   time.Now().Add(365 * 24 * time.Hour),
+	rule1, ok := decoded["test-rule-1"]
+	if !ok {
+		t.Fatalf("Expected test-rule-1 in output, got keys: %v", mapKeys(decoded))
+	}
+	if len(rule1) != 2 {
+		t.Fatalf("Expected 2 datapoints for test-rule-1, got %d", len(rule1))
+	}
+	if rule1[0].Timestamp != startTime || rule1[0].IsFiring != 1 {
+		t.Errorf("Expected rule-1 datapoint[0] = firing at %d, got %+v", startTime, rule1[0])
+	}
+	if rule1[1].Timestamp != endTime || rule1[1].IsFiring != 0 {
+		t.Errorf("Expected rule-1 datapoint[1] = not firing (pending) at %d, got %+v", endTime, rule1[1])
 	}
 
-	handler := NewAlertRuleStateHandler(server.Client(), cfg)
+	rule2, ok := decoded["test-rule-2"]
+	if !ok {
+		t.Fatalf("Expected test-rule-2 in output, got keys: %v", mapKeys(decoded))
+	}
+	if rule2[0].IsFiring != 0 || rule2[1].IsFiring != 1 {
+		t.Errorf("Expected rule-2 to flip from 0 to 1, got %+v", rule2)
+	}
+}
 
-	ctx := context.Background()
+func TestAlertRuleStateHandler_ForwardsFilters(t *testing.T) {
+	var captured url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"timestamp": 1718000000, "window": 60, "alert_rules": []}`))
+	}))
+	defer server.Close()
 
-	t.Run("ValidRequest", func(t *testing.T) {
-		args := AlertRuleStateRequest{
-			StartTime: 1718000000,
-			EndTime:   1718000060,
-			Step:      60,
-		}
-		
-		req := &mcp.CallToolRequest{}
+	handler := NewAlertRuleStateHandler(server.Client(), newAlertRuleStateTestConfig(server.URL))
 
-		result, _, err := handler(ctx, req, args)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
+	args := AlertRuleStateRequest{
+		AlertGroupID:   "group-7",
+		RuleName:       ".*latency.*",
+		AlertGroupName: ".*api.*",
+		LabelFilters:   "env=prod,team=core",
+		State:          "firing",
+		StartTime:      1718000000,
+		EndTime:        1718000000 + 60,
+		Step:           60,
+	}
 
-		if len(result.Content) == 0 {
-			t.Fatalf("Expected content in result")
-		}
+	if _, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 
-		textContent, ok := result.Content[0].(*mcp.TextContent)
-		if !ok {
-			t.Fatalf("Expected TextContent")
+	expected := map[string]string{
+		"alert_group_id":   "group-7",
+		"rule_name":        ".*latency.*",
+		"alert_group_name": ".*api.*",
+		"label_filters":    "env=prod,team=core",
+		"state":            "firing",
+	}
+	for key, want := range expected {
+		if got := captured.Get(key); got != want {
+			t.Errorf("Expected query param %s=%q, got %q", key, want, got)
 		}
+	}
+}
 
-		// Verify that the response contains the rule map
-		if !strings.Contains(textContent.Text, "\"test-rule-1\": [") {
-			t.Errorf("Expected response to contain test-rule-1 key, got: %s", textContent.Text)
+func TestAlertRuleStateHandler_SetsAuthHeader(t *testing.T) {
+	var sawXLast9, sawAuthorization bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-LAST9-API-TOKEN") != "" {
+			sawXLast9 = true
 		}
-		// Since we removed client-side filtering, test-rule-2 SHOULD be in the output
-		if !strings.Contains(textContent.Text, "\"test-rule-2\": [") {
-			t.Errorf("Expected response to contain test-rule-2 key, got: %s", textContent.Text)
+		if r.Header.Get("Authorization") != "" {
+			sawAuthorization = true
 		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"timestamp": 1, "window": 60, "alert_rules": []}`))
+	}))
+	defer server.Close()
 
-		// Verify that the response was processed and mapped to IsFiring correctly for test-rule-1
-		if !strings.Contains(textContent.Text, "\"is_firing\": 1") || !strings.Contains(textContent.Text, "\"is_firing\": 0") {
-			t.Errorf("Expected is_firing to be 1 and 0 in response, got: %s", textContent.Text)
-		}
+	handler := NewAlertRuleStateHandler(server.Client(), newAlertRuleStateTestConfig(server.URL))
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AlertRuleStateRequest{
+		StartTime: 1, EndTime: 61, Step: 60,
 	})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !sawXLast9 {
+		t.Errorf("Expected X-LAST9-API-TOKEN header to be set")
+	}
+	if sawAuthorization {
+		t.Errorf("Authorization header should not be set; codebase convention is X-LAST9-API-TOKEN only")
+	}
+}
 
-	t.Run("APIError", func(t *testing.T) {
-		// Test with a broken URL to trigger an API error
-		badCfg := cfg
-		badCfg.APIBaseURL = "http://invalid.local"
-		badHandler := NewAlertRuleStateHandler(server.Client(), badCfg)
+func TestAlertRuleStateHandler_ValidationErrors(t *testing.T) {
+	handler := NewAlertRuleStateHandler(http.DefaultClient, newAlertRuleStateTestConfig("http://unused"))
 
-		args := AlertRuleStateRequest{
-			StartTime: 1718000000,
-			EndTime:   1718000060,
-			Step:      60,
-		}
+	cases := []struct {
+		name string
+		args AlertRuleStateRequest
+		want string
+	}{
+		{
+			name: "start equals end",
+			args: AlertRuleStateRequest{StartTime: 100, EndTime: 100, Step: 60},
+			want: "start_time must be less than end_time",
+		},
+		{
+			name: "non-positive step",
+			args: AlertRuleStateRequest{StartTime: 100, EndTime: 200, Step: 0},
+			want: "step must be greater than 0",
+		},
+		{
+			name: "too many points",
+			args: AlertRuleStateRequest{StartTime: 0, EndTime: 60 * 200, Step: 60},
+			want: "too many points",
+		},
+		{
+			name: "cap boundary - 101 samples is rejected",
+			args: AlertRuleStateRequest{StartTime: 0, EndTime: 60 * 100, Step: 60},
+			want: "too many points",
+		},
+	}
 
-		_, _, err := badHandler(ctx, &mcp.CallToolRequest{}, args)
-		if err == nil {
-			t.Fatalf("Expected API error result for broken URL")
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, tc.args)
+			if err != nil {
+				t.Fatalf("Expected IsError result, got transport error: %v", err)
+			}
+			if result == nil || !result.IsError {
+				t.Fatalf("Expected IsError=true, got %+v", result)
+			}
+			text := result.Content[0].(*mcp.TextContent).Text
+			if !strings.Contains(text, tc.want) {
+				t.Errorf("Expected message containing %q, got %q", tc.want, text)
+			}
+		})
+	}
+}
+
+func TestAlertRuleStateHandler_APIError(t *testing.T) {
+	// Reserve a port by binding then closing the listener — guarantees connection-refused.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve port: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	handler := NewAlertRuleStateHandler(&http.Client{Timeout: 2 * time.Second}, newAlertRuleStateTestConfig("http://"+addr))
+
+	_, _, err = handler(context.Background(), &mcp.CallToolRequest{}, AlertRuleStateRequest{
+		StartTime: 1, EndTime: 61, Step: 60,
 	})
+	if err == nil {
+		t.Fatalf("Expected API error for closed port")
+	}
+}
+
+func mapKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/internal/alerting/alert_rule_state_test.go
+++ b/internal/alerting/alert_rule_state_test.go
@@ -170,6 +170,37 @@ func TestAlertRuleStateHandler_ForwardsFilters(t *testing.T) {
 	}
 }
 
+func TestAlertRuleStateHandler_OmitsAbsentFilters(t *testing.T) {
+	var captured url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"timestamp": 1, "window": 60, "alert_rules": []}`))
+	}))
+	defer server.Close()
+
+	handler := NewAlertRuleStateHandler(server.Client(), newAlertRuleStateTestConfig(server.URL))
+
+	// No filters set — only the always-present timestamp/window should be in the query.
+	if _, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AlertRuleStateRequest{
+		StartTime: 1, EndTime: 61, Step: 60,
+	}); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	for _, key := range []string{"alert_group_id", "rule_name", "alert_group_name", "label_filters", "state"} {
+		if captured.Has(key) {
+			t.Errorf("Expected %s to be absent from query when filter not set, got %q", key, captured.Get(key))
+		}
+	}
+
+	for _, key := range []string{"timestamp", "window"} {
+		if !captured.Has(key) {
+			t.Errorf("Expected %s to always be present in query", key)
+		}
+	}
+}
+
 func TestAlertRuleStateHandler_SetsAuthHeader(t *testing.T) {
 	var sawXLast9, sawAuthorization bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/alerting/alert_rule_state_test.go
+++ b/internal/alerting/alert_rule_state_test.go
@@ -1,0 +1,144 @@
+package alerting
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestAlertRuleStateHandler(t *testing.T) {
+	// Mock server that returns a predefined matrix result simulating Prometheus output
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("Expected GET request, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/alerts/monitor") {
+			t.Errorf("Expected path to contain /alerts/monitor, got %s", r.URL.Path)
+		}
+		
+		// Assert that query params are correctly set
+		query := r.URL.Query()
+		if query.Get("rule_name") == "" && query.Get("state") == "" {
+			// fallback check if not testing filter passing specifically
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		
+		// Return alerts monitor format
+		mockResponse := `{
+			"timestamp": 1686072840,
+			"window": 60,
+			"alert_rules": [
+				{
+					"rule_id": "test-rule-1",
+					"state": "firing"
+				},
+				{
+					"rule_id": "test-rule-2",
+					"state": "normal"
+				}
+			]
+		}`
+		// Change the response for the second request
+		if strings.Contains(r.URL.RawQuery, "timestamp=1686072900") {
+			mockResponse = `{
+				"timestamp": 1686072900,
+				"window": 60,
+				"alert_rules": [
+					{
+						"rule_id": "test-rule-1",
+						"state": "pending"
+					},
+					{
+						"rule_id": "test-rule-2",
+						"state": "firing"
+					}
+				]
+			}`
+		}
+		w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	cfg := models.Config{
+		APIBaseURL: server.URL,
+	}
+
+	// Update config to use the test server directly instead of prepending APIBaseURL
+	// The implementation in alert_rule_state.go uses cfg.APIBaseURL + "/api/v4/organizations/" + cfg.OrgSlug
+	cfg.APIBaseURL = server.URL
+	cfg.OrgSlug = "test-org"
+
+	// Mock token manager if needed (though handler doesn't fail if absent)
+	cfg.TokenManager = &auth.TokenManager{
+		AccessToken: "mock-token",
+		ExpiresAt:   time.Now().Add(365 * 24 * time.Hour),
+	}
+
+	handler := NewAlertRuleStateHandler(server.Client(), cfg)
+
+	ctx := context.Background()
+
+	t.Run("ValidRequest", func(t *testing.T) {
+		args := AlertRuleStateRequest{
+			AlertRuleID: "test-rule-1",
+			StartTime:   1686072840,
+			EndTime:     1686072900,
+			Step:        60,
+		}
+		
+		req := &mcp.CallToolRequest{}
+
+		result, _, err := handler(ctx, req, args)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if len(result.Content) == 0 {
+			t.Fatalf("Expected content in result")
+		}
+
+		textContent, ok := result.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("Expected TextContent")
+		}
+
+		// Verify that the response contains the rule map
+		if !strings.Contains(textContent.Text, "\"test-rule-1\": [") {
+			t.Errorf("Expected response to contain test-rule-1 key, got: %s", textContent.Text)
+		}
+		// Since we filtered by AlertRuleID, test-rule-2 should not be in the output
+		if strings.Contains(textContent.Text, "\"test-rule-2\": [") {
+			t.Errorf("Expected response to NOT contain test-rule-2 key due to filtering, got: %s", textContent.Text)
+		}
+
+		// Verify that the response was processed and mapped to IsFiring correctly for test-rule-1
+		if !strings.Contains(textContent.Text, "\"is_firing\": 1") || !strings.Contains(textContent.Text, "\"is_firing\": 0") {
+			t.Errorf("Expected is_firing to be 1 and 0 in response, got: %s", textContent.Text)
+		}
+	})
+
+	t.Run("APIError", func(t *testing.T) {
+		// Test with a broken URL to trigger an API error
+		badCfg := cfg
+		badCfg.APIBaseURL = "http://invalid.local"
+		badHandler := NewAlertRuleStateHandler(server.Client(), badCfg)
+
+		args := AlertRuleStateRequest{
+			AlertRuleID: "test-rule",
+		}
+
+		_, _, err := badHandler(ctx, &mcp.CallToolRequest{}, args)
+		if err == nil {
+			t.Fatalf("Expected API error result for broken URL")
+		}
+	})
+}

--- a/internal/alerting/entity_alert_rules.go
+++ b/internal/alerting/entity_alert_rules.go
@@ -42,10 +42,7 @@ func NewGetEntityAlertRulesHandler(client *http.Client, cfg models.Config) func(
 	return func(ctx context.Context, _ *mcp.CallToolRequest, args GetEntityAlertRulesArgs) (*mcp.CallToolResult, any, error) {
 		entityID := strings.TrimSpace(args.EntityID)
 		if entityID == "" {
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: "entity_id is required"}},
-				IsError: true,
-			}, nil, nil
+			return toolErrorResult("entity_id is required"), nil, nil
 		}
 
 		rules, err := fetchEntityAlertRules(ctx, client, cfg, entityID)

--- a/internal/alerting/errors.go
+++ b/internal/alerting/errors.go
@@ -1,0 +1,13 @@
+package alerting
+
+import "github.com/modelcontextprotocol/go-sdk/mcp"
+
+// toolErrorResult builds a user-facing MCP tool error (IsError=true) carrying msg as text.
+// Use it for input-validation failures so the model receives a structured tool error
+// rather than a transport-level protocol error.
+func toolErrorResult(msg string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: msg}},
+		IsError: true,
+	}
+}

--- a/internal/alerting/integration_test.go
+++ b/internal/alerting/integration_test.go
@@ -2,6 +2,7 @@ package alerting
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -163,4 +164,75 @@ func TestGetEntityAlertRulesHandler_Integration(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestAlertRuleStateHandler_Integration(t *testing.T) {
+	cfg := utils.SetupTestConfigOrSkip(t)
+	handler := NewAlertRuleStateHandler(http.DefaultClient, *cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)
+	defer cancel()
+
+	// 5-minute window at 60s resolution → 6 samples (well under the 100 cap).
+	end := time.Now().Unix()
+	start := end - 5*60
+	args := AlertRuleStateRequest{
+		StartTime: start,
+		EndTime:   end,
+		Step:      60,
+	}
+
+	result, _, err := handler(ctx, &mcp.CallToolRequest{}, args)
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+	if result == nil {
+		t.Fatalf("expected non-nil result")
+	}
+	if result.IsError {
+		text := utils.GetTextContent(t, result)
+		t.Fatalf("unexpected IsError result: %s", text)
+	}
+
+	text := utils.GetTextContent(t, result)
+	t.Logf("response (truncated to 500 chars):\n%s", truncate(text, 500))
+
+	// Output must be a JSON object — map[ruleID][]Datapoint. Empty {} is valid (no rules in window).
+	var decoded map[string][]struct {
+		Timestamp int64 `json:"timestamp"`
+		IsFiring  int   `json:"is_firing"`
+	}
+	if err := json.Unmarshal([]byte(text), &decoded); err != nil {
+		t.Fatalf("expected JSON map output, got error: %v\npayload: %s", err, text)
+	}
+
+	if len(decoded) == 0 {
+		t.Skip("no alert rules surfaced in the last 5 minutes; nothing to assert on")
+	}
+
+	// Every rule's timeseries must have exactly the expected number of samples
+	// (inclusive: (end-start)/step + 1) and contiguous timestamps at `step` intervals.
+	expectedSamples := (end-start)/60 + 1
+	for ruleID, dps := range decoded {
+		if int64(len(dps)) != expectedSamples {
+			t.Errorf("rule %s: expected %d samples, got %d", ruleID, expectedSamples, len(dps))
+			continue
+		}
+		for i, dp := range dps {
+			wantT := start + int64(i)*60
+			if dp.Timestamp != wantT {
+				t.Errorf("rule %s sample %d: expected timestamp %d, got %d", ruleID, i, wantT, dp.Timestamp)
+			}
+			if dp.IsFiring != 0 && dp.IsFiring != 1 {
+				t.Errorf("rule %s sample %d: is_firing must be 0 or 1, got %d", ruleID, i, dp.IsFiring)
+			}
+		}
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
 }

--- a/tools.go
+++ b/tools.go
@@ -158,6 +158,12 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCa
 		Description: alerting.GetAlertsDescription,
 	}, alerting.NewGetAlertsHandler(client, cfg))
 
+	// Register get alert rule state tool
+	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+		Name:        "get_alert_rule_state",
+		Description: alerting.GetAlertRuleStateDescription,
+	}, alerting.NewAlertRuleStateHandler(client, cfg))
+
 	// Register get traces tool (enhanced with trace query instructions)
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
 		Name:        "get_traces",


### PR DESCRIPTION
# Alert Rule State Tool Updates

## Changes Made
- Upgraded the `get_alert_rule_state` tool's schema to accept multiple filters: `alert_group_id`, `rule_name`, `alert_group_name`, `label_filters`, and `state`.
- Ensured strict 1:1 mapping with the upstream Last9 `/alerts/monitor` API, providing all supported native filters while omitting synthetic client-side filters (such as `alert_rule_id`).
- Remapped the historical timeseries JSON output so it groups datapoints explicitly by `rule_id` (returning `map[string][]Datapoint`), providing structured context instead of a flat array.
- Updated the MCP JSON-RPC schemas and verified `invopop/jsonschema` reflection tag formatting.
- Fixed a panic on startup during tool registration by removing `WORD=` formatted prefixes like `required,description=` from struct tags.

## Validation Results
- Verified correct map-based JSON extraction and test cases natively handling all returned rules in `internal/alerting/alert_rule_state_test.go`.
- Successfully built `last9-mcp` binary (`go build .`).
- Executed the actual MCP server native binary (`go run .`) with a wrapper client script sending JSON-RPC payloads over `stdin`.
- Captured a fully functioning response indicating a `2.0` JSON-RPC success payload from the tool containing the correctly grouped timeseries maps across multiple `rule_id`s.

## Design Decisions
- **Filter Mapping Parity**: Refactored the tool to only provide filters natively supported by the Last9 API, strictly mapping the query parameters directly without applying any post-processing pruning.
- **Refresh Tokens**: Added notes to the project's knowledge base (`gemini-local.md`) highlighting that the Last9 API utilizes refresh tokens that logically never expire, but short-lived access tokens require frequent exchange.
- **Strict JSON Schemas**: Refactored `jsonschema` struct tags to use the standardized string-only description format since the `mcp-go-sdk` wrapper rigidly panics on assignment operators (`=`).
