### PR TITLE
fix: tolerate LLM param-name mismatches with aliases and -32602 error hints

### DIFF
--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -37,6 +37,8 @@ type ServiceSummaryArgs struct {
 	EndTimeISO      string  `json:"end_time_iso,omitempty" jsonschema:"End time in RFC3339/ISO8601 format (e.g. 2024-06-01T13:00:00Z). Defaults to now when omitted."`
 	LookbackMinutes float64 `json:"lookback_minutes,omitempty" jsonschema:"Number of minutes to look back from now (default: 60, minimum: 1). Use for relative windows like last 30 minutes."`
 	Env             string  `json:"env,omitempty" jsonschema:"Environment to filter by (default: .*, e.g. prod)"`
+	ServiceName     string  `json:"service_name,omitempty" jsonschema:"Optional service name to filter the summary by (e.g. my-api). When omitted, returns all services."`
+	Service         string  `json:"service,omitempty" jsonschema:"Alias of service_name. Ignored when service_name is set."`
 }
 
 type ServiceEnvironmentsArgs struct {
@@ -87,6 +89,7 @@ type PromqlInstantQueryArgs struct {
 
 type PromqlLabelValuesArgs struct {
 	MatchQuery      string  `json:"match_query,omitempty" jsonschema:"PromQL query to match series (e.g. up{job=\"prometheus\"})"`
+	Match           string  `json:"match,omitempty" jsonschema:"Alias of match_query (matches the Prometheus API's match parameter). Ignored when match_query is set."`
 	Label           string  `json:"label" jsonschema:"Label name to get values for (required)"`
 	StartTimeISO    string  `json:"start_time_iso,omitempty" jsonschema:"Start time in RFC3339/ISO8601 format (e.g. 2024-06-01T12:00:00Z). Optional when lookback_minutes is provided."`
 	EndTimeISO      string  `json:"end_time_iso,omitempty" jsonschema:"End time in RFC3339/ISO8601 format (e.g. 2024-06-01T13:00:00Z). Defaults to now when omitted."`
@@ -96,6 +99,7 @@ type PromqlLabelValuesArgs struct {
 
 type PromqlLabelsArgs struct {
 	MatchQuery      string  `json:"match_query,omitempty" jsonschema:"PromQL query to match series (e.g. up{job=\"prometheus\"})"`
+	Match           string  `json:"match,omitempty" jsonschema:"Alias of match_query (matches the Prometheus API's match parameter). Ignored when match_query is set."`
 	StartTimeISO    string  `json:"start_time_iso,omitempty" jsonschema:"Start time in RFC3339/ISO8601 format (e.g. 2024-06-01T12:00:00Z). Optional when lookback_minutes is provided."`
 	EndTimeISO      string  `json:"end_time_iso,omitempty" jsonschema:"End time in RFC3339/ISO8601 format (e.g. 2024-06-01T13:00:00Z). Defaults to now when omitted."`
 	LookbackMinutes float64 `json:"lookback_minutes,omitempty" jsonschema:"Number of minutes to look back from now (default: 60, minimum: 1). Use for relative windows like last 30 minutes."`
@@ -162,6 +166,7 @@ const GetServiceSummaryDescription = `
 	- start_time_iso: (Optional) Start time of the time range in RFC3339/ISO8601 format (e.g. 2026-02-09T15:04:05Z). Overrides lookback when provided.
 	- end_time_iso: (Optional) End time of the time range in RFC3339/ISO8601 format (e.g. 2026-02-09T16:04:05Z). Defaults to current time.
 	- env: (Optional) Environment to filter by. If not provided, defaults to all environments.
+	- service_name: (Optional) Service name to filter by. Also accepted under the alias "service"; service_name wins when both are set. If not provided, returns all services.
 `
 
 func NewServiceSummaryHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, ServiceSummaryArgs) (*mcp.CallToolResult, any, error) {
@@ -176,13 +181,22 @@ func NewServiceSummaryHandler(client *http.Client, cfg models.Config) func(conte
 		if env == "" {
 			env = ".*" // default value
 		}
+		// Accept service filter under both service_name (canonical) and service (alias)
+		serviceFilter := args.ServiceName
+		if serviceFilter == "" {
+			serviceFilter = args.Service
+		}
+		if serviceFilter == "" {
+			serviceFilter = ".*" // default value
+		}
 		// get the value of service througputs using the query
 		// quantile_over_time(0.95, sum by (service_name)(trace_endpoint_count{service_name=~'.*', env=~'prod', span_kind=~'SPAN_KIND_SERVER|SPAN_KIND_CLIENT'})[30m])
 		// add the filter values in the promql from the filterParams
 		// Build PromQL filter string from filterParams
 		// Build PromQL query
 		promql := fmt.Sprintf(
-			"quantile_over_time(0.95, sum by (service_name)(trace_endpoint_count{env=~'%s', span_kind='SPAN_KIND_SERVER'}[%dm]))",
+			"quantile_over_time(0.95, sum by (service_name)(trace_endpoint_count{service_name=~'%s', env=~'%s', span_kind='SPAN_KIND_SERVER'}[%dm]))",
+			serviceFilter,
 			env,
 			int((endTimeParam-startTimeParam)/60),
 		)
@@ -232,7 +246,8 @@ func NewServiceSummaryHandler(client *http.Client, cfg models.Config) func(conte
 		}
 		// Make another prom_query_instant call for response time
 		respTimePromql := fmt.Sprintf(
-			"quantile_over_time(0.95, sum by (service_name)(trace_service_response_time{quantile=\"p95\", env=~'%s'}[%dm]))",
+			"quantile_over_time(0.95, sum by (service_name)(trace_service_response_time{quantile=\"p95\", service_name=~'%s', env=~'%s'}[%dm]))",
+			serviceFilter,
 			env,
 			int((endTimeParam-startTimeParam)/60),
 		)
@@ -270,7 +285,8 @@ func NewServiceSummaryHandler(client *http.Client, cfg models.Config) func(conte
 		}
 		// Make another prom_query_instant call for error rate
 		errorRateQuery := fmt.Sprintf(
-			"quantile_over_time(0.95, sum by (service_name)(trace_endpoint_count{env=~'%s', span_kind=~'SPAN_KIND_SERVER', http_status_code=~\"5.*\"}[%dm]))",
+			"quantile_over_time(0.95, sum by (service_name)(trace_endpoint_count{service_name=~'%s', env=~'%s', span_kind=~'SPAN_KIND_SERVER', http_status_code=~\"5.*\"}[%dm]))",
+			serviceFilter,
 			env,
 			int((endTimeParam-startTimeParam)/60),
 		)
@@ -2097,7 +2113,7 @@ const PromqlLabelValuesQueryDetails = `
 	This works similar to the prometheus /label_values call
 	It returns an array of values for the label.
 	Parameters:
-	- match_query: (Required) A valid promql filter query
+	- match_query: (Required) A valid promql filter query. Also accepted under the alias "match"; match_query wins when both are set.
 	- label: (Required) Name of the label to return values for
 	- lookback_minutes: (Optional) Number of minutes to look back from now. Defaults to 60.
 	- start_time_iso: (Optional) Start time of the time range in RFC3339/ISO8601 format (e.g. 2026-02-09T15:04:05Z). Overrides lookback when provided.
@@ -2113,6 +2129,9 @@ const PromqlLabelValuesQueryDetails = `
 func NewPromqlLabelValuesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, PromqlLabelValuesArgs) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, args PromqlLabelValuesArgs) (*mcp.CallToolResult, any, error) {
 		query := args.MatchQuery
+		if query == "" {
+			query = args.Match
+		}
 		if query == "" {
 			return nil, nil, fmt.Errorf("match_query is required")
 		}
@@ -2164,7 +2183,7 @@ const PromqlLabelsQueryDetails = `
 	This works similar to the prometheus /labels call
 	It returns an array of labels.
 	Parameters:
-	- match_query: (Required) A valid promql filter query
+	- match_query: (Required) A valid promql filter query. Also accepted under the alias "match"; match_query wins when both are set.
 	- lookback_minutes: (Optional) Number of minutes to look back from now. Defaults to 60.
 	- start_time_iso: (Optional) Start time of the time range in RFC3339/ISO8601 format (e.g. 2026-02-09T15:04:05Z). Overrides lookback when provided.
 	- end_time_iso: (Optional) End time of the time range in RFC3339/ISO8601 format (e.g. 2026-02-09T16:04:05Z). Defaults to current time.
@@ -2179,6 +2198,9 @@ const PromqlLabelsQueryDetails = `
 func NewPromqlLabelsHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, PromqlLabelsArgs) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, args PromqlLabelsArgs) (*mcp.CallToolResult, any, error) {
 		query := args.MatchQuery
+		if query == "" {
+			query = args.Match
+		}
 		if query == "" {
 			return nil, nil, fmt.Errorf("match_query is required")
 		}

--- a/internal/apm/apm_test.go
+++ b/internal/apm/apm_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-
 func TestNewServiceSummaryHandler_ExtraParams(t *testing.T) {
 	// Mock responses should match apiPromInstantResp format (direct array)
 	throughputResp := `[
@@ -653,4 +652,124 @@ func TestNewListDatasourcesHandler(t *testing.T) {
 			t.Errorf("empty list text = %q, want []", textContent.Text)
 		}
 	})
+}
+
+func TestNewPromqlLabelValuesHandler_MatchAlias(t *testing.T) {
+	var captured []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Matches []string `json:"matches"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		captured = body.Matches
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `[]`)
+	}))
+	defer server.Close()
+
+	cfg := models.Config{APIBaseURL: server.URL, Region: "us-east-1"}
+	cfg.TokenManager = &auth.TokenManager{
+		AccessToken: "mock-access-token-for-testing",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	handler := NewPromqlLabelValuesHandler(server.Client(), cfg)
+
+	cases := []struct {
+		name string
+		args PromqlLabelValuesArgs
+		want string
+	}{
+		{"match alias used when match_query empty", PromqlLabelValuesArgs{Match: "up", Label: "job"}, "up"},
+		{"match_query wins over match", PromqlLabelValuesArgs{MatchQuery: "canonical", Match: "alias", Label: "job"}, "canonical"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			captured = nil
+			_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, tc.args)
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			if len(captured) == 0 || captured[0] != tc.want {
+				t.Fatalf("backend received matches %v, want [%q]", captured, tc.want)
+			}
+		})
+	}
+
+	t.Run("neither match nor match_query errors", func(t *testing.T) {
+		_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, PromqlLabelValuesArgs{Label: "job"})
+		if err == nil || !strings.Contains(err.Error(), "match_query is required") {
+			t.Fatalf("expected match_query required error, got: %v", err)
+		}
+	})
+}
+
+func TestNewPromqlLabelsHandler_MatchAlias(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `[]`)
+	}))
+	defer server.Close()
+
+	cfg := models.Config{APIBaseURL: server.URL, Region: "us-east-1"}
+	cfg.TokenManager = &auth.TokenManager{
+		AccessToken: "mock-access-token-for-testing",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	handler := NewPromqlLabelsHandler(server.Client(), cfg)
+
+	if _, _, err := handler(context.Background(), &mcp.CallToolRequest{}, PromqlLabelsArgs{Match: "up"}); err != nil {
+		t.Fatalf("match alias should satisfy required match query, got: %v", err)
+	}
+	if _, _, err := handler(context.Background(), &mcp.CallToolRequest{}, PromqlLabelsArgs{}); err == nil {
+		t.Fatal("expected error when neither match nor match_query set")
+	}
+}
+
+func TestNewServiceSummaryHandler_ServiceFilter(t *testing.T) {
+	var queries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Query string `json:"query"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		queries = append(queries, body.Query)
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `[]`)
+	}))
+	defer server.Close()
+
+	cfg := models.Config{APIBaseURL: server.URL, Region: "us-east-1"}
+	cfg.TokenManager = &auth.TokenManager{
+		AccessToken: "mock-access-token-for-testing",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	handler := NewServiceSummaryHandler(server.Client(), cfg)
+
+	cases := []struct {
+		name string
+		args ServiceSummaryArgs
+		want string
+	}{
+		{"service_name filters queries", ServiceSummaryArgs{ServiceName: "svc1"}, "service_name=~'svc1'"},
+		{"service alias filters queries", ServiceSummaryArgs{Service: "svc2"}, "service_name=~'svc2'"},
+		{"service_name wins over service", ServiceSummaryArgs{ServiceName: "canonical", Service: "alias"}, "service_name=~'canonical'"},
+		{"omitted defaults to all services", ServiceSummaryArgs{}, "service_name=~'.*'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			queries = nil
+			_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, tc.args)
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			if len(queries) == 0 {
+				t.Fatal("backend received no queries")
+			}
+			for _, q := range queries {
+				if !strings.Contains(q, tc.want) {
+					t.Fatalf("query %q missing filter %q", q, tc.want)
+				}
+			}
+		})
+	}
 }

--- a/internal/apm/apm_test.go
+++ b/internal/apm/apm_test.go
@@ -843,7 +843,10 @@ func TestNewServiceSummaryHandler_ServiceFilter_Integration(t *testing.T) {
 		return
 	}
 	var all map[string]ServiceSummary
-	if err := json.Unmarshal([]byte(utils.GetTextContent(t, unfiltered)), &all); err != nil || len(all) == 0 {
+	if err := json.Unmarshal([]byte(utils.GetTextContent(t, unfiltered)), &all); err != nil {
+		t.Fatalf("unfiltered response not JSON: %v", err)
+	}
+	if len(all) == 0 {
 		t.Skip("no services in window; cannot exercise the filter")
 	}
 

--- a/internal/apm/apm_test.go
+++ b/internal/apm/apm_test.go
@@ -775,3 +775,105 @@ func TestNewServiceSummaryHandler_ServiceFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestPromqlLabelValuesHandler_MatchAlias_Integration(t *testing.T) {
+	cfg := utils.SetupTestConfigOrSkip(t)
+
+	handler := NewPromqlLabelValuesHandler(http.DefaultClient, *cfg)
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+	start := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	end := time.Now().UTC().Format(time.RFC3339)
+
+	canonical, _, err := handler(ctx, req, PromqlLabelValuesArgs{
+		MatchQuery: "up", Label: "job", StartTimeISO: start, EndTimeISO: end,
+	})
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+	aliased, _, err := handler(ctx, req, PromqlLabelValuesArgs{
+		Match: "up", Label: "job", StartTimeISO: start, EndTimeISO: end,
+	})
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+
+	canonicalText := utils.GetTextContent(t, canonical)
+	aliasedText := utils.GetTextContent(t, aliased)
+	if canonicalText != aliasedText {
+		t.Fatalf("alias and canonical param returned different results:\ncanonical: %s\nalias: %s", canonicalText, aliasedText)
+	}
+	t.Logf("Integration test successful: match alias returns identical results to match_query")
+}
+
+func TestPromqlLabelsHandler_MatchAlias_Integration(t *testing.T) {
+	cfg := utils.SetupTestConfigOrSkip(t)
+
+	handler := NewPromqlLabelsHandler(http.DefaultClient, *cfg)
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+	result, _, err := handler(ctx, req, PromqlLabelsArgs{
+		Match:        "up",
+		StartTimeISO: time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339),
+		EndTimeISO:   time.Now().UTC().Format(time.RFC3339),
+	})
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+	text := utils.GetTextContent(t, result)
+	if text == "" {
+		t.Fatal("expected non-empty labels response via match alias")
+	}
+	t.Logf("Integration test successful: match alias accepted by prometheus_labels")
+}
+
+func TestNewServiceSummaryHandler_ServiceFilter_Integration(t *testing.T) {
+	cfg := utils.SetupTestConfigOrSkip(t)
+
+	handler := NewServiceSummaryHandler(http.DefaultClient, *cfg)
+	ctx := context.Background()
+	req := &mcp.CallToolRequest{}
+	args := ServiceSummaryArgs{
+		StartTimeISO: time.Now().Add(-60 * time.Minute).UTC().Format(time.RFC3339),
+		EndTimeISO:   time.Now().UTC().Format(time.RFC3339),
+	}
+
+	unfiltered, _, err := handler(ctx, req, args)
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+	var all map[string]ServiceSummary
+	if err := json.Unmarshal([]byte(utils.GetTextContent(t, unfiltered)), &all); err != nil || len(all) == 0 {
+		t.Skip("no services in window; cannot exercise the filter")
+	}
+
+	var target string
+	for name := range all {
+		if name != "" {
+			target = name
+			break
+		}
+	}
+	if target == "" {
+		t.Skip("only empty service names in window")
+	}
+
+	args.ServiceName = target
+	filtered, _, err := handler(ctx, req, args)
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+	var got map[string]ServiceSummary
+	if err := json.Unmarshal([]byte(utils.GetTextContent(t, filtered)), &got); err != nil {
+		t.Fatalf("filtered response not JSON: %v", err)
+	}
+	for name := range got {
+		if name != target {
+			t.Fatalf("filter service_name=%q leaked service %q", target, name)
+		}
+	}
+	if _, ok := got[target]; !ok {
+		t.Fatalf("filter service_name=%q returned no entry for it: %v", target, got)
+	}
+	t.Logf("Integration test successful: filter restricted summary to %q (%d of %d services)", target, len(got), len(all))
+}

--- a/internal/apm/apm_test.go
+++ b/internal/apm/apm_test.go
@@ -734,7 +734,9 @@ func TestNewServiceSummaryHandler_ServiceFilter(t *testing.T) {
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		queries = append(queries, body.Query)
 		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, `[]`)
+		// Non-empty result so the handler proceeds past the throughput query
+		// and issues all three queries (empty throughput short-circuits).
+		io.WriteString(w, `[{"metric":{"service_name":"svc1"},"value":[1687600000,"10"]}]`)
 	}))
 	defer server.Close()
 
@@ -762,8 +764,8 @@ func TestNewServiceSummaryHandler_ServiceFilter(t *testing.T) {
 			if err != nil {
 				t.Fatalf("handler error: %v", err)
 			}
-			if len(queries) == 0 {
-				t.Fatal("backend received no queries")
+			if len(queries) != 3 {
+				t.Fatalf("expected 3 queries (throughput, response time, error rate), got %d: %v", len(queries), queries)
 			}
 			for _, q := range queries {
 				if !strings.Contains(q, tc.want) {

--- a/internal/paramhint/paramhint.go
+++ b/internal/paramhint/paramhint.go
@@ -1,0 +1,174 @@
+// Package paramhint enriches MCP schema-validation errors (-32602
+// "unexpected additional properties") with the tool's valid parameter list
+// and a single did-you-mean suggestion, so LLM clients can self-correct
+// instead of burning calls on opaque rejections.
+package paramhint
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Registry maps tool names to their valid top-level parameter names.
+type Registry struct {
+	params map[string][]string
+}
+
+func NewRegistry() *Registry {
+	return &Registry{params: make(map[string][]string)}
+}
+
+// Register records the valid parameter names for a tool.
+func (r *Registry) Register(toolName string, params []string) {
+	sorted := append([]string(nil), params...)
+	sort.Strings(sorted)
+	r.params[toolName] = sorted
+}
+
+// ParamsOf derives the top-level parameter names from a tool's typed
+// argument struct, using the same schema inference the SDK applies.
+func ParamsOf[In any]() []string {
+	schema, err := jsonschema.For[In](nil)
+	if err != nil || schema == nil {
+		return nil
+	}
+	names := make([]string, 0, len(schema.Properties))
+	for name := range schema.Properties {
+		names = append(names, name)
+	}
+	return names
+}
+
+// quoted matches the Go %q-rendered key names inside the jsonschema-go
+// validation error: unexpected additional properties ["match" "foo"].
+var quoted = regexp.MustCompile(`"([^"]+)"`)
+
+// offendingKeys extracts the rejected property names from the validation
+// error text produced by jsonschema-go.
+func offendingKeys(errText string) []string {
+	idx := strings.Index(errText, "unexpected additional properties")
+	if idx < 0 {
+		return nil
+	}
+	tail := errText[idx:]
+	if end := strings.Index(tail, "]"); end >= 0 {
+		tail = tail[:end+1]
+	}
+	var keys []string
+	for _, m := range quoted.FindAllStringSubmatch(tail, -1) {
+		keys = append(keys, m[1])
+	}
+	return keys
+}
+
+// suggest returns the single closest valid parameter for an unknown key, or
+// "" when no candidate is unambiguously close (distance must be small
+// relative to key length). One suggestion only — repo convention.
+func suggest(key string, valid []string) string {
+	best := ""
+	bestDist := -1
+	for _, v := range valid {
+		d := levenshtein(strings.ToLower(key), strings.ToLower(v))
+		if bestDist == -1 || d < bestDist {
+			best, bestDist = v, d
+		}
+	}
+	if best == "" {
+		return ""
+	}
+	limit := len(key) / 3
+	if limit < 2 {
+		limit = 2
+	}
+	if bestDist > limit {
+		return ""
+	}
+	return best
+}
+
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+func min3(a, b, c int) int {
+	if b < a {
+		a = b
+	}
+	if c < a {
+		a = c
+	}
+	return a
+}
+
+// Hint builds the recovery hint for a failed tools/call, or "" when the
+// error is not an unknown-parameter rejection or the tool is unregistered.
+func (r *Registry) Hint(toolName, errText string) string {
+	valid, ok := r.params[toolName]
+	if !ok || len(valid) == 0 {
+		return ""
+	}
+	keys := offendingKeys(errText)
+	if len(keys) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, key := range keys {
+		if s := suggest(key, valid); s != "" {
+			fmt.Fprintf(&b, " Unknown parameter %q — did you mean %q?", key, s)
+			break // one suggestion only
+		}
+	}
+	fmt.Fprintf(&b, " Valid parameters for %s: %s.", toolName, strings.Join(valid, ", "))
+	return b.String()
+}
+
+// Middleware intercepts failed tools/call requests and appends the recovery
+// hint to schema-validation errors. All other traffic passes through
+// untouched.
+func Middleware(r *Registry) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			res, err := next(ctx, method, req)
+			if err == nil || method != "tools/call" {
+				return res, err
+			}
+			if !strings.Contains(err.Error(), "unexpected additional properties") {
+				return res, err
+			}
+			params, ok := req.GetParams().(*mcp.CallToolParamsRaw)
+			if !ok {
+				return res, err
+			}
+			hint := r.Hint(params.Name, err.Error())
+			if hint == "" {
+				return res, err
+			}
+			return res, fmt.Errorf("%w%s", err, hint)
+		}
+	}
+}

