### PR TITLE
feat(prompts): conditional STOP in get_exceptions + aggregate-first investigation guidance in get_logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,12 @@ traces_output.json
 
 # Local planning docs
 docs
+
+# Codex config (contains local secrets — never commit)
+.codex/
+
+# Agent/tool local dirs (never commit)
+.superpowers/
+.cursor/
+.worktrees/
+.aider*

--- a/internal/prompts/descriptions/get_exceptions.md
+++ b/internal/prompts/descriptions/get_exceptions.md
@@ -20,9 +20,10 @@ Investigation flow — follow this exactly:
      prometheus_instant_query), span exceptions often show downstream SYMPTOMS
      (retry storms, connection-pool timeouts) while the ROOT CAUSE exists only in log
      bodies (e.g. an un-instrumented dependency failing). Do NOT stop — continue to logs.
-   - When continuing to logs, use AGGREGATE/COUNT pipelines in get_logs
-     (filter service → parse level → filter ERROR → groupby logger → count): cheap and
-     wide-window-safe. NEVER chain into broad raw log pulls from here — those time out.
+   - When continuing to logs, use ONLY `get_logs` aggregate/count pipelines
+     (filter service → parse level → filter severity in (ERROR, FATAL, CRITICAL) →
+     aggregate `$count` grouped by logger): cheap and wide-window-safe.
+     Do NOT use `get_service_logs` or raw `get_logs` fetches here — those time out.
 
 limit: (Optional) The maximum number of exceptions to return. Defaults to 20.
 lookback_minutes: (Recommended) Number of minutes to look back from now. Default: 60 minutes.

--- a/internal/prompts/descriptions/get_exceptions.md
+++ b/internal/prompts/descriptions/get_exceptions.md
@@ -12,8 +12,17 @@ Investigation flow — follow this exactly:
    - env = exception.deployment_environment (if present)
    - If you somehow have a trace_id, use get_service_traces with trace_id instead of service_name.
      Never use get_traces for trace_id lookups.
-3. STOP. Report findings to the user. Do NOT call get_traces, get_service_logs,
-   or get_logs after this — those calls are unnecessary and will time out.
+3. Decide whether exceptions are the ANSWER or a SYMPTOM before reporting:
+   - Exceptions here are SPAN-DERIVED. For a well trace-instrumented service they are usually
+     the answer — report findings and stop.
+   - For a LOG-HEAVY or severity-less service (check log presence:
+     `physical_index_service_count{destination="logs", service_name="<svc>"}` via
+     prometheus_instant_query), span exceptions often show downstream SYMPTOMS
+     (retry storms, connection-pool timeouts) while the ROOT CAUSE exists only in log
+     bodies (e.g. an un-instrumented dependency failing). Do NOT stop — continue to logs.
+   - When continuing to logs, use AGGREGATE/COUNT pipelines in get_logs
+     (filter service → parse level → filter ERROR → groupby logger → count): cheap and
+     wide-window-safe. NEVER chain into broad raw log pulls from here — those time out.
 
 limit: (Optional) The maximum number of exceptions to return. Defaults to 20.
 lookback_minutes: (Recommended) Number of minutes to look back from now. Default: 60 minutes.

--- a/internal/prompts/descriptions/get_logs.md
+++ b/internal/prompts/descriptions/get_logs.md
@@ -15,6 +15,21 @@ These are instructions for constructing a natural language logs analytics querie
 - If the user asks "how many", "count", "average", "sum" → Then add aggregation
 - Most log queries are simple filtering - do NOT assume aggregation is needed
 
+**CRITICAL: INCIDENT INVESTIGATION = AGGREGATE FIRST, RAW LINES LAST**
+For error investigation, trend, onset, or blast-radius questions over any window wider than a few
+minutes, aggregation IS the requested shape — raw fetches over wide windows time out AND give wrong
+onset conclusions (a narrow raw sample is not a trend):
+1. **Discover error signatures** (do not guess strings):
+   scope filter → parse (level from Body if needed) → filter level/severity == ERROR →
+   aggregate `$count` grouped by logger/exception-class. The data ranks its own top errors.
+2. **Count by ERROR SIGNATURE, never by bare component/logger name without the ERROR gate** —
+   a logger name matches its INFO lines too and can overcount the real errors by ~100-1000×.
+3. **Trend/onset:** `window_aggregate` with `$count` over the full window (cheap, safe).
+4. **Sanity-check** any error count against the service's APM error rate
+   (`get_service_summary`): a count orders-of-magnitude above it usually means the filter
+   matched non-error noise — re-narrow and re-count.
+5. Fetch raw lines LAST, only 1–3 exemplars of the top-ranked signatures.
+
 **CRITICAL: PIPELINE ORDERING**
 - The first stage MUST be a **scope filter** (service, time, tenant, environment, host — or a match-all on non-empty Body / all services when no narrower scope applies). NEVER start with aggregate or window_aggregate.
 - **Canonical order:** scope filter(s) → parse (whenever a later stage references a field that lives inside the JSON Body) → filter/groupby on parsed or indexed fields → aggregate.

--- a/internal/prompts/descriptions/get_logs.md
+++ b/internal/prompts/descriptions/get_logs.md
@@ -20,7 +20,7 @@ For error investigation, trend, onset, or blast-radius questions over any window
 minutes, aggregation IS the requested shape — raw fetches over wide windows time out AND give wrong
 onset conclusions (a narrow raw sample is not a trend):
 1. **Discover error signatures** (do not guess strings):
-   scope filter → parse (level from Body if needed) → filter level/severity == ERROR →
+   scope filter → parse (level from Body if needed) → filter level/severity in (ERROR, FATAL, CRITICAL) →
    aggregate `$count` grouped by logger/exception-class. The data ranks its own top errors.
 2. **Count by ERROR SIGNATURE, never by bare component/logger name without the ERROR gate** —
    a logger name matches its INFO lines too and can overcount the real errors by ~100-1000×.


### PR DESCRIPTION
## Problem

`get_exceptions.md` carried an unconditional "STOP — do not call log tools" instruction. This misdirected investigations on log-heavy/severity-less services, where span exceptions are downstream symptoms (retry storms, pool timeouts) and the root cause exists only in log bodies.

## Changes

**get_exceptions.md**: rewritten as a regime conditional instead of a blanket stop. Trace-instrumented services still stop (timeout protection for broad raw pulls retained). Log-heavy services continue to logs via aggregate/count pipelines (cheap, wide-window-safe). Regime discriminator: `physical_index_service_count` log presence.

**get_logs.md**: new CRITICAL block for incident investigation:
- Discover error signatures via ERROR-gated group-by (never guess strings)
- Never count a bare component/logger name without the ERROR gate (observed ~750x overcount in the wild)
- Trend/onset via `window_aggregate`
- Sanity-check counts against the service's APM error rate
- Fetch raw exemplars last

**.gitignore**: adds `.codex/` and other local agent/tool dirs so local credentials and agent state can never be committed.

## Eval evidence (last9-mcp-evals)

- Exception suite: 9/9 passing with the new text vs 7/9 with the old (eq-008/eq-009 fail on the old misdirecting STOP)
- Log suite: passes including new lq-104/lq-105 count-discipline cases

Pairs with the last9-mcp-evals PR `feat/investigation-guardrail-evals`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)