### PR TITLE
fix(mcp): stateless Streamable HTTP handler for multi-replica safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The HTTP (Streamable HTTP) server now runs the MCP handler in **stateless** mode. Session state was previously held per-instance in memory, so running more than one replica behind a load balancer caused intermittent `404 "session not found"` when a follow-up request (`tools/list`, `tools/call`) was routed to a different instance than the one that handled `initialize` — surfacing in clients as "tools fetch failed / no capabilities" plus reconnect storms. Stateless mode lets any instance serve any request, enabling safe horizontal scaling. Transport-contract change: the server no longer validates the `Mcp-Session-Id` header, and `GET /mcp` (the server→client SSE notification stream) now returns `405`. All tools are independent request/response queries and use neither server-initiated notifications nor session-scoped state (#174).
+
 ## [0.9.0] - 2026-06-25
 
 ### Added

--- a/http_server.go
+++ b/http_server.go
@@ -52,12 +52,16 @@ func (h *HTTPServer) Start() error {
 	// Create a mux to handle multiple endpoints
 	mux := http.NewServeMux()
 
-	// Create stateless MCP handler for maximum client compatibility
-	// Enables direct tool calls without session management - perfect for curl testing,
-	// serverless deployments, and horizontal scaling per MCP team recommendations
+	// Run the Streamable HTTP handler in stateless mode. Otherwise session
+	// state is kept per-instance in memory, so when more than one replica runs
+	// behind a load balancer a follow-up request (e.g. tools/list) can be
+	// routed to a different instance than the one that handled initialize and
+	// fail with "session not found" (404). All tools are independent
+	// request/response queries, so a temporary per-request session is
+	// sufficient and lets the server scale horizontally.
 	httpHandler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {
 		return h.server.Server
-	}, nil)
+	}, &mcp.StreamableHTTPOptions{Stateless: true})
 
 	// Register handlers on both root and /mcp paths for maximum client flexibility
 	mux.Handle("/", httpHandler)    // Root endpoint for standard MCP clients

--- a/http_server.go
+++ b/http_server.go
@@ -44,6 +44,17 @@ func NewHTTPServer(server *last9mcp.Last9MCPServer, config models.Config) *HTTPS
 	}
 }
 