--- a/internal/paramhint/paramhint.go
+++ b/internal/paramhint/paramhint.go
@@ -10,13 +10,17 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // Registry maps tool names to their valid top-level parameter names.
+// Registration re-runs periodically (description refresh loop in main), so
+// writes can race in-flight reads from the middleware — guard both.
 type Registry struct {
+	mu     sync.RWMutex
 	params map[string][]string
 }
 
@@ -28,7 +32,9 @@ func NewRegistry() *Registry {
 func (r *Registry) Register(toolName string, params []string) {
 	sorted := append([]string(nil), params...)
 	sort.Strings(sorted)
+	r.mu.Lock()
 	r.params[toolName] = sorted
+	r.mu.Unlock()
 }
 
 // ParamsOf derives the top-level parameter names from a tool's typed
@@ -128,7 +134,9 @@ func min3(a, b, c int) int {
 // Hint builds the recovery hint for a failed tools/call, or "" when the
 // error is not an unknown-parameter rejection or the tool is unregistered.
 func (r *Registry) Hint(toolName, errText string) string {
+	r.mu.RLock()
 	valid, ok := r.params[toolName]
+	r.mu.RUnlock()
 	if !ok || len(valid) == 0 {
 		return ""
 	}

--- a/internal/paramhint/paramhint_test.go
+++ b/internal/paramhint/paramhint_test.go
@@ -1,0 +1,88 @@
+package paramhint
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOffendingKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		err  string
+		want []string
+	}{
+		{
+			"single key",
+			`calling "tools/call": invalid params: validating "arguments": validating root: unexpected additional properties ["match"]`,
+			[]string{"match"},
+		},
+		{
+			"multiple keys",
+			`validating root: unexpected additional properties ["foo" "bar"]`,
+			[]string{"foo", "bar"},
+		},
+		{
+			"unrelated error",
+			"connection refused",
+			nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := offendingKeys(tc.err)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got %v, want %v", got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestSuggest(t *testing.T) {
+	valid := []string{"service_name", "env", "lookback_minutes"}
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{"servicename", "service_name"},
+		{"service_nme", "service_name"},
+		{"frobnicate", ""},
+		{"ENV", "env"},
+	}
+	for _, tc := range cases {
+		if got := suggest(tc.key, valid); got != tc.want {
+			t.Errorf("suggest(%q) = %q, want %q", tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestHint(t *testing.T) {
+	r := NewRegistry()
+	r.Register("get_service_summary", []string{"service_name", "service", "env", "lookback_minutes", "start_time_iso", "end_time_iso"})
+
+	t.Run("near match gets one suggestion plus param list", func(t *testing.T) {
+		h := r.Hint("get_service_summary", `unexpected additional properties ["servicename"]`)
+		if !strings.Contains(h, `did you mean "service_name"`) {
+			t.Fatalf("missing suggestion: %s", h)
+		}
+		if !strings.Contains(h, "Valid parameters for get_service_summary") {
+			t.Fatalf("missing param list: %s", h)
+		}
+	})
+
+	t.Run("unregistered tool yields no hint", func(t *testing.T) {
+		if h := r.Hint("nope", `unexpected additional properties ["x"]`); h != "" {
+			t.Fatalf("expected empty hint, got: %s", h)
+		}
+	})
+
+	t.Run("non-validation error yields no hint", func(t *testing.T) {
+		if h := r.Hint("get_service_summary", "boom"); h != "" {
+			t.Fatalf("expected empty hint, got: %s", h)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -176,6 +176,10 @@ func main() {
 		}
 	}
 
+	// Attach -32602 param-hint middleware once; registerAllTools re-runs on
+	// refresh and must not stack additional copies.
+	AttachParamHintMiddleware(server)
+
 	// Register all tools
 	if err := registerAllTools(server, cfg, attrCache); err != nil {
 		log.Fatalf("failed to register tools: %v", err)

--- a/schema_validation_test.go
+++ b/schema_validation_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/attributes"
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/models"
+
+	last9mcp "github.com/last9/mcp-go-sdk/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// newTestSession spins up the full MCP server with all tools registered and
+// connects a client over in-memory transports, so calls exercise the SDK's
+// schema validation layer (which direct handler invocation bypasses).
+func newTestSession(t *testing.T) *mcp.ClientSession {
+	t.Helper()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, "[]")
+	}))
+	t.Cleanup(backend.Close)
+
+	cfg := models.Config{
+		APIBaseURL: backend.URL,
+		Region:     "us-east-1",
+	}
+	cfg.TokenManager = &auth.TokenManager{
+		AccessToken: "mock-access-token-for-testing",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+
+	server, err := last9mcp.NewServerWithOptions("last9-mcp-test", "0.0.0", last9mcp.WithSkipProviderInit())
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+
+	attrCache := attributes.NewAttributeCache(backend.Client(), cfg)
+	if err := registerAllTools(server, cfg, attrCache); err != nil {
+		t.Fatalf("failed to register tools: %v", err)
+	}
+
+	ctx := context.Background()
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("failed to connect server: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("failed to connect client: %v", err)
+	}
+	t.Cleanup(func() { session.Close() })
+	return session
+}
+
+// failIfSchemaRejected fails the test when the call was rejected by JSON
+// schema validation ("unexpected additional properties"). Handler-level
+// errors are acceptable — the assertion targets the validation layer only.
+func failIfSchemaRejected(t *testing.T, res *mcp.CallToolResult, err error) {
+	t.Helper()
+	if err != nil && strings.Contains(err.Error(), "unexpected additional properties") {
+		t.Fatalf("call rejected by schema validation: %v", err)
+	}
+	if res != nil && res.IsError {
+		for _, c := range res.Content {
+			if tc, ok := c.(*mcp.TextContent); ok && strings.Contains(tc.Text, "unexpected additional properties") {
+				t.Fatalf("call rejected by schema validation: %s", tc.Text)
+			}
+		}
+	}
+}
+
+// TestToolCall_ParamAliases reproduces the two wrong-param calls observed
+// from Cursor agents: `match` instead of `match_query`, and `service` on
+// get_service_summary which declared no service parameter at all.
+func TestToolCall_ParamAliases(t *testing.T) {
+	session := newTestSession(t)
+	ctx := context.Background()
+
+	t.Run("prometheus_label_values accepts match alias", func(t *testing.T) {
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name: "prometheus_label_values",
+			Arguments: map[string]any{
+				"label": "service",
+				"match": `{l9_event_name="last9_scheduled_search"}`,
+			},
+		})
+		failIfSchemaRejected(t, res, err)
+	})
+
+	t.Run("prometheus_labels accepts match alias", func(t *testing.T) {
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name: "prometheus_labels",
+			Arguments: map[string]any{
+				"match": `{l9_event_name="last9_scheduled_search"}`,
+			},
+		})
+		failIfSchemaRejected(t, res, err)
+	})
+
+	t.Run("get_service_summary accepts service", func(t *testing.T) {
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "get_service_summary",
+			Arguments: map[string]any{"service": "cartlyst-python"},
+		})
+		failIfSchemaRejected(t, res, err)
+	})
+
+	t.Run("get_service_summary accepts service_name", func(t *testing.T) {
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "get_service_summary",
+			Arguments: map[string]any{"service_name": "cartlyst-python"},
+		})
+		failIfSchemaRejected(t, res, err)
+	})
+}
+
+// TestToolCall_UnknownParamHint asserts that genuinely unknown parameters
+// are still rejected (additionalProperties stays strict) and that the error
+// is recoverable: it names valid parameters and offers a did-you-mean
+// suggestion when an unambiguous near-match exists.
+func TestToolCall_UnknownParamHint(t *testing.T) {
+	session := newTestSession(t)
+	ctx := context.Background()
+
+	t.Run("near-match key gets one suggestion", func(t *testing.T) {
+		_, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "get_service_summary",
+			Arguments: map[string]any{"servicename": "cartlyst-python"},
+		})
+		if err == nil {
+			t.Fatal("expected schema validation error for unknown key, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "unexpected additional properties") {
+			t.Fatalf("expected strict validation to stay in force, got: %s", msg)
+		}
+		if !strings.Contains(msg, `did you mean "service_name"`) {
+			t.Fatalf("expected did-you-mean suggestion for service_name, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Valid parameters") {
+			t.Fatalf("expected valid parameter list in error, got: %s", msg)
+		}
+	})
+
+	t.Run("no near-match key gets param list without suggestion", func(t *testing.T) {
+		_, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "get_service_summary",
+			Arguments: map[string]any{"frobnicate": 1},
+		})
+		if err == nil {
+			t.Fatal("expected schema validation error for unknown key, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "Valid parameters") {
+			t.Fatalf("expected valid parameter list in error, got: %s", msg)
+		}
+		if strings.Contains(msg, "did you mean") {
+			t.Fatalf("expected no suggestion for a far-off key, got: %s", msg)
+		}
+	})
+}

