### PR TITLE
fix(get_alerts): add explicit window cap-at-3600 guidance (ENG-1201)

### DIFF
--- a/internal/prompts/descriptions/get_alerts.md
+++ b/internal/prompts/descriptions/get_alerts.md
@@ -4,7 +4,7 @@
 	Parameters:
 	- time_iso: Evaluation time in RFC3339/ISO8601 format (e.g. 2026-02-09T15:04:05Z). Preferred over timestamp.
 	- timestamp: Unix timestamp for the query time (deprecated alias, defaults to current time)
-	- window: Time window in seconds to look back for alerts (defaults to 900 seconds = 15 minutes, range: 1-3600)
+	- window: Time window in seconds to look back for alerts (defaults to 900 seconds = 15 minutes, range: 1-3600). Max is 3600 seconds (1 hour). If the user asks for a longer period (e.g. 90 minutes, 2 hours, a day), cap window at 3600 — do not pass the raw computed value (such as 5400 or 7200), as the server rejects anything above 3600.
 	- lookback_minutes: Relative time window in minutes (range: 1-60). Used only when window is not provided.
 	
 	Uses the datasource configured in the server config (or default if not specified).


### PR DESCRIPTION
## Problem

`get_alerts` enforces a max `window` of 3600s server-side (`internal/alerting/alerts.go:182-183`), but its tool description only stated the range `1-3600` without telling the model to **cap** when the user asks for a longer period. So the model emitted raw computed seconds:

- "last 90 minutes" → `window: 5400`
- "last 2 hours" → `window: 7200`

Both are rejected with `window must be between 1 and 3600 seconds` — the user gets an error instead of alerts. Reproduced live on `last9-prod`: `get_alerts(window=7200)` errors; `get_alerts(window=3600)` returns data.

> Note: the original ticket's premise (no `.md` file, needs create/embed/wire) was stale — the file already exists, is embedded (`prompts.go:65`) and wired (`tools.go:158`). The real gap was the missing cap instruction. See ENG-1201 for the corrected diagnosis.

## Fix

One-line edit to the existing `internal/prompts/descriptions/get_alerts.md` — add an explicit "cap `window` at 3600 for longer periods" rule to the `window` param. No embed/wiring change; `buildEnhancedDescription` not needed here. File bytes (tab indent, single trailing newline) preserved per `AGENTS.md` so the `dump-tools` snapshot stays stable.

## Verification

last9-mcp-evals `get_alerts` suite, run against this build's `dump-tools` snapshot:

- **With fix:** 6/6 pass (al-001…al-006)
- **Baseline (cap rule stripped):** al-003 → `{"window": 7200}`, al-001 & al-002 also fail

Clean before/after causation.

Fixes ENG-1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)