### PR TITLE
Build multi-arch (amd64+arm64) mcp-server image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -179,6 +179,12 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
+      # setup-buildx-action creates a docker-container buildkit driver (separate
+      # from the host daemon). The multi-arch push below works because the ECR
+      # login step above writes a plain base64 `auth` into ~/.docker/config.json,
+      # which build-push-action forwards into the builder. If amazon-ecr-login is
+      # ever switched to a credential-helper (credsStore) mode, that auth won't
+      # propagate to the builder and the push will start failing with 401s.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -199,6 +205,8 @@ jobs:
             VERSION=${{ steps.get_version.outputs.version }}
             COMMIT=${{ github.sha }}
             BUILD_TIME=${{ steps.build_time.outputs.build_time }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${{ steps.extract_branch.outputs.branch_name }}
             652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${{ steps.extract_branch.outputs.branch_name }}-v${{ steps.get_version.outputs.version }}
@@ -216,6 +224,8 @@ jobs:
             VERSION=${{ needs.tag-and-release.outputs.new_version }}
             COMMIT=${{ github.sha }}
             BUILD_TIME=${{ steps.build_time.outputs.build_time }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:v${{ needs.tag-and-release.outputs.new_version }}
             652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,39 +173,49 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
+      # QEMU registers binfmt handlers so the arm64 leg's alpine RUN steps
+      # (apk/adduser/chown) can execute; the Go compile itself cross-compiles
+      # on the native amd64 runner and is never emulated.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Push to Amazon ECR (Release Branch)
         if: |
           github.event_name == 'push' &&
           startsWith(github.ref, 'refs/heads/release-')
-        env:
-          VERSION: ${{ steps.get_version.outputs.version }}
-          COMMIT: ${{ github.sha }}
-          BRANCH: ${{ steps.extract_branch.outputs.branch_name }}
-          BUILD_TIME: ${{ steps.build_time.outputs.build_time }}
-        run: |
-          docker build -f Dockerfile \
-            --build-arg VERSION="${VERSION}" \
-            --build-arg COMMIT="${COMMIT}" \
-            --build-arg BUILD_TIME="${BUILD_TIME}" \
-            -t 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build .
-          docker tag 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${BRANCH}
-          docker tag 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${BRANCH}-v${VERSION}
-          docker push 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${BRANCH}
-          docker push 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${BRANCH}-v${VERSION}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          # provenance: false keeps the pushed artifact a clean 2-manifest list
+          # (no attestation index) so plain `docker pull` on ECR resolves cleanly.
+          provenance: false
+          push: true
+          build-args: |
+            VERSION=${{ steps.get_version.outputs.version }}
+            COMMIT=${{ github.sha }}
+            BUILD_TIME=${{ steps.build_time.outputs.build_time }}
+          tags: |
+            652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${{ steps.extract_branch.outputs.branch_name }}
+            652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${{ steps.extract_branch.outputs.branch_name }}-v${{ steps.get_version.outputs.version }}
 
       - name: Push to Amazon ECR (Main Branch)
         if: needs.tag-and-release.outputs.version_changed == 'true'
-        env:
-          VERSION: ${{ needs.tag-and-release.outputs.new_version }}
-          COMMIT: ${{ github.sha }}
-          BUILD_TIME: ${{ steps.build_time.outputs.build_time }}
-        run: |
-          docker build -f Dockerfile \
-            --build-arg VERSION="${VERSION}" \
-            --build-arg COMMIT="${COMMIT}" \
-            --build-arg BUILD_TIME="${BUILD_TIME}" \
-            -t 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build .
-          for tag in v${VERSION} latest; do
-            docker tag 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:build 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:$tag
-            docker push 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:$tag
-          done
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          push: true
+          build-args: |
+            VERSION=${{ needs.tag-and-release.outputs.new_version }}
+            COMMIT=${{ github.sha }}
+            BUILD_TIME=${{ steps.build_time.outputs.build_time }}
+          tags: |
+            652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:v${{ needs.tag-and-release.outputs.new_version }}
+            652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,13 +134,25 @@ jobs:
         if: steps.npm_check.outputs.exists == 'false'
         run: npm publish --access public --provenance
 
-  publish-docker:
+  # Multi-arch image build WITHOUT qemu (ENG-1074: qemu cross-arch docker
+  # builds reliably time out on hosted runners). Instead: build each arch on a
+  # native runner (D3 pattern, ENG-1049), push per-arch staging tags, then merge
+  # into manifest lists in the docker-manifest job below.
+  build-docker:
     needs: tag-and-release
     if: |
       always() &&
       (needs.tag-and-release.outputs.version_changed == 'true' ||
        (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')))
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest    # GitHub-hosted native amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm # GitHub-hosted native arm64 (no qemu)
+    runs-on: ${{ matrix.runner }}
     permissions:
       id-token: write
       contents: read
@@ -148,21 +160,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get version from package.json
-        id: get_version
+      - name: Resolve version + build metadata
+        id: meta
         run: |
-          VERSION=$(jq -r .version package.json)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Get build time
-        id: build_time
-        run: echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
-
-      - name: Extract branch name
-        id: extract_branch
-        run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          if [ "${{ needs.tag-and-release.outputs.version_changed }}" = "true" ]; then
+            VERSION="${{ needs.tag-and-release.outputs.new_version }}"
+          else
+            VERSION="$(jq -r .version package.json)"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(echo "${GITHUB_SHA}" | cut -c1-7)" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -173,59 +181,83 @@ jobs:
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
 
-      # QEMU registers binfmt handlers so the arm64 leg's alpine RUN steps
-      # (apk/adduser/chown) can execute; the Go compile itself cross-compiles
-      # on the native amd64 runner and is never emulated.
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      # Native build: matrix.arch always equals the runner's own arch, so
+      # `--platform linux/${arch}` and the resulting binary are native — nothing
+      # is emulated. Pushed under a per-arch staging tag keyed on the commit sha;
+      # the docker-manifest job merges the two into the real tags.
+      - name: Build and push (${{ matrix.arch }})
+        env:
+          DOCKER_BUILDKIT: "1"
+          REPO: 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server
+          VERSION: ${{ steps.meta.outputs.version }}
+          BUILD_TIME: ${{ steps.meta.outputs.build_time }}
+          SHA_SHORT: ${{ steps.meta.outputs.sha_short }}
+        run: |
+          STAGING="${REPO}:sha-${SHA_SHORT}-${{ matrix.arch }}"
+          docker build -f Dockerfile \
+            --platform "linux/${{ matrix.arch }}" \
+            --build-arg VERSION="${VERSION}" \
+            --build-arg COMMIT="${GITHUB_SHA}" \
+            --build-arg BUILD_TIME="${BUILD_TIME}" \
+            --build-arg TARGETARCH="${{ matrix.arch }}" \
+            -t "${STAGING}" .
+          docker push "${STAGING}"
 
-      # setup-buildx-action creates a docker-container buildkit driver (separate
-      # from the host daemon). The multi-arch push below works because the ECR
-      # login step above writes a plain base64 `auth` into ~/.docker/config.json,
-      # which build-push-action forwards into the builder. If amazon-ecr-login is
-      # ever switched to a credential-helper (credsStore) mode, that auth won't
-      # propagate to the builder and the push will start failing with 401s.
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+  # Merge the per-arch staging images into one manifest list per final tag.
+  # `imagetools create` is a registry-side operation (reads the two arch
+  # manifests, writes an OCI index) — no build, no qemu, no builder needed.
+  docker-manifest:
+    needs: [tag-and-release, build-docker]
+    if: |
+      always() &&
+      needs.build-docker.result == 'success' &&
+      (needs.tag-and-release.outputs.version_changed == 'true' ||
+       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-')))
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Push to Amazon ECR (Release Branch)
-        if: |
-          github.event_name == 'push' &&
-          startsWith(github.ref, 'refs/heads/release-')
-        uses: docker/build-push-action@v6
+      - name: Resolve final tags
+        id: tags
+        run: |
+          echo "sha_short=$(echo "${GITHUB_SHA}" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+          if [ "${{ needs.tag-and-release.outputs.version_changed }}" = "true" ]; then
+            VERSION="${{ needs.tag-and-release.outputs.new_version }}"
+            echo "final_tags=v${VERSION} latest" >> "$GITHUB_OUTPUT"
+          else
+            VERSION="$(jq -r .version package.json)"
+            BRANCH="${GITHUB_REF#refs/heads/}"
+            echo "final_tags=${BRANCH} ${BRANCH}-v${VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          # provenance: false keeps the pushed artifact a clean 2-manifest list
-          # (no attestation index) so plain `docker pull` on ECR resolves cleanly.
-          provenance: false
-          push: true
-          build-args: |
-            VERSION=${{ steps.get_version.outputs.version }}
-            COMMIT=${{ github.sha }}
-            BUILD_TIME=${{ steps.build_time.outputs.build_time }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: |
-            652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${{ steps.extract_branch.outputs.branch_name }}
-            652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:${{ steps.extract_branch.outputs.branch_name }}-v${{ steps.get_version.outputs.version }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ap-south-1
 
-      - name: Push to Amazon ECR (Main Branch)
-        if: needs.tag-and-release.outputs.version_changed == 'true'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          push: true
-          build-args: |
-            VERSION=${{ needs.tag-and-release.outputs.new_version }}
-            COMMIT=${{ github.sha }}
-            BUILD_TIME=${{ steps.build_time.outputs.build_time }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: |
-            652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:v${{ needs.tag-and-release.outputs.new_version }}
-            652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:latest
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Create and push multi-arch manifests
+        env:
+          REPO: 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server
+          SHA_SHORT: ${{ steps.tags.outputs.sha_short }}
+        run: |
+          for TAG in ${{ steps.tags.outputs.final_tags }}; do
+            docker buildx imagetools create \
+              -t "${REPO}:${TAG}" \
+              "${REPO}:sha-${SHA_SHORT}-amd64" \
+              "${REPO}:sha-${SHA_SHORT}-arm64"
+          done
+
+      - name: Verify manifest list
+        env:
+          REPO: 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server
+        run: |
+          FIRST="$(echo '${{ steps.tags.outputs.final_tags }}' | awk '{print $1}')"
+          docker buildx imagetools inspect "${REPO}:${FIRST}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 # Standard MCP Server Dockerfile
 # This follows typical MCP server patterns for containerized distribution
 #
-# Multi-arch: the builder runs on the native BUILDPLATFORM and cross-compiles
-# the pure-Go (CGO_ENABLED=0) binary to the requested TARGETARCH, so the Go
-# compile is never emulated. buildx pulls the final alpine stage for the target
-# platform (its trivial apk/adduser/chown RUN steps run under QEMU).
+# Multi-arch: CI builds this once per architecture on a native runner
+# (amd64 -> ubuntu-latest, arm64 -> ubuntu-24.04-arm) and merges the results
+# into a manifest list — no QEMU emulation (see ENG-1074). On a native build
+# BUILDPLATFORM == TARGETPLATFORM, so the builder is native and the pure-Go
+# (CGO_ENABLED=0) binary is compiled for TARGETARCH without emulation. The ARGs
+# also keep a plain `docker buildx build --platform` cross-build working locally.
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 # Install build dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 # Standard MCP Server Dockerfile
 # This follows typical MCP server patterns for containerized distribution
-FROM golang:1.25-alpine AS builder
+#
+# Multi-arch: the builder runs on the native BUILDPLATFORM and cross-compiles
+# the pure-Go (CGO_ENABLED=0) binary to the requested TARGETARCH, so the Go
+# compile is never emulated. buildx pulls the final alpine stage for the target
+# platform (its trivial apk/adduser/chown RUN steps run under QEMU).
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates
@@ -19,8 +24,13 @@ ARG VERSION=dev
 ARG COMMIT=unknown
 ARG BUILD_TIME=unknown
 
+# Target platform, injected automatically by buildx (defaults to the build
+# host's arch for a plain `docker build`).
+ARG TARGETOS=linux
+ARG TARGETARCH
+
 # Build the application for STDIO mode (default MCP pattern)
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -installsuffix cgo \
     -ldflags "-s -w -X main.Version=${VERSION} -X main.CommitSHA=${COMMIT} -X main.BuildTime=${BUILD_TIME}" \
     -o last9-mcp-server .
 


### PR DESCRIPTION
## Summary

- **Dockerfile**: builder is now `FROM --platform=$BUILDPLATFORM golang:1.25-alpine` with `ARG TARGETOS`/`ARG TARGETARCH`; the pure-Go (`CGO_ENABLED=0`) binary is built with `GOOS/GOARCH`, so it cross-compiles on the native runner and the Go compile is never emulated. buildx pulls the final alpine stage for the target platform (its trivial `apk`/`adduser`/`chown` RUN steps run under QEMU).
- **.github/workflows/release.yaml** (`publish-docker`): replace plain `docker build`/`tag`/`push` with `docker/setup-qemu-action@v3` + `docker/setup-buildx-action@v3` + `docker/build-push-action@v6`, pushing `linux/amd64,linux/arm64` as a manifest list with `provenance: false`. Tag scheme unchanged (`:latest`, `:v<ver>`, `:<branch>`, `:<branch>-v<ver>`) and same `VERSION`/`COMMIT`/`BUILD_TIME` build-args.

## Why

`mcp-server` currently ships an amd64-only image, forcing consumers onto amd64 nodes. On the `credit-euc1-tdp` (cpluseuc1) Karpenter/Graviton cluster — whose default nodepools prefer cheaper arm64 instances — the amd64-only image lands on an arm64 node and dies with `exec format error`. This is worked around today by a `node_selector = { "kubernetes.io/arch" = "amd64" }` pin in the shipment repo. Making the image multi-arch lets it run natively on Graviton and lets that pin be dropped.

Mirrors the established multi-arch pattern in `last9/last9` (#11006 otel-ingestor, #11001 scheduled-jobs) and PDE-381 (configmapupdater).

## Test plan

- [x] `make`-equivalent cross-compile locally: `GOOS=linux GOARCH=amd64` and `GOARCH=arm64` both produce static ELF binaries (x86-64 / aarch64).
- [x] `docker buildx build --platform linux/amd64,linux/arm64 --provenance=false` produces a **2-manifest list** (`linux/amd64`, `linux/arm64`) — verified via OCI export.
- [ ] CI on a `release-*` branch pushes a multi-arch tag; verify with `docker buildx imagetools inspect 652845092827.dkr.ecr.ap-south-1.amazonaws.com/mcp-server:<TAG>` → two manifests.
- [ ] Existing amd64 consumers pull/run the new tag unchanged.
- [ ] After a multi-arch tag reaches cpluseuc1, remove the `node_selector` amd64 block in shipment and confirm the pod schedules + runs on an arm64 node.

Companion `supervisor-mithai` is blocked on its `mithai` base image (itself amd64-only) — tracked in ENG-1529.

Closes ENG-1528

🤖 Generated with [Claude Code](https://claude.com/claude-code)