### PR TITLE
feat(logs): scoped log-attribute discovery (get_log_attributes_for_pipeline)

### DIFF
--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -12,6 +12,9 @@ const (
 
 	// Logs API endpoints
 	EndpointLogsQueryRange = "/logs/api/v2/query_range/json"
+	// EndpointLogsSeries returns the label-sets present for a given log pipeline.
+	// Used for pipeline-scoped attribute discovery.
+	EndpointLogsSeries = "/logs/api/v2/series/json"
 
 	// Prometheus API endpoints
 	EndpointPromQueryInstant = "/prom_query_instant"

--- a/internal/prompts/descriptions/get_logs.md
+++ b/internal/prompts/descriptions/get_logs.md
@@ -28,6 +28,7 @@ These are instructions for constructing a natural language logs analytics querie
    - If the user mentions a tenant name, map it to `resources['last9.tenant']`
    - If the user mentions a deployment environment (prod, staging, etc.), map it to `resources['deployment.environment']`
    - If the query scope is ambiguous (multiple tenants or environments exist in the discovered attributes but the user did not specify one), ask: "Which tenant/environment should I scope this to?"
+   - **When filtering on any field-level value:** `get_log_attributes` returns the global catalog, which can list keys that are empty for your scope and near-duplicate names that coexist. Do NOT assume a key name. After adding your scoping filter stage(s) — commonly a service, but it may be a namespace, environment, host, or any combination — call `get_log_attributes_for_pipeline` with that pipeline and use only the `filter_field` it returns for fields present within that scope. (Example: HTTP status is keyed `status_code` on some sources and `http.status_code` on others — neither is a safe default.)
 4. Translate the query to JSON pipeline format using the correct field references
 5. Call the `get_logs` tool with canonical time params:
    - Use `start_time_iso` + `end_time_iso` when the user gave explicit absolute dates/times
@@ -293,6 +294,17 @@ These are examples of pipeline json structure and available stages and functions
 
 ### Example 3: Status Code Filter (FILTER ONLY - NO AGGREGATION)
 **Natural Language:** "Get 5xx errors from the logs"
+
+> **Field names are not universal — confirm before filtering.** The same logical
+> value can be keyed differently across sources (HTTP status is `status_code` on
+> some and `http.status_code` on others), and the global `get_log_attributes`
+> catalog may list keys that are empty for your scope. Filtering on a key that
+> is not populated silently returns 0. Add your scoping filter stage(s) (commonly a
+> service, but it may be a namespace/environment/host/etc.), call
+> `get_log_attributes_for_pipeline`, and use the `filter_field` it returns. The
+> field shown in the example below is illustrative — substitute the one your
+> discovery step reports.
+
 **JSON:**
 ```json
 [{

--- a/internal/prompts/descriptions/get_service_logs.md
+++ b/internal/prompts/descriptions/get_service_logs.md
@@ -14,6 +14,8 @@ Use this tool to fetch raw log entries for a single service using simple filters
 
 Before using `body_filters`, call `get_log_attributes` to discover what structured attributes are available for the service. If the value you are filtering on is stored as a structured attribute, **prefer an attribute filter via `get_logs`** over a body text search.
 
+**Do not assume an attribute's key name** — which fields exist and how they're keyed depend on the scope you've filtered to (for example, HTTP status is keyed `status_code` on some sources and `http.status_code` on others; neither is a safe default). To get the field that is actually present for your scope, build a pipeline scoped to this service (e.g. `{"$eq":["ServiceName","<service>"]}`, plus any other filters such as namespace or environment), call `get_log_attributes_for_pipeline`, then use the `filter_field` it returns.
+
 Structured attribute queries are:
 - **Faster**: indexed, not a full-text scan
 - **More precise**: exact value match, not partial text

--- a/internal/telemetry/logs/series_attributes.go
+++ b/internal/telemetry/logs/series_attributes.go
@@ -1,0 +1,257 @@
+package logs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"last9-mcp/internal/constants"
+	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// GetLogAttributesForPipelineDescription describes the pipeline-scoped log attributes tool.
+const GetLogAttributesForPipelineDescription = `
+Returns the log fields that actually exist AFTER applying the given pipeline,
+each enriched with the exact filter_field string to use in a get_logs condition.
+
+Unlike get_log_attributes (which returns the global label catalog), this tool is
+scoped to your in-progress pipeline, so it only reports fields that are really
+present for that slice of logs.
+
+Use it before filtering on a structured attribute (HTTP status, etc.):
+1. First narrow with a filter stage, e.g. {"type":"filter","query":{"$eq":["ServiceName","<service>"]}}.
+2. Call this tool with that pipeline.
+3. Build your get_logs filter using only the filter_field values it returns.
+
+Do not assume any field's key name. Which fields exist and how they are keyed
+depend on the scope you have filtered to; the global get_log_attributes catalog
+can list keys that are empty for a given scope. Confirm the real field with this
+tool instead of guessing. (Example: HTTP status is keyed 'status_code' on some
+sources and 'http.status_code' on others — neither is a safe default.)
+
+Returns a JSON array sorted by name. Each entry has:
+  - name:         raw field name as present in the logs (e.g. "status_code")
+  - filter_field: exact string to use in a get_logs $eq/$gte/etc. condition
+                  (e.g. "attributes['status_code']", "ServiceName", "resources['k8s.namespace.name']")
+  - hint:         ready-made example condition using filter_field
+
+Use filter_field directly — do not transform it further.
+
+Defaults to the last 15 minutes if no time window is provided.
+
+Time format rules:
+- Prefer lookback_minutes for relative windows.
+- Use start_time_iso/end_time_iso for absolute windows.
+- start_time_iso/end_time_iso accept RFC3339/ISO8601 (e.g. 2026-02-09T15:04:05Z).
+- Legacy format YYYY-MM-DD HH:MM:SS is accepted only for compatibility.
+
+Index rules:
+- Pass index only when the user explicitly names a log index.
+- Accepted values are physical_index:<name> and rehydration_index:<block_name>.
+- Omit index when the user did not specify one.
+`
+
+// GetLogAttributesForPipelineArgs represents the input arguments for the
+// get_log_attributes_for_pipeline tool.
+type GetLogAttributesForPipelineArgs struct {
+	Pipeline        []map[string]interface{} `json:"pipeline,omitempty" jsonschema:"Pipeline of prior filter stages to scope discovery, e.g. [{\"type\":\"filter\",\"query\":{\"$eq\":[\"ServiceName\",\"<service>\"]}}] (required)"`
+	LookbackMinutes int                      `json:"lookback_minutes,omitempty" jsonschema:"Number of minutes to look back from now (default: 15, minimum: 1)"`
+	StartTimeISO    string                   `json:"start_time_iso,omitempty" jsonschema:"Start time in RFC3339/ISO8601 format (e.g. 2026-02-09T15:04:05Z)"`
+	EndTimeISO      string                   `json:"end_time_iso,omitempty" jsonschema:"End time in RFC3339/ISO8601 format (e.g. 2026-02-09T16:04:05Z)"`
+	Region          string                   `json:"region,omitempty" jsonschema:"Region to query (optional). Defaults to configured region."`
+	Index           string                   `json:"index,omitempty" jsonschema:"Optional log index in the form physical_index:<name> or rehydration_index:<block_name>. Omit this when the user did not specify an index."`
+}
+
+// logSeriesResponse represents the /logs/api/v2/series/json response. Each entry
+// in Data is a label-set; we only need its keys (the field names present).
+type logSeriesResponse struct {
+	Data   []map[string]json.RawMessage `json:"data"`
+	Status string                       `json:"status"`
+}
+
+// LogAttribute is an enriched attribute entry returned by
+// get_log_attributes_for_pipeline. filter_field is the exact string to use in a
+// logjson filter condition.
+type LogAttribute struct {
+	Name        string `json:"name"`
+	FilterField string `json:"filter_field"`
+	Hint        string `json:"hint"`
+}
+
+// logFieldFilterField maps a raw log field name to the exact filter_field string
+// used in a logjson condition:
+//   - service  -> ServiceName
+//   - severity -> SeverityText
+//   - body     -> Body
+//   - resource_x -> resources['x']
+//   - log_x      -> attributes['x']
+//   - default    -> attributes['<name>']
+func logFieldFilterField(name string) string {
+	switch name {
+	case "service":
+		return "ServiceName"
+	case "severity":
+		return "SeverityText"
+	case "body":
+		return "Body"
+	}
+	if rest, ok := strings.CutPrefix(name, "resource_"); ok {
+		return fmt.Sprintf("resources['%s']", rest)
+	}
+	if rest, ok := strings.CutPrefix(name, "log_"); ok {
+		return fmt.Sprintf("attributes['%s']", rest)
+	}
+	return fmt.Sprintf("attributes['%s']", name)
+}
+
+// fetchLogSeriesFieldNames POSTs the given pipeline to /logs/api/v2/series/json
+// and returns the union of field names present across all returned label-sets.
+func fetchLogSeriesFieldNames(ctx context.Context, client *http.Client, cfg models.Config, pipeline []map[string]interface{}, queryParams url.Values) ([]string, error) {
+	apiURL := fmt.Sprintf("%s%s?%s", cfg.APIBaseURL, constants.EndpointLogsSeries, queryParams.Encode())
+
+	requestBody := map[string]interface{}{
+		"pipeline": pipeline,
+	}
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %v", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", apiURL, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %v", err)
+	}
+
+	httpReq.Header.Set(constants.HeaderAccept, constants.HeaderAcceptJSON)
+	httpReq.Header.Set(constants.HeaderContentType, constants.HeaderContentTypeJSON)
+	httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+cfg.TokenManager.GetAccessToken(ctx))
+	httpReq.Header.Set(constants.HeaderUserAgent, constants.UserAgentLast9MCP)
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var errorBody map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&errorBody)
+		return nil, fmt.Errorf("API returned status %d: %v", resp.StatusCode, errorBody)
+	}
+
+	var result logSeriesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response for series api: %+v", err)
+	}
+
+	if result.Status != "success" {
+		return nil, fmt.Errorf("API returned non-success status: %s", result.Status)
+	}
+
+	// Union the keys across every label-set so a field present in any matching
+	// log is reported.
+	seen := map[string]struct{}{}
+	for _, entry := range result.Data {
+		for fieldName := range entry {
+			if fieldName == "" {
+				continue
+			}
+			seen[fieldName] = struct{}{}
+		}
+	}
+
+	names := make([]string, 0, len(seen))
+	for fieldName := range seen {
+		names = append(names, fieldName)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// NewGetLogAttributesForPipelineHandler creates a handler that returns the log
+// attributes present for a given pipeline, each enriched with its filter_field.
+func NewGetLogAttributesForPipelineHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetLogAttributesForPipelineArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args GetLogAttributesForPipelineArgs) (*mcp.CallToolResult, any, error) {
+		if len(args.Pipeline) == 0 {
+			return nil, nil, fmt.Errorf("pipeline parameter is required. Provide at least one filter stage to scope discovery, e.g. [{\"type\":\"filter\",\"query\":{\"$eq\":[\"ServiceName\",\"<service>\"]}}]")
+		}
+
+		params := make(map[string]interface{})
+		if args.LookbackMinutes > 0 {
+			params["lookback_minutes"] = args.LookbackMinutes
+		}
+		if args.StartTimeISO != "" {
+			params["start_time_iso"] = args.StartTimeISO
+		}
+		if args.EndTimeISO != "" {
+			params["end_time_iso"] = args.EndTimeISO
+		}
+
+		const defaultLogAttributesLookback = 15
+		startTimeParsed, endTimeParsed, err := utils.GetTimeRange(params, defaultLogAttributesLookback)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse time range: %w", err)
+		}
+		endTime := endTimeParsed.Unix()
+		startTime := startTimeParsed.Unix()
+		// Cap the window magnitude to keep server cost bounded, matching get_log_attributes.
+		maxWindowSeconds := int64(utils.MaxLogAttributeLookbackMinutes * 60)
+		if endTime-startTime > maxWindowSeconds {
+			startTime = endTime - maxWindowSeconds
+		}
+
+		region := cfg.Region
+		if args.Region != "" {
+			region = args.Region
+		}
+
+		normalizedIndex, err := utils.NormalizeLogIndex(args.Index)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid index: %w", err)
+		}
+
+		queryParams := url.Values{}
+		queryParams.Set("region", region)
+		queryParams.Set("start", fmt.Sprintf("%d", startTime))
+		queryParams.Set("end", fmt.Sprintf("%d", endTime))
+		if normalizedIndex != "" {
+			queryParams.Set("index", normalizedIndex)
+		}
+
+		names, err := fetchLogSeriesFieldNames(ctx, client, cfg, args.Pipeline, queryParams)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		out := make([]LogAttribute, 0, len(names))
+		for _, name := range names {
+			filterField := logFieldFilterField(name)
+			out = append(out, LogAttribute{
+				Name:        name,
+				FilterField: filterField,
+				Hint:        fmt.Sprintf("{\"$eq\":[\"%s\",\"<value>\"]}", filterField),
+			})
+		}
+
+		payload, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal attributes: %w", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: string(payload),
+				},
+			},
+		}, nil, nil
+	}
+}

--- a/internal/telemetry/logs/series_attributes.go
+++ b/internal/telemetry/logs/series_attributes.go
@@ -88,12 +88,15 @@ type LogAttribute struct {
 
 // logFieldFilterField maps a raw log field name to the exact filter_field string
 // used in a logjson condition:
-//   - service  -> ServiceName
-//   - severity -> SeverityText
-//   - body     -> Body
+//   - service    -> ServiceName
+//   - severity   -> SeverityText
+//   - body       -> Body
 //   - resource_x -> resources['x']
-//   - log_x      -> attributes['x']
 //   - default    -> attributes['<name>']
+//
+// The series endpoint returns log attributes bare (only resource attributes are
+// prefixed, with resource_), so a field name keeps its full name: e.g. a real
+// attribute named log_level maps to attributes['log_level'], not attributes['level'].
 func logFieldFilterField(name string) string {
 	switch name {
 	case "service":
@@ -105,9 +108,6 @@ func logFieldFilterField(name string) string {
 	}
 	if rest, ok := strings.CutPrefix(name, "resource_"); ok {
 		return fmt.Sprintf("resources['%s']", rest)
-	}
-	if rest, ok := strings.CutPrefix(name, "log_"); ok {
-		return fmt.Sprintf("attributes['%s']", rest)
 	}
 	return fmt.Sprintf("attributes['%s']", name)
 }

--- a/internal/telemetry/logs/series_attributes_test.go
+++ b/internal/telemetry/logs/series_attributes_test.go
@@ -1,0 +1,137 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func decodeLogAttributes(t *testing.T, res *mcp.CallToolResult) []LogAttribute {
+	t.Helper()
+	if res == nil || len(res.Content) == 0 {
+		t.Fatal("expected non-empty tool result content")
+	}
+	text, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", res.Content[0])
+	}
+	var attrs []LogAttribute
+	if err := json.Unmarshal([]byte(text.Text), &attrs); err != nil {
+		t.Fatalf("failed to unmarshal result: %v\nraw: %s", err, text.Text)
+	}
+	return attrs
+}
+
+// TestGetLogAttributesForPipeline_UsesSeriesEndpoint verifies the tool POSTs the
+// pipeline to /logs/api/v2/series/json and returns the union of field names from
+// all label-sets, each mapped to the correct filter_field.
+func TestGetLogAttributesForPipeline_UsesSeriesEndpoint(t *testing.T) {
+	var capturedPath, capturedMethod string
+	var capturedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedMethod = r.Method
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &capturedBody)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Two label-sets with overlapping + distinct keys to exercise the union.
+		_, _ = w.Write([]byte(`{"status":"success","data":[` +
+			`{"service":"checkout-service","status_code":"500","resource_k8s.namespace.name":"prod"},` +
+			`{"service":"checkout-service","uri":"/v1/orders"}` +
+			`]}`))
+	}))
+	defer server.Close()
+
+	cfg := testAttrConfig(server.URL)
+	handler := NewGetLogAttributesForPipelineHandler(server.Client(), cfg)
+
+	pipeline := []map[string]interface{}{
+		{"type": "filter", "query": map[string]interface{}{"$eq": []interface{}{"ServiceName", "checkout-service"}}},
+	}
+	res, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLogAttributesForPipelineArgs{
+		Pipeline:        pipeline,
+		LookbackMinutes: 30,
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	// Must POST to the series endpoint.
+	if capturedMethod != "POST" || !strings.Contains(capturedPath, "/logs/api/v2/series/json") {
+		t.Errorf("expected POST /logs/api/v2/series/json, got: %s %s", capturedMethod, capturedPath)
+	}
+
+	// Must forward the pipeline in the request body.
+	if capturedBody == nil || capturedBody["pipeline"] == nil {
+		t.Fatalf("expected pipeline forwarded in request body, got: %v", capturedBody)
+	}
+
+	// Union of keys, sorted, each with the correct filter_field.
+	got := map[string]string{}
+	for _, a := range decodeLogAttributes(t, res) {
+		got[a.Name] = a.FilterField
+	}
+
+	want := map[string]string{
+		"service":                     "ServiceName",
+		"status_code":                 "attributes['status_code']",
+		"resource_k8s.namespace.name": "resources['k8s.namespace.name']",
+		"uri":                         "attributes['uri']",
+	}
+	if len(got) != len(want) {
+		t.Errorf("expected %d unioned fields, got %d: %v", len(want), len(got), got)
+	}
+	for name, ff := range want {
+		if got[name] != ff {
+			t.Errorf("field %q: expected filter_field %q, got %q", name, ff, got[name])
+		}
+	}
+}
+
+// TestGetLogAttributesForPipeline_RequiresPipeline verifies the tool errors when
+// no pipeline is provided.
+func TestGetLogAttributesForPipeline_RequiresPipeline(t *testing.T) {
+	cfg := testAttrConfig("http://unused.example")
+	handler := NewGetLogAttributesForPipelineHandler(http.DefaultClient, cfg)
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLogAttributesForPipelineArgs{})
+	if err == nil {
+		t.Fatal("expected error when pipeline is empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "pipeline parameter is required") {
+		t.Errorf("expected pipeline-required error, got: %v", err)
+	}
+}
+
+// TestGetLogAttributesForPipeline_EmptyData verifies an empty series response
+// yields an empty attribute list (not an error).
+func TestGetLogAttributesForPipeline_EmptyData(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"success","data":[]}`))
+	}))
+	defer server.Close()
+
+	cfg := testAttrConfig(server.URL)
+	handler := NewGetLogAttributesForPipelineHandler(server.Client(), cfg)
+
+	res, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLogAttributesForPipelineArgs{
+		Pipeline: []map[string]interface{}{{"type": "filter", "query": map[string]interface{}{}}},
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if attrs := decodeLogAttributes(t, res); len(attrs) != 0 {
+		t.Errorf("expected empty attribute list, got: %v", attrs)
+	}
+}

