### PR TITLE
fix(apm): remove erroneous 1000x multiplier on DB latency queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `get_databases` and `get_database_queries` reported database latency 1000x too high. Their PromQL queries multiplied `trace_client_duration` by 1000 on the assumption it was in seconds, but the metric is already in milliseconds — so `p95_latency_ms` / `avg_latency_ms` were inflated by three orders of magnitude (e.g. a real ~30s Redis blocking read surfaced as `p95_latency_ms: 30010484`, ~8.3 hours). Removed the multiplier; the values now match their `_ms` unit and the frontend's own database queries. Consumers that anchored dashboards or thresholds on the old inflated numbers will see values drop 1000x (#177).
 - Malformed tool-call input (unknown parameter name, wrong value type) now surfaces to the model as a tool-call error (`CallToolResult.isError`) instead of a swallowed JSON-RPC `-32602` protocol error, letting the agent self-correct instead of burning the call. Achieved by bumping `modelcontextprotocol/go-sdk` v1.4.1 → v1.5.0, which adopts the SEP-1303 input-validation contract (#173).
 
 ## [0.9.0] - 2026-06-25

--- a/internal/apm/databases.go
+++ b/internal/apm/databases.go
@@ -64,7 +64,7 @@ func NewGetDatabasesHandler(client *http.Client, cfg models.Config) func(context
 			baseFilter, durationMin, durationMin,
 		)
 		latencyQuery := fmt.Sprintf(
-			`max by(db_system, net_peer_name)(avg_over_time(trace_client_duration{%s, quantile="p95"}[%dm])) * 1000`,
+			`max by(db_system, net_peer_name)(avg_over_time(trace_client_duration{%s, quantile="p95"}[%dm]))`,
 			baseFilter, durationMin,
 		)
 		errorCountQuery := fmt.Sprintf(
@@ -461,11 +461,11 @@ func NewGetDatabaseQueriesHandler(client *http.Client, cfg models.Config) func(c
 
 		// 2. Remaining metrics in parallel (avg latency, p95 latency, error count, total count)
 		avgLatencyQuery := fmt.Sprintf(
-			`avg by(span_name)(avg_over_time(trace_client_duration{%s, quantile="p50"}[%dm])) * 1000`,
+			`avg by(span_name)(avg_over_time(trace_client_duration{%s, quantile="p50"}[%dm]))`,
 			baseFilter, durationMin,
 		)
 		p95LatencyQuery := fmt.Sprintf(
-			`avg by(span_name)(avg_over_time(trace_client_duration{%s, quantile="p95"}[%dm])) * 1000`,
+			`avg by(span_name)(avg_over_time(trace_client_duration{%s, quantile="p95"}[%dm]))`,
 			baseFilter, durationMin,
 		)
 		errorCountQuery := fmt.Sprintf(

--- a/internal/apm/databases_test.go
+++ b/internal/apm/databases_test.go
@@ -3,6 +3,7 @@ package apm
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -114,6 +115,63 @@ func TestGetDatabasesHandler_NoDatabases(t *testing.T) {
 	text := result.Content[0].(*mcp.TextContent).Text
 	if !strings.Contains(text, "No databases found") {
 		t.Errorf("expected 'No databases found' message, got: %s", text)
+	}
+}
+
+// TestGetDatabasesHandler_LatencyQuery_NoUnitMultiplier is a regression test
+// for a unit bug: the latency PromQL query multiplied trace_client_duration
+// by 1000, but that metric is already in milliseconds (confirmed against
+// apm.go's identical trace_client_duration quantile queries, which apply no
+// multiplier). The bug inflated p95_latency_ms by 1000x on the real backend
+// (e.g. a real 30s redis block showed as 30,010,484ms instead of ~30,010ms).
+//
+// The multiplication happens in the PromQL expression evaluated by the
+// metrics backend, not in Go arithmetic — a mock HTTP server can't evaluate
+// PromQL, so the only way to catch this is asserting on the query text sent.
+func TestGetDatabasesHandler_LatencyQuery_NoUnitMultiplier(t *testing.T) {
+	var capturedQueries []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Query string `json:"query"`
+		}
+		bodyBytes, _ := io.ReadAll(r.Body)
+		json.Unmarshal(bodyBytes, &body)
+		capturedQueries = append(capturedQueries, body.Query)
+
+		w.WriteHeader(http.StatusOK)
+		response := []map[string]any{
+			{
+				"metric": map[string]string{"db_system": "redis", "net_peer_name": "redis-cache.internal"},
+				"value":  []any{1700000000, "10.0"},
+			},
+		}
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	handler := NewGetDatabasesHandler(server.Client(), testDBConfig(server.URL))
+	now := time.Now().UTC()
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetDatabasesArgs{
+		StartTimeISO: now.Add(-60 * time.Minute).Format(time.RFC3339),
+		EndTimeISO:   now.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	found := false
+	for _, q := range capturedQueries {
+		if !strings.Contains(q, "trace_client_duration") {
+			continue
+		}
+		found = true
+		if strings.Contains(q, "* 1000") {
+			t.Errorf("latency query multiplies by 1000, but trace_client_duration is already in ms: %s", q)
+		}
+	}
+	if !found {
+		t.Fatal("expected a trace_client_duration query to be issued")
 	}
 }
 

--- a/internal/apm/databases_test.go
+++ b/internal/apm/databases_test.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -118,60 +120,110 @@ func TestGetDatabasesHandler_NoDatabases(t *testing.T) {
 	}
 }
 
-// TestGetDatabasesHandler_LatencyQuery_NoUnitMultiplier is a regression test
-// for a unit bug: the latency PromQL query multiplied trace_client_duration
-// by 1000, but that metric is already in milliseconds (confirmed against
-// apm.go's identical trace_client_duration quantile queries, which apply no
-// multiplier). The bug inflated p95_latency_ms by 1000x on the real backend
-// (e.g. a real 30s redis block showed as 30,010,484ms instead of ~30,010ms).
+// latencyUnitMultiplierRE matches a "* 1000" multiplier applied to a query,
+// tolerating whitespace and a trailing decimal (e.g. "*1000", "* 1000.0").
+// The trailing \b prevents matching larger literals like "* 10000".
+var latencyUnitMultiplierRE = regexp.MustCompile(`\*\s*1000\b`)
+
+// TestDatabaseLatencyQueries_NoUnitMultiplier is a regression test for a unit
+// bug: the latency PromQL queries multiplied trace_client_duration by 1000, but
+// that metric is already in milliseconds (confirmed against apm.go's identical
+// trace_client_duration quantile queries, which apply no multiplier). The bug
+// inflated p95_latency_ms / avg_latency_ms by 1000x on the real backend (e.g. a
+// real 30s redis block showed as 30,010,484ms instead of ~30,010ms).
 //
-// The multiplication happens in the PromQL expression evaluated by the
-// metrics backend, not in Go arithmetic — a mock HTTP server can't evaluate
-// PromQL, so the only way to catch this is asserting on the query text sent.
-func TestGetDatabasesHandler_LatencyQuery_NoUnitMultiplier(t *testing.T) {
-	var capturedQueries []string
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Query string `json:"query"`
-		}
-		bodyBytes, _ := io.ReadAll(r.Body)
-		json.Unmarshal(bodyBytes, &body)
-		capturedQueries = append(capturedQueries, body.Query)
-
-		w.WriteHeader(http.StatusOK)
-		response := []map[string]any{
-			{
-				"metric": map[string]string{"db_system": "redis", "net_peer_name": "redis-cache.internal"},
-				"value":  []any{1700000000, "10.0"},
-			},
-		}
-		json.NewEncoder(w).Encode(response)
-	}))
-	defer server.Close()
-
-	handler := NewGetDatabasesHandler(server.Client(), testDBConfig(server.URL))
+// The multiplication happens in the PromQL expression evaluated by the metrics
+// backend, not in Go arithmetic — a mock HTTP server can't evaluate PromQL, so
+// the only way to catch this is asserting on the query text sent. The bug lived
+// in 3 queries across both DB handlers, so both are covered here.
+func TestDatabaseLatencyQueries_NoUnitMultiplier(t *testing.T) {
 	now := time.Now().UTC()
-	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetDatabasesArgs{
-		StartTimeISO: now.Add(-60 * time.Minute).Format(time.RFC3339),
-		EndTimeISO:   now.Format(time.RFC3339),
-	})
-	if err != nil {
-		t.Fatalf("handler returned error: %v", err)
+	tests := []struct {
+		name string
+		run  func(client *http.Client, cfg models.Config) error
+	}{
+		{
+			name: "get_databases",
+			run: func(client *http.Client, cfg models.Config) error {
+				_, _, err := NewGetDatabasesHandler(client, cfg)(context.Background(), &mcp.CallToolRequest{}, GetDatabasesArgs{
+					StartTimeISO: now.Add(-60 * time.Minute).Format(time.RFC3339),
+					EndTimeISO:   now.Format(time.RFC3339),
+				})
+				return err
+			},
+		},
+		{
+			name: "get_database_queries",
+			run: func(client *http.Client, cfg models.Config) error {
+				_, _, err := NewGetDatabaseQueriesHandler(client, cfg)(context.Background(), &mcp.CallToolRequest{}, GetDatabaseQueriesArgs{
+					DBSystem:     "redis",
+					StartTimeISO: now.Add(-60 * time.Minute).Format(time.RFC3339),
+					EndTimeISO:   now.Format(time.RFC3339),
+				})
+				return err
+			},
+		},
 	}
 
-	found := false
-	for _, q := range capturedQueries {
-		if !strings.Contains(q, "trace_client_duration") {
-			continue
-		}
-		found = true
-		if strings.Contains(q, "* 1000") {
-			t.Errorf("latency query multiplies by 1000, but trace_client_duration is already in ms: %s", q)
-		}
-	}
-	if !found {
-		t.Fatal("expected a trace_client_duration query to be issued")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				mu              sync.Mutex
+				capturedQueries []string
+			)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body struct {
+					Query string `json:"query"`
+				}
+				bodyBytes, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("failed to read request body: %v", err)
+					return
+				}
+				if err := json.Unmarshal(bodyBytes, &body); err != nil {
+					t.Errorf("failed to unmarshal request body %q: %v", bodyBytes, err)
+					return
+				}
+
+				mu.Lock()
+				capturedQueries = append(capturedQueries, body.Query)
+				mu.Unlock()
+
+				w.WriteHeader(http.StatusOK)
+				// Include labels for both handlers' grouping (db_system/net_peer_name
+				// for get_databases, span_name for get_database_queries) so each
+				// issues its latency queries.
+				response := []map[string]any{
+					{
+						"metric": map[string]string{"db_system": "redis", "net_peer_name": "redis-cache.internal", "span_name": "GET"},
+						"value":  []any{1700000000, "10.0"},
+					},
+				}
+				json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+
+			if err := tt.run(server.Client(), testDBConfig(server.URL)); err != nil {
+				t.Fatalf("handler returned error: %v", err)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			found := false
+			for _, q := range capturedQueries {
+				if !strings.Contains(q, "trace_client_duration") {
+					continue
+				}
+				found = true
+				if latencyUnitMultiplierRE.MatchString(q) {
+					t.Errorf("latency query multiplies by 1000, but trace_client_duration is already in ms: %s", q)
+				}
+			}
+			if !found {
+				t.Fatal("expected a trace_client_duration query to be issued")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

`get_databases` and `get_database_queries` multiply `trace_client_duration` by 1000 in their PromQL latency queries, on the assumption it's stored in seconds. It's already in milliseconds — confirmed against `apm.go`'s identical `trace_client_duration` quantile queries elsewhere in this codebase (used by `get_service_operations_summary` and related tools), which apply no multiplier at all on the same metric.

## Impact

`p95_latency_ms` (and `avg_latency_ms`/`p95_latency_ms` in `get_database_queries`) are inflated 1000x.

**Observed live**, debugging a customer's Redis noise: a `xreadgroup` blocking read that genuinely takes ~30s (30010.484ms) was reported by `get_databases` as `p95_latency_ms: 30010484` — read literally, ~8.3 hours. Every DB latency panel/threshold built on this tool's output is off by 3 orders of magnitude.

## Fix

Removed `* 1000` from the 3 affected PromQL query strings (`databases.go:67,464,468`).

## Testing

Since the multiplication happens in the PromQL expression evaluated by the metrics backend, not in Go arithmetic, a response-mocking test can't observe it directly (the mock server can't evaluate PromQL). Added a test asserting the query text sent has no `* 1000` for the `trace_client_duration` query — verified it fails against the buggy query and passes against the fix (see commit description for the manual before/after verification done).

Full `internal/apm` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)