--- a/schema_validation_test.go
+++ b/schema_validation_test.go
@@ -43,9 +43,14 @@ func newTestSession(t *testing.T) *mcp.ClientSession {
 		t.Fatalf("failed to create server: %v", err)
 	}
 
+	AttachParamHintMiddleware(server)
 	attrCache := attributes.NewAttributeCache(backend.Client(), cfg)
-	if err := registerAllTools(server, cfg, attrCache); err != nil {
-		t.Fatalf("failed to register tools: %v", err)
+	// Register twice to mirror the production description-refresh loop
+	// (main.go re-runs registerAllTools every 2h): hints must not duplicate.
+	for i := 0; i < 2; i++ {
+		if err := registerAllTools(server, cfg, attrCache); err != nil {
+			t.Fatalf("failed to register tools: %v", err)
+		}
 	}
 
 	ctx := context.Background()
@@ -150,6 +155,9 @@ func TestToolCall_UnknownParamHint(t *testing.T) {
 		}
 		if !strings.Contains(msg, "Valid parameters") {
 			t.Fatalf("expected valid parameter list in error, got: %s", msg)
+		}
+		if n := strings.Count(msg, "Valid parameters"); n != 1 {
+			t.Fatalf("hint duplicated %d times (middleware stacked across re-registration?): %s", n, msg)
 		}
 	})
 