--- a/internal/telemetry/logs/series_attributes_test.go
+++ b/internal/telemetry/logs/series_attributes_test.go
@@ -28,6 +28,31 @@ func decodeLogAttributes(t *testing.T, res *mcp.CallToolResult) []LogAttribute {
 	return attrs
 }
 
+// TestLogFieldFilterField locks the raw-name -> filter_field convention. In
+// particular, a real attribute whose name starts with "log_" must keep its full
+// name (log_level -> attributes['log_level']), not be stripped to attributes['level'].
+func TestLogFieldFilterField(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"service", "ServiceName"},
+		{"severity", "SeverityText"},
+		{"body", "Body"},
+		{"status_code", "attributes['status_code']"},
+		{"http.status_code", "attributes['http.status_code']"},
+		{"log_level", "attributes['log_level']"}, // must NOT become attributes['level']
+		{"log_id", "attributes['log_id']"},       // must NOT become attributes['id']
+		{"resource_container_name", "resources['container_name']"},
+		{"resource_k8s.namespace.name", "resources['k8s.namespace.name']"},
+	}
+	for _, c := range cases {
+		if got := logFieldFilterField(c.name); got != c.want {
+			t.Errorf("logFieldFilterField(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
 // TestGetLogAttributesForPipeline_UsesSeriesEndpoint verifies the tool POSTs the
 // pipeline to /logs/api/v2/series/json and returns the union of field names from
 // all label-sets, each mapped to the correct filter_field.

--- a/tools.go
+++ b/tools.go
@@ -183,6 +183,13 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCa
 		Description: logs.GetLogAttributesDescription,
 	}, logs.NewGetLogAttributesHandler(client, cfg))
 
+	// Register pipeline-scoped log attributes tool (discovers fields actually
+	// present for a given pipeline via the series endpoint)
+	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+		Name:        "get_log_attributes_for_pipeline",
+		Description: logs.GetLogAttributesForPipelineDescription,
+	}, logs.NewGetLogAttributesForPipelineHandler(client, cfg))
+
 	// Register trace attributes tool
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
 		Name:        "get_trace_attributes",


