### PR TITLE
fix: expose dashboard input schemas as objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-06-18
+
+### Fixed
+
+- Dashboard create and update tools now expose `dashboard` and `metadata` inputs as JSON objects in their MCP schemas, allowing clients to pass dashboard definitions directly.
+
 ## [0.8.0] - 2026-06-08
 
 ### Added

--- a/internal/dashboards/input_schema.go
+++ b/internal/dashboards/input_schema.go
@@ -1,0 +1,45 @@
+package dashboards
+
+func dashboardObjectSchema(description string) map[string]interface{} {
+	return map[string]interface{}{
+		"type":        "object",
+		"description": description,
+	}
+}
+
+func metadataObjectSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type":        "object",
+		"description": "Optional dashboard metadata, for example {\"_category\":\"custom\",\"_type\":\"metrics\"}.",
+	}
+}
+
+// GetCreateDashboardInputSchema returns the MCP-facing schema for create_dashboard.
+// The handler uses json.RawMessage internally, but clients must see dashboard and
+// metadata as JSON objects rather than byte arrays.
+func GetCreateDashboardInputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"dashboard": dashboardObjectSchema("Dashboard definition with name and panels."),
+			"metadata":  metadataObjectSchema(),
+		},
+		"required": []string{"dashboard"},
+	}
+}
+
+// GetUpdateDashboardInputSchema returns the MCP-facing schema for update_dashboard.
+func GetUpdateDashboardInputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"id": map[string]interface{}{
+				"type":        "string",
+				"description": "Dashboard UUID to update.",
+			},
+			"dashboard": dashboardObjectSchema("Full replacement dashboard definition with name and panels."),
+			"metadata":  metadataObjectSchema(),
+		},
+		"required": []string{"id", "dashboard"},
+	}
+}

--- a/internal/dashboards/schema_test.go
+++ b/internal/dashboards/schema_test.go
@@ -1,0 +1,49 @@
+package dashboards
+
+import (
+	"slices"
+	"testing"
+)
+
+func assertDashboardObjectSchema(t *testing.T, schema map[string]interface{}, requiredFields []string) {
+	t.Helper()
+
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("InputSchema missing properties")
+	}
+
+	dashboard, ok := props["dashboard"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("dashboard missing from properties")
+	}
+	if dashboard["type"] != "object" {
+		t.Fatalf("dashboard type: want object, got %v", dashboard["type"])
+	}
+
+	metadata, ok := props["metadata"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("metadata missing from properties")
+	}
+	if metadata["type"] != "object" {
+		t.Fatalf("metadata type: want object, got %v", metadata["type"])
+	}
+
+	required, ok := schema["required"].([]string)
+	if !ok {
+		t.Fatalf("InputSchema missing required fields")
+	}
+	for _, field := range requiredFields {
+		if !slices.Contains(required, field) {
+			t.Fatalf("%q must be required, got %v", field, required)
+		}
+	}
+}
+
+func TestCreateDashboardInputSchema_DashboardIsObject(t *testing.T) {
+	assertDashboardObjectSchema(t, GetCreateDashboardInputSchema(), []string{"dashboard"})
+}
+
+func TestUpdateDashboardInputSchema_DashboardIsObject(t *testing.T) {
+	assertDashboardObjectSchema(t, GetUpdateDashboardInputSchema(), []string{"id", "dashboard"})
+}

