### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-17
+
 ### Added
 
 - `get_apm_service_deviations` MCP tool comparing a current window against an equal-duration baseline (fleet or single service). Returns `regressions`/`improvements` leaderboards, `evidence_quality`, an Apdex reconciliation, and a terminal `outcome`. Arithmetic is computed server-side; correlations are supporting evidence only. V1 supports server-request workloads (#184).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
Minor release **0.12.0** — two new MCP tool sets since v0.11.0. Merging bumps the version in \`package.json\`, which triggers the automated release pipeline.

## What changed since v0.11.0

### Added
- **\`get_apm_service_deviations\`** — bounded APM service deviation analysis: compares a current window against an equal-duration baseline (fleet or single service), returns \`regressions\`/\`improvements\` leaderboards, \`evidence_quality\`, an Apdex reconciliation, and a terminal \`outcome\`. V1 supports server-request workloads (#184).
- **\`list_dashboard_snapshots\` / \`get_dashboard_snapshot\` / \`delete_dashboard_snapshot\`** — MCP tools for frozen point-in-time dashboard snapshots (#185).

## Release checklist (auto on merge)
- [ ] \`tag-and-release\` — detects version change, tags \`v0.12.0\`, runs GoReleaser
- [ ] \`publish-docker\` — pushes image to \`docker-registry.last9.io\` + ECR (\`v0.12.0\`, \`latest\`)
- [ ] \`publish-npm\` — publishes \`@last9/mcp-server@0.12.0\` via OIDC
- [ ] homebrew-tap dispatch — opens + auto-merges formula PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)