### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-22
+
+### Changed
+
+- `mcp-server` Docker image is now multi-arch (`linux/amd64` + `linux/arm64`), built with `docker buildx` and pushed as a manifest list. Lets the image run natively on arm64/Graviton nodes without an amd64 node-selector pin (#192).
+
 ## [0.12.0] - 2026-07-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
Patch/minor release **0.13.0** — one change since v0.12.0. Merging bumps the version in `package.json`, which triggers the automated release pipeline.

## What changed since v0.12.0

### Changed
- `mcp-server` Docker image is now multi-arch (`linux/amd64` + `linux/arm64`), built with `docker buildx` and pushed as a manifest list. Lets the image run natively on arm64/Graviton nodes without an amd64 node-selector pin (#192).

## Release checklist (auto on merge)
- [ ] `tag-and-release` — detects version change, tags `v0.13.0`, runs GoReleaser
- [ ] `publish-docker` — pushes multi-arch image to `docker-registry.last9.io` + ECR (`v0.13.0`, `latest`)
- [ ] `publish-npm` — publishes `@last9/mcp-server@0.13.0` via OIDC
- [ ] homebrew-tap dispatch — opens + auto-merges formula PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)