--- a/internal/dashboards/schema_test.go
+++ b/internal/dashboards/schema_test.go
@@ -1,8 +1,11 @@
 package dashboards
 
 import (
+	"encoding/json"
 	"slices"
 	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
 )
 
 func assertDashboardObjectSchema(t *testing.T, schema map[string]interface{}, requiredFields []string) {
@@ -46,4 +49,88 @@ func TestCreateDashboardInputSchema_DashboardIsObject(t *testing.T) {
 
 func TestUpdateDashboardInputSchema_DashboardIsObject(t *testing.T) {
 	assertDashboardObjectSchema(t, GetUpdateDashboardInputSchema(), []string{"id", "dashboard"})
+}
+
+func validateInputSchema(t *testing.T, inputSchema map[string]interface{}, args any) error {
+	t.Helper()
+
+	schemaBytes, err := json.Marshal(inputSchema)
+	if err != nil {
+		t.Fatalf("json.Marshal(inputSchema) error = %v", err)
+	}
+
+	var schema jsonschema.Schema
+	if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+		t.Fatalf("json.Unmarshal(inputSchema) error = %v", err)
+	}
+
+	resolved, err := schema.Resolve(nil)
+	if err != nil {
+		t.Fatalf("schema.Resolve() error = %v", err)
+	}
+
+	return resolved.Validate(args)
+}
+
+func TestCreateDashboardInputSchema_ValidatesDashboardObject(t *testing.T) {
+	validArgs := map[string]any{
+		"dashboard": map[string]any{
+			"name":   "Created",
+			"panels": []any{},
+		},
+		"metadata": map[string]any{
+			"_category": "custom",
+			"_type":     "metrics",
+		},
+	}
+
+	if err := validateInputSchema(t, GetCreateDashboardInputSchema(), validArgs); err != nil {
+		t.Fatalf("expected dashboard object args to validate: %v", err)
+	}
+}
+
+func TestCreateDashboardInputSchema_RejectsMissingDashboard(t *testing.T) {
+	args := map[string]any{
+		"metadata": map[string]any{
+			"_category": "custom",
+			"_type":     "metrics",
+		},
+	}
+
+	if err := validateInputSchema(t, GetCreateDashboardInputSchema(), args); err == nil {
+		t.Fatal("expected missing dashboard to fail validation")
+	}
+}
+
+func TestCreateDashboardInputSchema_RejectsRawMessageByteArray(t *testing.T) {
+	args := map[string]any{
+		"dashboard": []any{123, 34, 110, 97, 109, 101, 34, 58, 34, 120, 34, 125},
+	}
+
+	if err := validateInputSchema(t, GetCreateDashboardInputSchema(), args); err == nil {
+		t.Fatal("expected byte-array dashboard payload to fail validation")
+	}
+}
+
+func TestUpdateDashboardInputSchema_RequiresIDAndDashboard(t *testing.T) {
+	validArgs := map[string]any{
+		"id": "uuid-1",
+		"dashboard": map[string]any{
+			"name":   "Updated",
+			"panels": []any{},
+		},
+	}
+	if err := validateInputSchema(t, GetUpdateDashboardInputSchema(), validArgs); err != nil {
+		t.Fatalf("expected update args to validate: %v", err)
+	}
+
+	missingIDArgs := map[string]any{
+		"dashboard": map[string]any{
+			"name":   "Updated",
+			"panels": []any{},
+		},
+	}
+	if err := validateInputSchema(t, GetUpdateDashboardInputSchema(), missingIDArgs); err == nil {
+		t.Fatal("expected update args without id to fail validation")
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"

--- a/tools.go
+++ b/tools.go
@@ -252,11 +252,13 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCa
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
 		Name:        "create_dashboard",
 		Description: dashboards.CreateDashboardDescription,
+		InputSchema: dashboards.GetCreateDashboardInputSchema(),
 	}, dashboards.NewCreateDashboardHandler(client, cfg))
 
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
 		Name:        "update_dashboard",
 		Description: dashboards.UpdateDashboardDescription,
+		InputSchema: dashboards.GetUpdateDashboardInputSchema(),
 	}, dashboards.NewUpdateDashboardHandler(client, cfg))
 
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/attributes"
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/dashboards"
+	"last9-mcp/internal/models"
+
+	last9mcp "github.com/last9/mcp-go-sdk/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func testToolRegistrationConfig() models.Config {
+	return models.Config{
+		APIBaseURL: "http://example.test",
+		OrgSlug:    "test-org",
+		Region:     "us-east-1",
+		ClusterID:  "cluster-1",
+		TokenManager: &auth.TokenManager{
+			AccessToken: "test-token",
+			ExpiresAt:   time.Now().Add(24 * time.Hour),
+		},
+	}
+}
+
+func schemaAsMap(t *testing.T, schema any) map[string]any {
+	t.Helper()
+
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("json.Marshal(schema) error = %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("json.Unmarshal(schema) error = %v", err)
+	}
+	return out
+}
+
+func toolByName(t *testing.T, tools []*mcp.Tool, name string) *mcp.Tool {
+	t.Helper()
+
+	for _, tool := range tools {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	t.Fatalf("tool %q not found", name)
+	return nil
+}
+
+func assertRegisteredDashboardSchema(t *testing.T, tool *mcp.Tool, required []string) {
+	t.Helper()
+
+	schema := schemaAsMap(t, tool.InputSchema)
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s InputSchema missing properties: %v", tool.Name, schema)
+	}
+
+	dashboard, ok := props["dashboard"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s InputSchema missing dashboard property: %v", tool.Name, props)
+	}
+	if dashboard["type"] != "object" {
+		t.Fatalf("%s dashboard type: want object, got %v", tool.Name, dashboard["type"])
+	}
+
+	requiredRaw, ok := schema["required"].([]any)
+	if !ok {
+		t.Fatalf("%s InputSchema missing required list: %v", tool.Name, schema)
+	}
+	requiredSet := make(map[string]bool, len(requiredRaw))
+	for _, field := range requiredRaw {
+		if s, ok := field.(string); ok {
+			requiredSet[s] = true
+		}
+	}
+	for _, field := range required {
+		if !requiredSet[field] {
+			t.Fatalf("%s required fields missing %q: %v", tool.Name, field, requiredRaw)
+		}
+	}
+}
+
+func TestRegisterAllTools_ExposesDashboardObjectSchemas(t *testing.T) {
+	server, err := last9mcp.NewServerWithOptions("test-last9-mcp", "test", last9mcp.WithSkipProviderInit())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Shutdown(context.Background())
+
+	cfg := testToolRegistrationConfig()
+	if err := registerAllTools(server, cfg, attributes.NewAttributeCache(nil, cfg)); err != nil {
+		t.Fatal(err)
+	}
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Server.Connect(context.Background(), serverTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverSession.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "test"}, nil)
+	clientSession, err := client.Connect(context.Background(), clientTransport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientSession.Close()
+
+	list, err := clientSession.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertRegisteredDashboardSchema(t, toolByName(t, list.Tools, "create_dashboard"), []string{"dashboard"})
+	assertRegisteredDashboardSchema(t, toolByName(t, list.Tools, "update_dashboard"), []string{"id", "dashboard"})
+
+	if got, want := schemaAsMap(t, toolByName(t, list.Tools, "create_dashboard").InputSchema), schemaAsMap(t, dashboards.GetCreateDashboardInputSchema()); !reflect.DeepEqual(got, want) {
+		t.Fatalf("create_dashboard InputSchema mismatch:\ngot  %v\nwant %v", got, want)
+	}
+	if got, want := schemaAsMap(t, toolByName(t, list.Tools, "update_dashboard").InputSchema), schemaAsMap(t, dashboards.GetUpdateDashboardInputSchema()); !reflect.DeepEqual(got, want) {
+		t.Fatalf("update_dashboard InputSchema mismatch:\ngot  %v\nwant %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Dashboard create/update calls now expose MCP input schemas that match how users actually provide dashboard definitions: `dashboard` and `metadata` are JSON objects, not raw byte payloads. This prevents MCP clients from rejecting or mis-shaping valid dashboard JSON before the handler can validate and send it to the API.

The internal handler payload remains unchanged; this only fixes the client-facing tool contract and covers it with schema tests.

## Test Plan

- `go test ./internal/dashboards`
- `go test ./...`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