--- a/tools.go
+++ b/tools.go
@@ -10,6 +10,7 @@ import (
 	"last9-mcp/internal/change_events"
 	"last9-mcp/internal/dashboards"
 	"last9-mcp/internal/models"
+	"last9-mcp/internal/paramhint"
 	"last9-mcp/internal/prompts"
 	"last9-mcp/internal/suggest"
 	"last9-mcp/internal/telemetry/logs"
@@ -33,9 +34,18 @@ func buildEnhancedDescription(base, instructions string, labelValues []string) s
 	return desc
 }
 
+// registerTool registers a tool and records its valid parameter names so the
+// paramhint middleware can build recovery hints for schema-validation errors.
+func registerTool[In, Out any](server *last9mcp.Last9MCPServer, reg *paramhint.Registry, tool *mcp.Tool, handler mcp.ToolHandlerFor[In, Out]) error {
+	reg.Register(tool.Name, paramhint.ParamsOf[In]())
+	return last9mcp.RegisterInstrumentedTool(server, tool, handler)
+}
+
 // registerAllTools registers all tools with the MCP server using the new SDK pattern
 func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCache *attributes.AttributeCache) error {
 	client := auth.GetHTTPClient()
+	reg := paramhint.NewRegistry()
+	server.Server.AddReceivingMiddleware(paramhint.Middleware(reg))
 
 	// Build enhanced descriptions for tools that have embedded instructions
 	getLogsDesc := buildEnhancedDescription(logs.GetLogsDescription, prompts.GetLogsInstructions, attrCache.GetLogAttributes())
@@ -45,221 +55,221 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCa
 	getMetricsDesc := buildEnhancedDescription(apm.PromqlRangeQueryDetails, prompts.GetMetricsInstructions, nil)
 
 	// Register exceptions tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_exceptions",
 		Description: prompts.GetExceptionsInstructions,
 	}, traces.NewGetExceptionsHandler(client, cfg))
 
 	// Register service summary tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_service_summary",
 		Description: apm.GetServiceSummaryDescription,
 	}, apm.NewServiceSummaryHandler(client, cfg))
 
 	// Register service environments tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_service_environments",
 		Description: apm.GetServiceEnvironmentsDescription,
 	}, apm.NewServiceEnvironmentsHandler(client, cfg))
 
 	// Register service performance details tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_service_performance_details",
 		Description: apm.GetServicePerformanceDetails,
 	}, apm.NewServicePerformanceDetailsHandler(client, cfg))
 
 	// Register service operations summary tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_service_operations_summary",
 		Description: apm.GetServiceOperationsSummaryDescription,
 	}, apm.NewServiceOperationsSummaryHandler(client, cfg))
 
 	// Register service dependency graph tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_service_dependency_graph",
 		Description: apm.GetServiceDependencyGraphDetails,
 	}, apm.NewServiceDependencyGraphHandler(client, cfg))
 
 	// Register list datasources tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "list_datasources",
 		Description: apm.ListDatasourcesDescription,
 	}, apm.NewListDatasourcesHandler(cfg))
 
 	// Register PromQL range query tool (enhanced with metrics instructions)
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "prometheus_range_query",
 		Description: getMetricsDesc,
 	}, apm.NewPromqlRangeQueryHandler(client, cfg))
 
 	// Register PromQL instant query tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "prometheus_instant_query",
 		Description: apm.PromqlInstantQueryDetails,
 	}, apm.NewPromqlInstantQueryHandler(client, cfg))
 
 	// Register PromQL label values tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "prometheus_label_values",
 		Description: apm.PromqlLabelValuesQueryDetails,
 	}, apm.NewPromqlLabelValuesHandler(client, cfg))
 
 	// Register PromQL labels tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "prometheus_labels",
 		Description: apm.PromqlLabelsQueryDetails,
 	}, apm.NewPromqlLabelsHandler(client, cfg))
 
 	// Register logs tool (enhanced with log query instructions + labels)
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_logs",
 		Description: getLogsDesc,
 	}, logs.NewGetLogsHandler(client, cfg))
 
 	// Register service logs tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_service_logs",
 		Description: getServiceLogsDesc,
 	}, logs.NewGetServiceLogsHandler(client, cfg))
 
 	// Register drop rules tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_drop_rules",
 		Description: logs.GetDropRulesDescription,
 	}, logs.NewGetDropRulesHandler(client, cfg))
 
 	// Register add drop rule tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "add_drop_rule",
 		Description: logs.AddDropRuleDescription,
 	}, logs.NewAddDropRuleHandler(client, cfg))
 
 	// Register notification channels tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_notification_channels",
 		Description: alerting.GetNotificationChannelsDescription,
 	}, alerting.NewGetNotificationChannelsHandler(client, cfg))
 
 	// Register alert config tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_alert_config",
 		Description: alerting.GetAlertConfigDescription,
 	}, alerting.NewGetAlertConfigHandler(client, cfg))
 
 	// Register entity alert rules tool (entity-scoped, includes expression_args and resolved PromQL)
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_entity_alert_rules",
 		Description: alerting.GetEntityAlertRulesDescription,
 	}, alerting.NewGetEntityAlertRulesHandler(client, cfg))
 
 	// Register alerts tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_alerts",
 		Description: alerting.GetAlertsDescription,
 	}, alerting.NewGetAlertsHandler(client, cfg))
 
 	// Register get alert rule state tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_alert_rule_state",
 		Description: alerting.GetAlertRuleStateDescription,
 	}, alerting.NewAlertRuleStateHandler(client, cfg))
 
 	// Register get traces tool (enhanced with trace query instructions)
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_traces",
 		Description: getTracesDesc,
 		InputSchema: traces.GetTracesInputSchema(),
 	}, traces.NewGetTracesHandler(client, cfg))
 
 	// Register service traces tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_service_traces",
 		Description: getServiceTracesDesc,
 	}, traces.GetServiceTracesHandler(client, cfg))
 
 	// Register log attributes tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_log_attributes",
 		Description: logs.GetLogAttributesDescription,
 	}, logs.NewGetLogAttributesHandler(client, cfg))
 
 	// Register pipeline-scoped log attributes tool (discovers fields actually
 	// present for a given pipeline via the series endpoint)
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_log_attributes_for_pipeline",
 		Description: logs.GetLogAttributesForPipelineDescription,
 	}, logs.NewGetLogAttributesForPipelineHandler(client, cfg))
 
 	// Register trace attributes tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_trace_attributes",
 		Description: traces.GetTraceAttributesDescription,
 	}, traces.NewGetTraceAttributesHandler(client, cfg))
 
 	// Register trace attribute values tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_trace_attribute_values",
 		Description: traces.GetTraceAttributeValuesDescription,
 	}, traces.NewGetTraceAttributeValuesHandler(client, cfg))
 
 	// Register change events tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_change_events",
 		Description: change_events.GetChangeEventsDescription,
 	}, change_events.NewGetChangeEventsHandler(client, cfg))
 
 	// Register database discovery tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_databases",
 		Description: apm.GetDatabasesDescription,
 	}, apm.NewGetDatabasesHandler(client, cfg))
 
 	// Register database slow queries tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_database_slow_queries",
 		Description: apm.GetDatabaseSlowQueriesDescription,
 	}, apm.NewGetDatabaseSlowQueriesHandler(client, cfg))
 
 	// Register database query patterns tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_database_queries",
 		Description: apm.GetDatabaseQueriesDescription,
 	}, apm.NewGetDatabaseQueriesHandler(client, cfg))
 
 	// Register database server-side metrics tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_database_server_metrics",
 		Description: apm.GetDatabaseServerMetricsDescription,
 	}, apm.NewGetDatabaseServerMetricsHandler(client, cfg))
 
 	// Register did_you_mean tool
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "did_you_mean",
 		Description: suggest.DidYouMeanDescription,
 	}, suggest.NewDidYouMeanHandler(client, cfg))
 
 	// Register dashboard tools
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "list_dashboards",
 		Description: dashboards.ListDashboardsDescription,
 	}, dashboards.NewListDashboardsHandler(client, cfg))
 
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "get_dashboard",
 		Description: dashboards.GetDashboardDescription,
 	}, dashboards.NewGetDashboardHandler(client, cfg))
 
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "create_dashboard",
 		Description: dashboards.CreateDashboardDescription,
 	}, dashboards.NewCreateDashboardHandler(client, cfg))
 
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "update_dashboard",
 		Description: dashboards.UpdateDashboardDescription,
 	}, dashboards.NewUpdateDashboardHandler(client, cfg))
 