+// newStatelessStreamableHandler builds the MCP Streamable HTTP handler in
+// stateless mode. Otherwise session state is kept per-instance in memory, so
+// when more than one replica runs behind a load balancer a follow-up request
+// (e.g. tools/list) can be routed to a different instance than the one that
+// handled initialize and fail with "session not found" (404). All tools are
+// independent request/response queries, so a temporary per-request session is
+// sufficient and lets the server scale horizontally.
+func newStatelessStreamableHandler(getServer func(*http.Request) *mcp.Server) http.Handler {
+	return mcp.NewStreamableHTTPHandler(getServer, &mcp.StreamableHTTPOptions{Stateless: true})
+}
+
 // Start starts the HTTP server with streamable HTTP support
 func (h *HTTPServer) Start() error {
 	// url is host:port
@@ -52,16 +63,10 @@ func (h *HTTPServer) Start() error {
 	// Create a mux to handle multiple endpoints
 	mux := http.NewServeMux()
 
-	// Run the Streamable HTTP handler in stateless mode. Otherwise session
-	// state is kept per-instance in memory, so when more than one replica runs
-	// behind a load balancer a follow-up request (e.g. tools/list) can be
-	// routed to a different instance than the one that handled initialize and
-	// fail with "session not found" (404). All tools are independent
-	// request/response queries, so a temporary per-request session is
-	// sufficient and lets the server scale horizontally.
-	httpHandler := mcp.NewStreamableHTTPHandler(func(req *http.Request) *mcp.Server {
+	// See newStatelessStreamableHandler for why the handler runs in stateless mode.
+	httpHandler := newStatelessStreamableHandler(func(req *http.Request) *mcp.Server {
 		return h.server.Server
-	}, &mcp.StreamableHTTPOptions{Stateless: true})
+	})
 
 	// Register handlers on both root and /mcp paths for maximum client flexibility
 	mux.Handle("/", httpHandler)    // Root endpoint for standard MCP clients

--- a/http_server_test.go
+++ b/http_server_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestStatelessStreamableHandler verifies the HTTP handler runs in stateless
+// mode: a request carrying an Mcp-Session-Id that this instance never issued
+// must still succeed instead of returning 404 "session not found". This is what
+// makes running more than one replica behind a load balancer safe — in stateful
+// mode a follow-up request routed to a different pod than the one that handled
+// initialize fails, surfacing to clients as "tools fetch failed". A regression
+// back to stateful mode (opts nil / Stateless:false) fails this test.
+func TestStatelessStreamableHandler(t *testing.T) {
+	srv := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
+	ts := httptest.NewServer(newStatelessStreamableHandler(func(*http.Request) *mcp.Server {
+		return srv
+	}))
+	defer ts.Close()
+
+	t.Run("tools/list with unknown session returns 200, not 404", func(t *testing.T) {
+		body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+		req, _ := http.NewRequest(http.MethodPost, ts.URL, bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		// A session id this instance never created — the exact multi-replica case.
+		req.Header.Set("Mcp-Session-Id", "session-this-instance-never-issued")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		respBody, _ := io.ReadAll(resp.Body)
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("got HTTP %d, want 200 (stateful mode would 404 here); body: %s",
+				resp.StatusCode, respBody)
+		}
+		if strings.Contains(string(respBody), "session not found") {
+			t.Fatalf("response contains 'session not found' — handler is stateful, not stateless; body: %s", respBody)
+		}
+	})
+
+	t.Run("GET SSE stream returns 405 in stateless mode", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+		req.Header.Set("Accept", "text/event-stream")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		// Stateless mode has no per-session push channel, so GET is 405.
+		// Stateful mode would open a 200 SSE stream instead.
+		if resp.StatusCode != http.StatusMethodNotAllowed {
+			t.Fatalf("got HTTP %d, want 405", resp.StatusCode)
+		}
+	})
+}


### PR DESCRIPTION
## What

Set `Stateless: true` on the Streamable HTTP handler in `http_server.go` (was `nil`).

## Why

When the server runs more than one replica behind a load balancer, clients intermittently get `404 "session not found"` on `tools/list` / `tools/call`, which surfaces as **"tools fetch failed / no capabilities"** plus a reconnect storm.

Root cause: session state is held per-instance in memory (`Stateless=false`). A client's `initialize` creates the session on instance A, but a follow-up request load-balanced to instance B has no such session → the SDK returns 404 (`streamable.go:300`, `sessInfo == nil && !Stateless`). Forwarding the `Mcp-Session-Id` header doesn't help, since the receiving instance doesn't hold the session.

## Fix

Stateless mode skips `Mcp-Session-Id` validation and uses a temporary per-request session, so any instance can serve any request with no session affinity required. Safe because every tool is an independent request/response query; the only things given up are server→client requests and the long-lived GET/SSE notification stream, which these tools don't use.

## Verification

Build:
- `go build ./...`
- `go vet .`
- `go run . dump-tools` → full tool list served, unchanged
- `TestStatelessStreamableHandler` — unknown-session `tools/list` → 200; `GET` → 405

Behavior (single instance + real client):
- `tools/list` / `tools/call` with an **unknown or absent** `Mcp-Session-Id` now return **200** (previously `404 "session not found"`).
- `initialize` returns 200; a real MCP client connects, loads all tools, runs calls.

Multi-replica (alpha, 2 replicas):
- Tool calls load-balanced across both pods (no session affinity) all return **200** with data.
- `/mcp` traffic over the last 20 min shows **zero `session not found`** — POSTs are 200/202. (Stateful + 2 replicas would produce 404s; none present.)
- `GET /mcp` returns **405** — stateless mode offers no server→client SSE push channel (no per-session stream). Expected, and tolerated by real clients (they fall back to POST-only); no tool uses server push.

## Checklist

- [x] Builds, vets, `dump-tools` unchanged
- [x] Test coverage for stateless flip (`TestStatelessStreamableHandler`)
- [x] Unknown/absent-session requests return 200 (regression fixed)
- [x] Real MCP client smoke test (connect, list, call)
- [x] `GET`/SSE path behaves correctly in stateless mode (405)
- [x] Verified with 2 replicas on alpha (zero `session not found`)
- [x] CHANGELOG entry (no version bump)
- [ ] Production rollout