### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-06
+
 ### Changed
 
 - The HTTP (Streamable HTTP) server now runs the MCP handler in **stateless** mode. Session state was previously held per-instance in memory, so running more than one replica behind a load balancer caused intermittent `404 "session not found"` when a follow-up request (`tools/list`, `tools/call`) was routed to a different instance than the one that handled `initialize` — surfacing in clients as "tools fetch failed / no capabilities" plus reconnect storms. Stateless mode lets any instance serve any request, enabling safe horizontal scaling. Transport-contract change: the server no longer validates the `Mcp-Session-Id` header, and `GET /mcp` (the server→client SSE notification stream) now returns `405`. All tools are independent request/response queries and use neither server-initiated notifications nor session-scoped state (#174).
 - Normalized MCP tool parameter names to canonical spellings so agents guess them correctly more often: `get_service_logs`, `get_service_environments`, and `get_change_events` now take `service_name` (was `service`); `get_change_events` and `get_exceptions` now take `env` (was `environment` / `deployment_environment`). The old spellings are removed — a call using them returns a recoverable `isError` rather than silently failing. `prometheus_labels` / `prometheus_label_values` additionally accept `match` as an alias of `match_query` (#176).
+- Bumped `golang.org/x/net` 0.52.0 → 0.55.0 (#175).
 
 ### Fixed
 
 - `get_databases` and `get_database_queries` reported database latency 1000x too high. Their PromQL queries multiplied `trace_client_duration` by 1000 on the assumption it was in seconds, but the metric is already in milliseconds — so `p95_latency_ms` / `avg_latency_ms` were inflated by three orders of magnitude (e.g. a real ~30s Redis blocking read surfaced as `p95_latency_ms: 30010484`, ~8.3 hours). Removed the multiplier; the values now match their `_ms` unit and the frontend's own database queries. Consumers that anchored dashboards or thresholds on the old inflated numbers will see values drop 1000x (#177).
 - Malformed tool-call input (unknown parameter name, wrong value type) now surfaces to the model as a tool-call error (`CallToolResult.isError`) instead of a swallowed JSON-RPC `-32602` protocol error, letting the agent self-correct instead of burning the call. Achieved by bumping `modelcontextprotocol/go-sdk` v1.4.1 → v1.5.0, which adopts the SEP-1303 input-validation contract (#173).
+- Single-condition trace filters in `get_traces` are now always wrapped in the `$and` logical operator that the tracejson spec requires. A bare top-level condition like `{"$eq": ["SpanKind", "SPAN_KIND_INTERNAL"]}` was forwarded unwrapped and rejected by the API; the server now normalizes one or more bare top-level field operators to `{"$and": [...]}` (keys sorted for deterministic output), while leaving a query already wrapped in `$and` / `$or` / `$not` untouched. The `get_traces` description's Example 7 was also corrected to model the wrapped form so weaker models emit valid queries directly (#172).
+- `get_alerts` now instructs the model to cap `window` at its 3600-second (1-hour) maximum when the user asks for a longer period, instead of emitting the raw computed value (e.g. `5400` for "90 minutes", `7200` for "2 hours") which the server hard-rejects with `window must be between 1 and 3600 seconds` — turning a valid intent into an error. Description-only change (#171).
 
 ## [0.9.0] - 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -325,43 +325,22 @@ Server starts at `http://localhost:8080/mcp`.
 
 ### Test with curl
 
-MCP Streamable HTTP requires an initialize handshake first. Don't set `Mcp-Session-Id` on the first request.
+The Streamable HTTP handler runs in **stateless** mode, so any request is served independently. An `initialize` handshake and an `Mcp-Session-Id` header are optional — clients that send them still work (the header is accepted and ignored), and clients can also skip straight to `tools/list` / `tools/call`. Every tool is an independent request/response query; the server issues no server→client notifications, so `GET /mcp` (the SSE stream) returns `405`.
 
 ```bash
-# Step 1: Initialize
-SESSION_ID=$(curl -si -X POST http://localhost:8080/mcp \
+# List tools — a session handshake is optional in stateless mode
+curl -s -X POST http://localhost:8080/mcp \
     -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}'
+
+# Call a tool
+curl -s -X POST http://localhost:8080/mcp \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
     -d '{
       "jsonrpc": "2.0",
-      "id": 1,
-      "method": "initialize",
-      "params": {
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": {"name": "curl-test", "version": "1.0"}
-      }
-    }' | grep -i "^Mcp-Session-Id:" | awk '{print $2}' | tr -d '\r')
-echo "Session: $SESSION_ID"
-
-# Step 2: Send initialized notification
-curl -s -X POST http://localhost:8080/mcp \
-    -H "Content-Type: application/json" \
-    -H "Mcp-Session-Id: $SESSION_ID" \
-    -d '{"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}'
-
-# Step 3: List tools
-curl -s -X POST http://localhost:8080/mcp \
-    -H "Content-Type: application/json" \
-    -H "Mcp-Session-Id: $SESSION_ID" \
-    -d '{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}'
-
-# Step 4: Call a tool
-curl -s -X POST http://localhost:8080/mcp \
-    -H "Content-Type: application/json" \
-    -H "Mcp-Session-Id: $SESSION_ID" \
-    -d '{
-      "jsonrpc": "2.0",
-      "id": 3,
+      "id": 2,
       "method": "tools/call",
       "params": {
         "name": "get_service_logs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
## Release v0.10.0

Minor bump (0.9.0 → 0.10.0) — the changeset includes **breaking changes** (removed old tool parameter spellings, stateless transport contract), so per pre-1.0 semver this is a minor.

### Changes since v0.9.0

**Changed**
- Streamable HTTP handler now runs in **stateless** mode for multi-replica safety — no more intermittent `404 "session not found"`; server no longer validates `Mcp-Session-Id`, `GET /mcp` → `405` (#174).
- Normalized MCP tool parameter names to canonical spellings (`service_name`, `env`); old spellings removed and now return a recoverable `isError`; `prometheus_labels`/`prometheus_label_values` accept `match` alias (#176).
- Bumped `golang.org/x/net` 0.52.0 → 0.55.0 (#175).

**Fixed**
- Removed erroneous 1000x multiplier on DB latency in `get_databases` / `get_database_queries` (#177).
- Malformed tool-call input now surfaces as `CallToolResult.isError` instead of a swallowed `-32602` (go-sdk v1.5.0 / SEP-1303) (#173).
- Single-condition trace filters in `get_traces` always wrapped in `$and` per tracejson spec (#172).
- `get_alerts` now instructs the model to cap `window` at 3600s instead of emitting server-rejected raw values (#171).

### Docs
- CHANGELOG `[Unreleased]` finalized as `[0.10.0] - 2026-07-06`.
- README HTTP curl example updated for stateless transport (handshake/session-id now optional).

### Release checklist (auto on merge)
- [ ] `tag-and-release` — git tag `v0.10.0` + GoReleaser
- [ ] `publish-docker` — Docker image `v0.10.0` + `latest`
- [ ] `publish-npm` — `@last9/mcp-server@0.10.0` via OIDC
- [ ] homebrew-tap dispatch — formula PR auto-merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)