-	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+	registerTool(server, reg, &mcp.Tool{
 		Name:        "delete_dashboard",
 		Description: dashboards.DeleteDashboardDescription,
 	}, dashboards.NewDeleteDashboardHandler(client, cfg))

--- a/tools.go
+++ b/tools.go
@@ -34,6 +34,21 @@ func buildEnhancedDescription(base, instructions string, labelValues []string) s
 	return desc
 }
 
+// paramRegistry is shared between tool registration (writes) and the
+// paramhint middleware (reads). Package-level because registerAllTools
+// re-runs every 2h to refresh tool descriptions (see main.go): the
+// middleware must be attached exactly once per server — attaching it inside
+// registerAllTools would stack one copy per refresh and append duplicate
+// hints — while re-registration only rewrites the same names into the
+// existing registry.
+var paramRegistry = paramhint.NewRegistry()
+
+// AttachParamHintMiddleware wires the -32602 enrichment middleware to a
+// server. Call exactly once per server, before serving.
+func AttachParamHintMiddleware(server *last9mcp.Last9MCPServer) {
+	server.Server.AddReceivingMiddleware(paramhint.Middleware(paramRegistry))
+}
+
 // registerTool registers a tool and records its valid parameter names so the
 // paramhint middleware can build recovery hints for schema-validation errors.
 func registerTool[In, Out any](server *last9mcp.Last9MCPServer, reg *paramhint.Registry, tool *mcp.Tool, handler mcp.ToolHandlerFor[In, Out]) error {
@@ -44,8 +59,7 @@ func registerTool[In, Out any](server *last9mcp.Last9MCPServer, reg *paramhint.R
 // registerAllTools registers all tools with the MCP server using the new SDK pattern
 func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCache *attributes.AttributeCache) error {
 	client := auth.GetHTTPClient()
-	reg := paramhint.NewRegistry()
-	server.Server.AddReceivingMiddleware(paramhint.Middleware(reg))
+	reg := paramRegistry
 
 	// Build enhanced descriptions for tools that have embedded instructions
 	getLogsDesc := buildEnhancedDescription(logs.GetLogsDescription, prompts.GetLogsInstructions, attrCache.GetLogAttributes())

--- a/tools.go
+++ b/tools.go
@@ -40,7 +40,9 @@ func buildEnhancedDescription(base, instructions string, labelValues []string) s
 // middleware must be attached exactly once per server — attaching it inside
 // registerAllTools would stack one copy per refresh and append duplicate
 // hints — while re-registration only rewrites the same names into the
-// existing registry.
+// existing registry. Shared across all servers in the process (tests create
+// several); safe because every server registers the identical tool set and
+// Register is last-write-wins idempotent for identical inputs.
 var paramRegistry = paramhint.NewRegistry()
 
 // AttachParamHintMiddleware wires the -32602 enrichment middleware to a


### PR DESCRIPTION
## Problem

Agents (observed: Cursor) call tools with ecosystem-prior parameter names and get hard-rejected with an opaque error they cannot recover from:

- `prometheus_label_values` called with `match` (the canonical Prometheus name) instead of `match_query`
- `get_service_summary` called with `service` — the tool declared no service parameter at all

Both fail pre-handler with `-32602: ... unexpected additional properties` because the SDK infers `additionalProperties: false` schemas from the arg structs. The error names the offending key but lists no valid alternatives, so the agent burns the call.

## Fix (three layers)

1. **Aliases for predictable priors** — `match` accepted on `prometheus_label_values` / `prometheus_labels` (canonical `match_query` wins when both set), mirroring the existing deprecated-alias pattern in `internal/alerting/alerts.go`.
2. **Real service filter on `get_service_summary`** — `service_name` (canonical, matching the 6-tool majority) + `service` alias, injected into all three PromQL selectors with the same default handling as `env`.
3. **Recoverable -32602 errors for the unpredictable tail** — new `internal/paramhint` receiving middleware appends the offending keys, the tool's valid parameter list, and at most one did-you-mean suggestion (Levenshtein, repo's one-suggestion convention). Strict validation stays in force; the error code is preserved via error wrapping.

## Tests

- New `schema_validation_test.go` runs the full server over in-memory MCP transports — the first tests in the repo to exercise the SDK validation layer (handler-direct tests bypass it). Written red-first: all 8 subtests reproduced the production failures before the fix.
- Handler-level alias/filter tests in `internal/apm/apm_test.go`; `internal/paramhint` unit tests.
- Agentic eval suite (`param_mismatch`, separate PR in last9-mcp-evals) verified red against a main build and 6/6 green against this branch.

Fixes ENG-1263

## Deferred follow-ups

- `service`/`service_name` alias sweep across the remaining 7 inconsistent tools
- upstreaming the middleware into last9/mcp-go-sdk

🤖 Generated with [Claude Code](https://claude.com/claude-code)