### PR DESCRIPTION
## Problem

When a query filters logs by a structured attribute (e.g. an HTTP status code), the model has to pick the attribute key to filter on. Today the only discovery tool, `get_log_attributes`, returns the **global** label catalog for the time window — every field that exists anywhere in the tenant.

That global set can include keys that are present for *some* services but **not populated for the specific service/scope being queried**, and near-duplicate names often coexist (e.g. one service keys HTTP status as `status_code`, while the global catalog also lists `http.status_code`, `StatusCode`, etc.). The model reasonably picks a plausible key — but if that key is empty for the target service, the filter **silently returns 0**, producing large undercounts that disagree with dashboards built on the field that's actually populated.

The discovery step is service-unaware, so a field that doesn't exist for the scope still looks like a valid choice.

## Fix

Add a new tool **`get_log_attributes_for_pipeline`** that mirrors how field discovery should be scoped:

- It accepts an in-progress `pipeline` (e.g. a `ServiceName` filter) and returns **only the fields actually present for that scope**, via the `/logs/api/v2/series/json` endpoint (union of keys across the matching series).
- Each field is returned enriched with the exact **`filter_field`** to drop straight into a `get_logs` condition — `ServiceName`, `resources['…']`, or `attributes['…']` — so the model never has to hand-build the reference or guess the key.

