### PR TITLE
fix(traces): always wrap single-condition filters in $and (ENG-1202)

### DIFF
--- a/internal/prompts/descriptions/get_traces.md
+++ b/internal/prompts/descriptions/get_traces.md
@@ -370,17 +370,21 @@ Filtering `Duration > "1000"` means 1000 **nanoseconds** (1µs), which matches n
 [{
   "type": "filter",
   "query": {
-    "$eq": ["resource_department", "engineering"]
+    "$and": [
+      {"$eq": ["resource_department", "engineering"]}
+    ]
   }
 }]
 ```
 
-✅ CORRECT — call get_trace_attributes first to get filter_field, then use it:
+✅ CORRECT — call get_trace_attributes first to get filter_field, then use it (note: a single condition is still wrapped in `$and` — see Rule 7):
 ```json
 [{
   "type": "filter",
   "query": {
-    "$eq": ["resources['department']", "engineering"]
+    "$and": [
+      {"$eq": ["resources['department']", "engineering"]}
+    ]
   }
 }]
 ```

--- a/internal/telemetry/traces/query_sanitize.go
+++ b/internal/telemetry/traces/query_sanitize.go
@@ -2,6 +2,7 @@ package traces
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -56,6 +57,12 @@ func sanitizeTraceJSONQuery(stages []map[string]interface{}) error {
 				if err := validateFilterFields(query, path+".query"); err != nil {
 					return err
 				}
+				// tracejson requires the top-level filter query to be wrapped in a
+				// logical operator. Models (especially weaker ones) frequently emit a
+				// bare single condition like {"$eq": [...]}, which the spec rejects.
+				// Normalize it to {"$and": [{"$eq": [...]}]} so the forwarded query is
+				// always valid regardless of how the model phrased it.
+				stage["query"] = wrapTopLevelFilterQuery(query)
 			}
 		}
 
@@ -66,6 +73,38 @@ func sanitizeTraceJSONQuery(stages []map[string]interface{}) error {
 		}
 	}
 	return nil
+}
+
+// wrapTopLevelFilterQuery ensures the top-level filter query is wrapped in a
+// logical operator, as the tracejson spec requires. A query that is already a
+// single logical operator ($and/$or/$not) is returned unchanged; anything else
+// — one or more bare field operators — is wrapped in $and, with each condition
+// becoming its own element. Keys are sorted so the output is deterministic.
+func wrapTopLevelFilterQuery(query interface{}) interface{} {
+	queryMap, ok := query.(map[string]interface{})
+	if !ok || len(queryMap) == 0 {
+		return query
+	}
+
+	if len(queryMap) == 1 {
+		for key := range queryMap {
+			if _, isLogical := traceFilterLogicalOperators[key]; isLogical {
+				return queryMap
+			}
+		}
+	}
+
+	keys := make([]string, 0, len(queryMap))
+	for key := range queryMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	conditions := make([]interface{}, 0, len(keys))
+	for _, key := range keys {
+		conditions = append(conditions, map[string]interface{}{key: queryMap[key]})
+	}
+	return map[string]interface{}{"$and": conditions}
 }
 
 func validateTraceFilterCondition(value interface{}, path string) error {

--- a/internal/telemetry/traces/query_sanitize_test.go
+++ b/internal/telemetry/traces/query_sanitize_test.go
@@ -1,6 +1,7 @@
 package traces
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -572,6 +573,114 @@ func TestSanitizeTraceJSONQuery_EdgeCases(t *testing.T) {
 		}
 		if err := sanitizeTraceJSONQuery(stages); err != nil {
 			t.Errorf("non-map aggregate entry should pass sanitizer, got: %v", err)
+		}
+	})
+}
+
+func TestSanitizeTraceJSONQuery_WrapsTopLevelFilterInAnd(t *testing.T) {
+	t.Run("bare single field operator is wrapped in $and", func(t *testing.T) {
+		stages := []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{
+				"$eq": []interface{}{"SpanKind", "SPAN_KIND_INTERNAL"},
+			}},
+		}
+		if err := sanitizeTraceJSONQuery(stages); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		want := map[string]interface{}{
+			"$and": []interface{}{
+				map[string]interface{}{"$eq": []interface{}{"SpanKind", "SPAN_KIND_INTERNAL"}},
+			},
+		}
+		if got := stages[0]["query"]; !reflect.DeepEqual(got, want) {
+			t.Errorf("query not wrapped in $and:\n got: %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("where stage is wrapped too", func(t *testing.T) {
+		stages := []map[string]interface{}{
+			{"type": "where", "query": map[string]interface{}{
+				"$eq": []interface{}{"ServiceName", "checkout"},
+			}},
+		}
+		if err := sanitizeTraceJSONQuery(stages); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		query, ok := stages[0]["query"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("query is not a map: %#v", stages[0]["query"])
+		}
+		if _, ok := query["$and"]; !ok {
+			t.Errorf("expected $and wrapper, got: %#v", query)
+		}
+	})
+
+	t.Run("multiple bare field operators are each wrapped in $and (sorted)", func(t *testing.T) {
+		stages := []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{
+				"$eq":  []interface{}{"ServiceName", "checkout"},
+				"$neq": []interface{}{"StatusCode", "STATUS_CODE_OK"},
+			}},
+		}
+		if err := sanitizeTraceJSONQuery(stages); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		want := map[string]interface{}{
+			"$and": []interface{}{
+				map[string]interface{}{"$eq": []interface{}{"ServiceName", "checkout"}},
+				map[string]interface{}{"$neq": []interface{}{"StatusCode", "STATUS_CODE_OK"}},
+			},
+		}
+		if got := stages[0]["query"]; !reflect.DeepEqual(got, want) {
+			t.Errorf("multiple conditions not wrapped deterministically:\n got: %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("already-wrapped $and is left unchanged", func(t *testing.T) {
+		inner := []interface{}{
+			map[string]interface{}{"$eq": []interface{}{"SpanKind", "SPAN_KIND_INTERNAL"}},
+		}
+		stages := []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{"$and": inner}},
+		}
+		if err := sanitizeTraceJSONQuery(stages); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		want := map[string]interface{}{"$and": inner}
+		if got := stages[0]["query"]; !reflect.DeepEqual(got, want) {
+			t.Errorf("already-wrapped query should be unchanged:\n got: %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("top-level $or is left unchanged", func(t *testing.T) {
+		or := []interface{}{
+			map[string]interface{}{"$eq": []interface{}{"SpanKind", "SPAN_KIND_CLIENT"}},
+			map[string]interface{}{"$eq": []interface{}{"SpanKind", "SPAN_KIND_SERVER"}},
+		}
+		stages := []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{"$or": or}},
+		}
+		if err := sanitizeTraceJSONQuery(stages); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		query := stages[0]["query"].(map[string]interface{})
+		if _, ok := query["$or"]; !ok {
+			t.Errorf("top-level $or should be preserved, got: %#v", query)
+		}
+		if _, ok := query["$and"]; ok {
+			t.Errorf("top-level $or should not be re-wrapped in $and, got: %#v", query)
+		}
+	})
+
+	t.Run("empty query map is left unchanged", func(t *testing.T) {
+		stages := []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{}},
+		}
+		if err := sanitizeTraceJSONQuery(stages); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if got := stages[0]["query"]; !reflect.DeepEqual(got, map[string]interface{}{}) {
+			t.Errorf("empty query should be unchanged, got: %#v", got)
 		}
 	})
 }


### PR DESCRIPTION
## Problem

A single-condition trace filter was emitted **without** the required `$and` wrapper:

```json
// actual (rejected by spec)
[{"type": "filter", "query": {"$eq": ["SpanKind", "SPAN_KIND_INTERNAL"]}}]
// expected
[{"type": "filter", "query": {"$and": [{"$eq": ["SpanKind", "SPAN_KIND_INTERNAL"]}]}}]
```

Caught by the mcp-evals `tq-009` case (`"show me internal spans"`, `must_contain: ["$and"]`).

## Root cause

1. **Prompt contradiction.** `get_traces.md` Rule 7 says "always wrap, even single conditions," but Example 7's **"✅ CORRECT"** block showed a bare single `$eq` with no `$and`. Strong models worked around it; weaker models anchored on the example and dropped the wrapper.
2. **No server-side guardrail.** `sanitizeTraceJSONQuery` accepted a bare top-level field operator, so nothing corrected a missing wrapper.

## Fix

- **`get_traces.md`** — wrap both halves of Example 7 in `$and` so the only highlighted difference is the field reference. This is what fixes the eval (it grades raw model output).
- **`query_sanitize.go`** — add `wrapTopLevelFilterQuery`: a top-level query already wrapped in a single logical operator (`$and`/`$or`/`$not`) is left untouched; one or more bare field operators are wrapped in `$and` (keys sorted for deterministic output). Defense-in-depth: the forwarded query is valid regardless of model strength.

The two fixes are complementary — the prompt fix makes the eval pass; the sanitizer fix never touches the eval path but guarantees a valid query if any future/weaker model still drops the wrapper.

## Verification

| Check | Result |
|---|---|
| `tq-009` on `claude-haiku-4-5` (deterministic repro) | 4/4 FAIL → **4/4 PASS** |
| Full `trace_query` eval suite (default model) | **22/22 PASS** |
| `TestSanitizeTraceJSONQuery_WrapsTopLevelFilterInAnd` (6 cases) | **pass** |
| `go build ./...` / `gofmt` | **clean** |

Closes ENG-1202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)