### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2026-06-08
 
 ### Added
 
+- `get_log_attributes_for_pipeline` tool for pipeline-scoped log-attribute discovery. Given an in-progress pipeline (e.g. a `ServiceName` filter), it returns only the log fields actually present for that scope via `/logs/api/v2/series/json`, each enriched with the exact `filter_field` to use in a `get_logs` condition. This prevents filtering on an attribute key that is empty for the queried service (e.g. assuming `http.status_code` when the service uses `status_code`), which silently returned 0 and caused large undercounts (#160).
 - `get_alert_rule_state` tool for historical firing state (1/0) per alert rule over a time range, grouped by `rule_id`. Supports server-side filtering by `alert_group_id`, `rule_name`, `alert_group_name`, `label_filters`, and `state` (#159).
 
 ## [0.7.5] - 2026-06-01

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
Release **v0.8.0** (minor — two new tools since v0.7.5).

## Changes since v0.7.5
- **`get_log_attributes_for_pipeline`** — pipeline-scoped log-attribute discovery; returns only fields present for the scope with the exact `filter_field`, so structured-attribute filters target the field that actually exists instead of an assumed/empty key. Also updates `get_logs`/`get_service_logs` guidance and fixes the `log_`-prefix mapping. (#160)
- **`get_alert_rule_state`** — historical firing state per alert rule with server-side filtering/grouping. (#159)

See `CHANGELOG.md` for details.

## Release checklist (auto on merge → `release.yaml`)
- [ ] `tag-and-release` — detects version change in `package.json`, tags `v0.8.0`, runs GoReleaser
- [ ] `publish-docker` — pushes image to ECR / registry (`v0.8.0`, `latest`)
- [ ] `publish-npm` — publishes `@last9/mcp-server@0.8.0`
- [ ] homebrew-tap dispatch — formula PR auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