Tool description and the `get_logs` / `get_service_logs` instructions are updated to: scope by filter first, call `get_log_attributes_for_pipeline`, and use only the `filter_field` it returns — explicitly **not** assuming a key name (HTTP status, for instance, is keyed differently across sources).

## Why this is safe / additive

- New, read-only tool. No change to `get_log_attributes`, the global `/labels` path, the attribute cache, or the `get_logs` / `get_service_logs` handlers.
- Reuses the same request/auth/time-range patterns as the existing attribute and logs tools.

## Changes

- `internal/telemetry/logs/series_attributes.go` — new tool (handler, args, series fetch, `filter_field` mapping).
- `internal/telemetry/logs/series_attributes_test.go` — tests: series endpoint + body, key union, `filter_field` mapping, required-pipeline guard, empty-data.
- `internal/constants/api.go` — `EndpointLogsSeries`.
- `tools.go` — register the tool.
- `internal/prompts/descriptions/get_logs.md`, `get_service_logs.md` — discovery guidance (don't assume the key; confirm via the scoped tool).

## Testing

`go build ./...`, `go vet ./...`, and `go test ./internal/telemetry/logs/...` all pass. Verified live against the series endpoint: the scoped tool returns the populated field for a service while the global catalog still lists the absent one, and a subsequent `get_logs` on the discovered field returns the correct count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
