### PR TITLE
fix(traces): never chunk aggregate pipelines; rewrite $exists to the working existence idiom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `get_traces` no longer chunks `aggregate`/`window_aggregate` pipelines — long-window group-by queries run as a single request, fixing duplicate keys and wrong `avg`/`median`/`quantile` math (#195).
+- Trace filter existence checks: `$exists` and `$notnull` are rewritten to `{"$neq": [field, ""]}` before hitting the backend (previously matched all spans / no spans respectively) (#195).
+
+### Changed
+
+- `get_traces` filter schema drops `$exists`/`$notnull` in favor of the `{"$neq": [field, ""]}` idiom; trace-query 408s now return a "narrow the window" error (#195).
+
 ## [0.13.0] - 2026-07-22
 
 ### Changed

--- a/internal/apm/databases.go
+++ b/internal/apm/databases.go
@@ -261,7 +261,7 @@ func NewGetDatabaseSlowQueriesHandler(client *http.Client, cfg models.Config) fu
 		} else {
 			// No specific db_system — match any span that has db.system set
 			conditions = append(conditions, map[string]any{
-				"$exists": []any{"attributes.db.system"},
+				"$neq": []any{"attributes['db.system']", ""},
 			})
 		}
 

--- a/internal/prompts/descriptions/get_traces.md
+++ b/internal/prompts/descriptions/get_traces.md
@@ -451,5 +451,6 @@ When a user asks about traces:
 5. **If the user query is ambiguous**, ask for clarification instead of guessing
 6. **Use filter or aggregation** only on labels passed in prompt
 7. **Always analyze the results** and provide insights
+8. **If the response includes `_last9_mcp.partial_result: true`**, the result is incomplete — a time chunk failed. Tell the user the data is partial, then narrow the time window (`start_time_iso`/`end_time_iso`) and retry.
 
 **CRITICAL: Always execute queries with tools - never show raw JSON to users**

--- a/internal/telemetry/logs/logs.go
+++ b/internal/telemetry/logs/logs.go
@@ -23,11 +23,6 @@ import (
 const defaultGetLogsLookbackMinutes = 5
 const partialResultMetadataKey = "_last9_mcp"
 
-var nonChunkedLogQueryStageTypes = []string{
-	"aggregate",
-	"window_aggregate",
-}
-
 // GetLogsArgs represents the input arguments for the get_logs tool
 type GetLogsArgs struct {
 	LogjsonQuery    []map[string]interface{} `json:"logjson_query,omitempty" jsonschema:"JSON pipeline query for logs (required)"`
@@ -341,20 +336,17 @@ func effectiveGetLogsChunkLimit(cfg models.Config, requestedLimit int) int {
 	return requestedLimit
 }
 
+// shouldChunkGetLogsQuery returns false for pipelines containing an
+// "aggregate" or "window_aggregate" stage: chunking those and concatenating
+// per-chunk results would produce duplicate group-by keys and mathematically
+// wrong aggregates, so they must run as a single, unchunked request.
 func shouldChunkGetLogsQuery(logjsonQuery interface{}) bool {
 	stages, ok := logjsonQuery.([]map[string]interface{})
 	if !ok {
 		return false
 	}
 
-	for _, stage := range stages {
-		stageType, _ := stage["type"].(string)
-		if slices.Contains(nonChunkedLogQueryStageTypes, stageType) {
-			return false
-		}
-	}
-
-	return true
+	return !utils.PipelineHasAggregateStage(stages)
 }
 
 func executeLogJSONQuery(ctx context.Context, client *http.Client, cfg models.Config, logjsonQuery interface{}, startTime, endTime int64, limit int, index string) (map[string]interface{}, error) {

--- a/internal/telemetry/traces/chunking_test.go
+++ b/internal/telemetry/traces/chunking_test.go
@@ -79,7 +79,7 @@ func TestGetTracesHandlerChunksAndHonorsLimit(t *testing.T) {
 		TracejsonQuery: []map[string]interface{}{
 			{
 				"type":  "filter",
-				"query": map[string]interface{}{"$exists": []string{"ServiceName"}},
+				"query": map[string]interface{}{"$neq": []interface{}{"ServiceName", ""}},
 			},
 		},
 		StartTimeISO: "1970-01-01T00:00:00Z",
@@ -130,7 +130,7 @@ func TestGetTracesHandlerCapsAtConfiguredMax(t *testing.T) {
 	handler := NewGetTracesHandler(server.Client(), cfg)
 	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
 		TracejsonQuery: []map[string]interface{}{
-			{"type": "filter", "query": map[string]interface{}{"$exists": []string{"ServiceName"}}},
+			{"type": "filter", "query": map[string]interface{}{"$neq": []interface{}{"ServiceName", ""}}},
 		},
 		StartTimeISO: "1970-01-01T00:00:00Z",
 		EndTimeISO:   "1970-01-01T01:30:00Z",
@@ -164,7 +164,7 @@ func TestGetTracesHandlerSingleChunkForSubThresholdRange(t *testing.T) {
 	// 30 min range — below SplitThresholdMs → adaptive returns a single chunk.
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
 		TracejsonQuery: []map[string]interface{}{
-			{"type": "filter", "query": map[string]interface{}{"$exists": []string{"ServiceName"}}},
+			{"type": "filter", "query": map[string]interface{}{"$neq": []interface{}{"ServiceName", ""}}},
 		},
 		StartTimeISO: "1970-01-01T00:00:00Z",
 		EndTimeISO:   "1970-01-01T00:30:00Z",
@@ -189,7 +189,7 @@ func TestGetTracesHandlerEmptyChunks(t *testing.T) {
 	handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
 	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
 		TracejsonQuery: []map[string]interface{}{
-			{"type": "filter", "query": map[string]interface{}{"$exists": []string{"ServiceName"}}},
+			{"type": "filter", "query": map[string]interface{}{"$neq": []interface{}{"ServiceName", ""}}},
 		},
 		StartTimeISO: "1970-01-01T00:00:00Z",
 		EndTimeISO:   "1970-01-01T00:07:00Z",
@@ -262,7 +262,7 @@ func TestGetTracesHandlerDoesNotChunkAggregateQueries(t *testing.T) {
 	handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
 	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
 		TracejsonQuery: []map[string]interface{}{
-			{"type": "filter", "query": map[string]interface{}{"$exists": []string{"ServiceName"}}},
+			{"type": "filter", "query": map[string]interface{}{"$neq": []interface{}{"ServiceName", ""}}},
 			{"type": "aggregate"},
 		},
 		// 7-day window: without the aggregate guard this would chunk into
@@ -323,7 +323,7 @@ func TestGetTracesHandlerPlainFilterOverSevenDaysStillChunks(t *testing.T) {
 	handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
 		TracejsonQuery: []map[string]interface{}{
-			{"type": "filter", "query": map[string]interface{}{"$exists": []string{"ServiceName"}}},
+			{"type": "filter", "query": map[string]interface{}{"$neq": []interface{}{"ServiceName", ""}}},
 		},
 		StartTimeISO: "2026-01-01T00:00:00Z",
 		EndTimeISO:   "2026-01-08T00:00:00Z",
@@ -375,7 +375,7 @@ func TestGetTracesHandlerHardErrorsWhenAllChunksFail(t *testing.T) {
 	handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
 	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
 		TracejsonQuery: []map[string]interface{}{
-			{"type": "filter", "query": map[string]interface{}{"$exists": []string{"ServiceName"}}},
+			{"type": "filter", "query": map[string]interface{}{"$neq": []interface{}{"ServiceName", ""}}},
 		},
 		StartTimeISO: "1970-01-01T00:00:00Z",
 		EndTimeISO:   "1970-01-01T01:30:00Z",
@@ -423,7 +423,7 @@ func TestGetTracesHandlerReturnsPartialResultAfterLaterChunkError(t *testing.T) 
 	handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
 	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
 		TracejsonQuery: []map[string]interface{}{
-			{"type": "filter", "query": map[string]interface{}{"$exists": []string{"ServiceName"}}},
+			{"type": "filter", "query": map[string]interface{}{"$neq": []interface{}{"ServiceName", ""}}},
 		},
 		StartTimeISO: "1970-01-01T00:00:00Z",
 		EndTimeISO:   "1970-01-01T01:30:00Z",

--- a/internal/telemetry/traces/chunking_test.go
+++ b/internal/telemetry/traces/chunking_test.go
@@ -251,6 +251,115 @@ func TestGetTracesHandlerExactTraceIDUsesSingleRequest(t *testing.T) {
 	}
 }
 
+func TestGetTracesHandlerDoesNotChunkAggregateQueries(t *testing.T) {
+	rec := newTracesRequestRecorder()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.add(r.URL.Query())
+		_, _ = w.Write([]byte(traceAPIResponse(2)))
+	}))
+	defer server.Close()
+
+	handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
+		TracejsonQuery: []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{"$exists": []string{"ServiceName"}}},
+			{"type": "aggregate"},
+		},
+		// 7-day window: without the aggregate guard this would chunk into
+		// many ~1h requests and concatenate per-chunk aggregate results,
+		// producing duplicate group-by keys and wrong avg/median/quantile.
+		StartTimeISO: "2026-01-01T00:00:00Z",
+		EndTimeISO:   "2026-01-08T00:00:00Z",
+		Limit:        10,
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if got := rec.count(); got != 1 {
+		t.Fatalf("expected aggregate pipeline over 7-day window to issue exactly 1 request, got %d", got)
+	}
+
+	payload := parseTracesToolResult(t, result)
+	if count := countTracesInPayload(t, payload); count != 2 {
+		t.Fatalf("expected 2 traces in single-request payload, got %d", count)
+	}
+}
+
+func TestGetTracesHandlerWindowAggregateAlsoUsesSingleRequest(t *testing.T) {
+	rec := newTracesRequestRecorder()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.add(r.URL.Query())
+		_, _ = w.Write([]byte(traceAPIResponse(1)))
+	}))
+	defer server.Close()
+
+	handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
+		TracejsonQuery: []map[string]interface{}{
+			{"type": "window_aggregate"},
+		},
+		StartTimeISO: "2026-01-01T00:00:00Z",
+		EndTimeISO:   "2026-01-08T00:00:00Z",
+		Limit:        10,
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if got := rec.count(); got != 1 {
+		t.Fatalf("expected window_aggregate pipeline over 7-day window to issue exactly 1 request, got %d", got)
+	}
+}
+
+func TestGetTracesHandlerPlainFilterOverSevenDaysStillChunks(t *testing.T) {
+	rec := newTracesRequestRecorder()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec.add(r.URL.Query())
+		_, _ = w.Write([]byte(traceAPIResponse(0)))
+	}))
+	defer server.Close()
+
+	handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
+		TracejsonQuery: []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{"$exists": []string{"ServiceName"}}},
+		},
+		StartTimeISO: "2026-01-01T00:00:00Z",
+		EndTimeISO:   "2026-01-08T00:00:00Z",
+		Limit:        10,
+	})
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if got := rec.count(); got <= 1 {
+		t.Fatalf("expected non-aggregate pipeline over 7-day window to chunk (>1 requests), got %d", got)
+	}
+}
+
+func TestGetTracesHandlerAggregateSingleRequestTimeoutHintsNarrowerWindow(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "query timeout", http.StatusRequestTimeout)
+	}))
+	defer server.Close()
+
+	handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
+		TracejsonQuery: []map[string]interface{}{
+			{"type": "aggregate"},
+		},
+		StartTimeISO: "2026-01-01T00:00:00Z",
+		EndTimeISO:   "2026-01-08T00:00:00Z",
+	})
+	if err == nil {
+		t.Fatalf("expected error when upstream returns 408")
+	}
+	if !strings.Contains(err.Error(), "narrow the time window") {
+		t.Fatalf("expected error to hint narrowing the time window, got: %v", err)
+	}
+}
+
 func TestGetTracesHandlerHardErrorsWhenAllChunksFail(t *testing.T) {
 	// Regression: when every chunk returns an upstream error and no chunk
 	// produced a valid response, fetchTraceJSONQuery must surface a hard

--- a/internal/telemetry/traces/input_schema.go
+++ b/internal/telemetry/traces/input_schema.go
@@ -66,7 +66,7 @@ func filterStageSchema() map[string]interface{} {
 					"Numeric: $gt, $lt, $gte, $lte. " +
 					"String: $contains, $notcontains, $icontains, $inotcontains, $containsWords, $notcontainsWords, $icontainsWords, $inotcontainsWords. " +
 					"Regex: $regex, $notregex, $iregex, $inotregex. " +
-					"Existence: $notnull. " +
+					"Existence: no $notnull operator — use $neq against an empty string instead, e.g. {\"$neq\": [field, \"\"]}. " +
 					"Each operator takes [field, value] except logical operators which take an array of conditions. " +
 					"Example: {\"$and\": [{\"$eq\": [\"ServiceName\", \"api\"]}, {\"$eq\": [\"StatusCode\", \"STATUS_CODE_ERROR\"]}]}",
 			},

--- a/internal/telemetry/traces/query_sanitize.go
+++ b/internal/telemetry/traces/query_sanitize.go
@@ -10,7 +10,6 @@ var traceFilterFieldOperators = map[string]struct{}{
 	"$contains":          {},
 	"$containsWords":     {},
 	"$eq":                {},
-	"$exists":            {},
 	"$gt":                {},
 	"$gte":               {},
 	"$icontains":         {},
@@ -51,6 +50,12 @@ func sanitizeTraceJSONQuery(stages []map[string]interface{}) error {
 
 		if stageType == "filter" || stageType == "where" {
 			if query, ok := stage["query"]; ok {
+				// The backend has no $exists operator — an unknown operator
+				// compiles to `1=1` and silently matches every span instead of
+				// erroring, so rewrite it to the working idiom before
+				// validation ever sees it. Covers $exists nested inside
+				// $and/$or/$not since it walks the same condition tree.
+				rewriteExistsOperator(query)
 				if err := validateTraceFilterCondition(query, path+".query"); err != nil {
 					return err
 				}
@@ -107,6 +112,37 @@ func wrapTopLevelFilterQuery(query interface{}) interface{} {
 	return map[string]interface{}{"$and": conditions}
 }
 
+// rewriteExistsOperator walks a filter condition tree and rewrites every
+// $exists leaf ({"$exists": [field]}) in place to the working existence idiom
+// {"$neq": [field, ""]}. The backend has no $exists operator; passing it
+// through compiles to `1=1` and silently matches every span rather than
+// erroring, so models' natural "$exists" output is normalized here instead of
+// rejected. Recurses through $and/$or/$not so nested conditions are covered.
+func rewriteExistsOperator(value interface{}) {
+	switch typed := value.(type) {
+	case []interface{}:
+		for _, item := range typed {
+			rewriteExistsOperator(item)
+		}
+	case map[string]interface{}:
+		for key, item := range typed {
+			if _, isLogical := traceFilterLogicalOperators[key]; isLogical {
+				rewriteExistsOperator(item)
+				continue
+			}
+			if key != "$exists" {
+				continue
+			}
+			args, ok := item.([]interface{})
+			if !ok || len(args) == 0 {
+				continue
+			}
+			delete(typed, "$exists")
+			typed["$neq"] = []interface{}{args[0], ""}
+		}
+	}
+}
+
 func validateTraceFilterCondition(value interface{}, path string) error {
 	switch typed := value.(type) {
 	case []interface{}:
@@ -127,7 +163,7 @@ func validateTraceFilterCondition(value interface{}, path string) error {
 				continue
 			}
 			return fmt.Errorf(
-				"invalid filter condition key %q at %s: keys must be operators ($eq, $neq, $gt, $gte, $lt, $lte, $contains, $notcontains, $icontains, $inotcontains, $icontainsWords, $inotcontainsWords, $regex, $notregex, $iregex, $inotregex, $ieq, $ineq, $notnull, $exists, $containsWords, $notcontainsWords) or logical operators ($and, $or, $not); use the form {%q: [field, value]} — for example {\"$eq\": [\"ServiceName\", \"checkout\"]}",
+				"invalid filter condition key %q at %s: keys must be operators ($eq, $neq, $gt, $gte, $lt, $lte, $contains, $notcontains, $icontains, $inotcontains, $icontainsWords, $inotcontainsWords, $regex, $notregex, $iregex, $inotregex, $ieq, $ineq, $notnull, $containsWords, $notcontainsWords) or logical operators ($and, $or, $not); use the form {%q: [field, value]} — for example {\"$eq\": [\"ServiceName\", \"checkout\"]}. For existence checks use {\"$neq\": [field, \"\"]} — there is no $exists operator.",
 				key,
 				path,
 				"$eq",

--- a/internal/telemetry/traces/query_sanitize.go
+++ b/internal/telemetry/traces/query_sanitize.go
@@ -26,9 +26,10 @@ var traceFilterFieldOperators = map[string]struct{}{
 	"$notcontains":       {},
 	"$notcontainsWords":  {},
 	"$notregex":          {},
-	"$notnull":           {},
 	"$regex":             {},
 }
+
+var brokenExistenceOperators = []string{"$exists", "$notnull"}
 
 var traceFilterLogicalOperators = map[string]struct{}{
 	"$and": {},
@@ -50,12 +51,11 @@ func sanitizeTraceJSONQuery(stages []map[string]interface{}) error {
 
 		if stageType == "filter" || stageType == "where" {
 			if query, ok := stage["query"]; ok {
-				// The backend has no $exists operator — an unknown operator
-				// compiles to `1=1` and silently matches every span instead of
-				// erroring, so rewrite it to the working idiom before
-				// validation ever sees it. Covers $exists nested inside
-				// $and/$or/$not since it walks the same condition tree.
-				rewriteExistsOperator(query)
+				// The backend has no $exists operator (unknown ops compile to
+				// `1=1`) and $notnull compiles to `!= null` (matches nothing in
+				// ClickHouse). Rewrite both to the working idiom before
+				// validation ever sees them. Recurses through $and/$or/$not.
+				rewriteBrokenExistenceOperators(query)
 				if err := validateTraceFilterCondition(query, path+".query"); err != nil {
 					return err
 				}
@@ -112,34 +112,50 @@ func wrapTopLevelFilterQuery(query interface{}) interface{} {
 	return map[string]interface{}{"$and": conditions}
 }
 
-// rewriteExistsOperator walks a filter condition tree and rewrites every
-// $exists leaf ({"$exists": [field]}) in place to the working existence idiom
-// {"$neq": [field, ""]}. The backend has no $exists operator; passing it
-// through compiles to `1=1` and silently matches every span rather than
-// erroring, so models' natural "$exists" output is normalized here instead of
-// rejected. Recurses through $and/$or/$not so nested conditions are covered.
-func rewriteExistsOperator(value interface{}) {
+// rewriteBrokenExistenceOperators walks a filter condition tree and rewrites
+// $exists and $notnull leaves in place to {"$neq": [field, ""]}. Recurses
+// through $and/$or/$not so nested conditions are covered.
+func rewriteBrokenExistenceOperators(value interface{}) {
 	switch typed := value.(type) {
 	case []interface{}:
 		for _, item := range typed {
-			rewriteExistsOperator(item)
+			rewriteBrokenExistenceOperators(item)
 		}
 	case map[string]interface{}:
+		rewriteBrokenExistenceOperatorsInMap(typed)
 		for key, item := range typed {
 			if _, isLogical := traceFilterLogicalOperators[key]; isLogical {
-				rewriteExistsOperator(item)
-				continue
+				rewriteBrokenExistenceOperators(item)
 			}
-			if key != "$exists" {
-				continue
-			}
-			args, ok := item.([]interface{})
-			if !ok || len(args) == 0 {
-				continue
-			}
-			delete(typed, "$exists")
-			typed["$neq"] = []interface{}{args[0], ""}
 		}
+	}
+}
+
+func rewriteBrokenExistenceOperatorsInMap(m map[string]interface{}) {
+	for _, op := range brokenExistenceOperators {
+		item, ok := m[op]
+		if !ok {
+			continue
+		}
+		args, ok := item.([]interface{})
+		if !ok || len(args) == 0 {
+			continue
+		}
+		delete(m, op)
+		existence := map[string]interface{}{"$neq": []interface{}{args[0], ""}}
+		if len(m) == 0 {
+			m["$neq"] = existence["$neq"]
+			continue
+		}
+		conditions := make([]interface{}, 0, len(m)+1)
+		for k, v := range m {
+			conditions = append(conditions, map[string]interface{}{k: v})
+		}
+		conditions = append(conditions, existence)
+		for k := range m {
+			delete(m, k)
+		}
+		m["$and"] = conditions
 	}
 }
 
@@ -163,7 +179,7 @@ func validateTraceFilterCondition(value interface{}, path string) error {
 				continue
 			}
 			return fmt.Errorf(
-				"invalid filter condition key %q at %s: keys must be operators ($eq, $neq, $gt, $gte, $lt, $lte, $contains, $notcontains, $icontains, $inotcontains, $icontainsWords, $inotcontainsWords, $regex, $notregex, $iregex, $inotregex, $ieq, $ineq, $notnull, $containsWords, $notcontainsWords) or logical operators ($and, $or, $not); use the form {%q: [field, value]} — for example {\"$eq\": [\"ServiceName\", \"checkout\"]}. For existence checks use {\"$neq\": [field, \"\"]} — there is no $exists operator.",
+				"invalid filter condition key %q at %s: keys must be operators ($eq, $neq, $gt, $gte, $lt, $lte, $contains, $notcontains, $icontains, $inotcontains, $icontainsWords, $inotcontainsWords, $regex, $notregex, $iregex, $inotregex, $ieq, $ineq, $containsWords, $notcontainsWords) or logical operators ($and, $or, $not); use the form {%q: [field, value]} — for example {\"$eq\": [\"ServiceName\", \"checkout\"]}. For existence checks use {\"$neq\": [field, \"\"]} — there is no $exists or $notnull operator.",
 				key,
 				path,
 				"$eq",

--- a/internal/telemetry/traces/query_sanitize_test.go
+++ b/internal/telemetry/traces/query_sanitize_test.go
@@ -1,6 +1,7 @@
 package traces
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -681,6 +682,81 @@ func TestSanitizeTraceJSONQuery_WrapsTopLevelFilterInAnd(t *testing.T) {
 		}
 		if got := stages[0]["query"]; !reflect.DeepEqual(got, map[string]interface{}{}) {
 			t.Errorf("empty query should be unchanged, got: %#v", got)
+		}
+	})
+}
+
+func TestSanitizeTraceJSONQuery_RewritesExistsOperator(t *testing.T) {
+	neq := func(field string) map[string]interface{} {
+		return map[string]interface{}{"$neq": []interface{}{field, ""}}
+	}
+
+	t.Run("top-level $exists rewritten to $neq empty string", func(t *testing.T) {
+		stages := []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{
+				"$exists": []interface{}{"attributes['mcp.session.id']"},
+			}},
+		}
+		if err := sanitizeTraceJSONQuery(stages); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Sanitizer wraps top-level conditions in $and; unwrap for the check.
+		query := stages[0]["query"].(map[string]interface{})
+		if _, hasExists := query["$exists"]; hasExists {
+			t.Fatalf("$exists survived rewrite: %#v", query)
+		}
+		want := neq("attributes['mcp.session.id']")
+		if got, hasNeq := query["$neq"]; hasNeq {
+			if !reflect.DeepEqual(map[string]interface{}{"$neq": got}, want) {
+				t.Fatalf("wrong rewrite: got %#v want %#v", query, want)
+			}
+		} else if and, ok := query["$and"].([]interface{}); !ok || !reflect.DeepEqual(and[0], want) {
+			t.Fatalf("wrong rewrite: got %#v want %#v", query, want)
+		}
+	})
+
+	t.Run("$exists nested in $and and $not rewritten", func(t *testing.T) {
+		stages := []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{
+				"$and": []interface{}{
+					map[string]interface{}{"$eq": []interface{}{"ServiceName", "api"}},
+					map[string]interface{}{"$exists": []interface{}{"attributes['user.id']"}},
+					map[string]interface{}{"$not": []interface{}{
+						map[string]interface{}{"$exists": []interface{}{"attributes['error']"}},
+					}},
+				},
+			}},
+		}
+		if err := sanitizeTraceJSONQuery(stages); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		blob, _ := json.Marshal(stages)
+		s := string(blob)
+		if strings.Contains(s, "$exists") {
+			t.Fatalf("$exists survived nested rewrite: %s", s)
+		}
+		for _, want := range []string{
+			`{"$neq":["attributes['user.id']",""]}`,
+			`{"$neq":["attributes['error']",""]}`,
+		} {
+			if !strings.Contains(s, want) {
+				t.Fatalf("missing rewrite %s in: %s", want, s)
+			}
+		}
+	})
+
+	t.Run("$exists with no args is rejected with guidance", func(t *testing.T) {
+		stages := []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{
+				"$exists": []interface{}{},
+			}},
+		}
+		err := sanitizeTraceJSONQuery(stages)
+		if err == nil {
+			t.Fatal("expected error for arg-less $exists")
+		}
+		if !strings.Contains(err.Error(), `{"$neq": [field, ""]}`) {
+			t.Fatalf("error should teach the $neq idiom, got: %v", err)
 		}
 	})
 }

--- a/internal/telemetry/traces/query_sanitize_test.go
+++ b/internal/telemetry/traces/query_sanitize_test.go
@@ -462,7 +462,7 @@ func TestSanitizeTraceJSONQuery_ValidFilterOperators(t *testing.T) {
 			},
 		},
 		{
-			name: "$notnull operator",
+			name: "$notnull operator rewritten to $neq",
 			stages: []map[string]interface{}{
 				{"type": "filter", "query": map[string]interface{}{
 					"$notnull": []interface{}{"TraceId"},
@@ -686,7 +686,7 @@ func TestSanitizeTraceJSONQuery_WrapsTopLevelFilterInAnd(t *testing.T) {
 	})
 }
 
-func TestSanitizeTraceJSONQuery_RewritesExistsOperator(t *testing.T) {
+func TestSanitizeTraceJSONQuery_RewritesBrokenExistenceOperators(t *testing.T) {
 	neq := func(field string) map[string]interface{} {
 		return map[string]interface{}{"$neq": []interface{}{field, ""}}
 	}
@@ -757,6 +757,50 @@ func TestSanitizeTraceJSONQuery_RewritesExistsOperator(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), `{"$neq": [field, ""]}`) {
 			t.Fatalf("error should teach the $neq idiom, got: %v", err)
+		}
+	})
+
+	t.Run("$notnull rewritten to $neq empty string", func(t *testing.T) {
+		stages := []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{
+				"$notnull": []interface{}{"attributes['user.id']"},
+			}},
+		}
+		if err := sanitizeTraceJSONQuery(stages); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		blob, _ := json.Marshal(stages)
+		s := string(blob)
+		if strings.Contains(s, "$notnull") {
+			t.Fatalf("$notnull survived rewrite: %s", s)
+		}
+		if !strings.Contains(s, `{"$neq":["attributes['user.id']",""]}`) {
+			t.Fatalf("missing $notnull rewrite in: %s", s)
+		}
+	})
+
+	t.Run("$exists alongside sibling $neq folds into $and", func(t *testing.T) {
+		stages := []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{
+				"$exists": []interface{}{"attributes['user.id']"},
+				"$neq":    []interface{}{"attributes['error.message']", ""},
+			}},
+		}
+		if err := sanitizeTraceJSONQuery(stages); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		blob, _ := json.Marshal(stages)
+		s := string(blob)
+		if strings.Contains(s, "$exists") {
+			t.Fatalf("$exists survived rewrite: %s", s)
+		}
+		for _, want := range []string{
+			`{"$neq":["attributes['user.id']",""]}`,
+			`{"$neq":["attributes['error.message']",""]}`,
+		} {
+			if !strings.Contains(s, want) {
+				t.Fatalf("missing condition %s in: %s", want, s)
+			}
 		}
 	})
 }

--- a/internal/telemetry/traces/traces.go
+++ b/internal/telemetry/traces/traces.go
@@ -304,7 +304,7 @@ func executeTraceJSONQuery(ctx context.Context, client *http.Client, cfg models.
 			bodyStr = bodyStr[:100] + "... (truncated)"
 		}
 		if resp.StatusCode == http.StatusRequestTimeout {
-			return nil, fmt.Errorf("trace aggregation query timed out; narrow the time window (start_time_iso/end_time_iso) and retry (status %d, endpoint: %s/cat/api/traces/v2/query_range/json). Response: %s",
+			return nil, fmt.Errorf("trace query timed out; narrow the time window or simplify the query and retry (status %d, endpoint: %s/cat/api/traces/v2/query_range/json). Response: %s",
 				resp.StatusCode, cfg.APIBaseURL, bodyStr)
 		}
 		return nil, fmt.Errorf("traces API request failed with status %d (endpoint: %s/cat/api/traces/v2/query_range/json). Response: %s",

--- a/internal/telemetry/traces/traces.go
+++ b/internal/telemetry/traces/traces.go
@@ -102,6 +102,22 @@ func fetchTraceJSONQuery(ctx context.Context, client *http.Client, cfg models.Co
 		return executeTraceJSONQuery(ctx, client, cfg, tracejsonQuery, startMs, endMs, effectiveLimit)
 	}
 
+	// Aggregate pipelines (group-by, avg/median/quantile/stddev, etc.) must
+	// never be chunked: concatenating per-chunk aggregate results produces
+	// duplicate group-by keys and mathematically wrong aggregates. Run the
+	// full window as a single request instead.
+	if utils.PipelineHasAggregateStage(args.TracejsonQuery) {
+		if chunkingDebug {
+			log.Printf(
+				"[chunking] get_traces aggregate stage detected, using single request start_ms=%d end_ms=%d effective_limit=%d",
+				startMs,
+				endMs,
+				effectiveLimit,
+			)
+		}
+		return executeTraceJSONQuery(ctx, client, cfg, tracejsonQuery, startMs, endMs, effectiveLimit)
+	}
+
 	// Trace pipelines never reference the Body field, so HasExpensiveBodyParsing
 	// is always false here — adaptive config falls through to the time-range
 	// rules, exactly as the frontend would treat a non-body-search query.
@@ -286,6 +302,10 @@ func executeTraceJSONQuery(ctx context.Context, client *http.Client, cfg models.
 		bodyStr := string(body)
 		if len(bodyStr) > 100 {
 			bodyStr = bodyStr[:100] + "... (truncated)"
+		}
+		if resp.StatusCode == http.StatusRequestTimeout {
+			return nil, fmt.Errorf("trace aggregation query timed out; narrow the time window (start_time_iso/end_time_iso) and retry (status %d, endpoint: %s/cat/api/traces/v2/query_range/json). Response: %s",
+				resp.StatusCode, cfg.APIBaseURL, bodyStr)
 		}
 		return nil, fmt.Errorf("traces API request failed with status %d (endpoint: %s/cat/api/traces/v2/query_range/json). Response: %s",
 			resp.StatusCode, cfg.APIBaseURL, bodyStr)

--- a/internal/telemetry/traces/traces_test.go
+++ b/internal/telemetry/traces/traces_test.go
@@ -115,7 +115,7 @@ func TestGetTracesLimitParameter(t *testing.T) {
 					{
 						"type": "filter",
 						"query": map[string]interface{}{
-							"$exists": []string{"ServiceName"},
+							"$neq": []interface{}{"ServiceName", ""},
 						},
 					},
 				},
@@ -352,7 +352,7 @@ func TestGetTracesHandler_Integration(t *testing.T) {
 					{
 						"type": "filter",
 						"query": map[string]interface{}{
-							"$exists": []string{"ServiceName"},
+							"$neq": []interface{}{"ServiceName", ""},
 						},
 					},
 				},

--- a/internal/utils/pipeline_inspect.go
+++ b/internal/utils/pipeline_inspect.go
@@ -22,6 +22,22 @@ import "strings"
 //  2. We only count transforms whose function is in BODY_TRANSFORM_OPERATIONS
 //     (matches the frontend list exactly: $split_into / $split / $replace_regex).
 
+// PipelineHasAggregateStage reports whether any stage in the pipeline is an
+// "aggregate" or "window_aggregate" stage. Chunking a pipeline that aggregates
+// (group-by, avg/median/quantile/stddev, etc.) and concatenating the per-chunk
+// results produces duplicate group-by keys and mathematically wrong
+// aggregates, so callers must treat true here as "run as a single request,
+// never chunk". Nil-safe.
+func PipelineHasAggregateStage(pipeline []map[string]interface{}) bool {
+	for _, stage := range pipeline {
+		switch stageType, _ := stage["type"].(string); stageType {
+		case "aggregate", "window_aggregate":
+			return true
+		}
+	}
+	return false
+}
+
 // HasJSONParsePipeline mirrors frontend hasJSONParsePipeline in
 // adaptive-chunk-loader.ts:31 — true if any stage is a JSON parse.
 func HasJSONParsePipeline(pipeline []map[string]any) bool {

--- a/internal/utils/pipeline_inspect_test.go
+++ b/internal/utils/pipeline_inspect_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import "testing"
+
+func TestPipelineHasAggregateStage(t *testing.T) {
+	tests := []struct {
+		name     string
+		pipeline []map[string]interface{}
+		want     bool
+	}{
+		{name: "nil pipeline", pipeline: nil, want: false},
+		{name: "empty pipeline", pipeline: []map[string]interface{}{}, want: false},
+		{name: "aggregate stage", pipeline: []map[string]interface{}{{"type": "aggregate"}}, want: true},
+		{name: "window_aggregate stage", pipeline: []map[string]interface{}{{"type": "window_aggregate"}}, want: true},
+		{name: "filter-only pipeline", pipeline: []map[string]interface{}{{"type": "filter"}}, want: false},
+		{
+			name: "aggregate mixed with filter",
+			pipeline: []map[string]interface{}{
+				{"type": "filter"},
+				{"type": "aggregate"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PipelineHasAggregateStage(tt.pipeline); got != tt.want {
+				t.Errorf("PipelineHasAggregateStage(%v) = %v, want %v", tt.pipeline, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes FDE-285 and FDE-286.

## Problem

1. **FDE-285** — `get_traces` split long time ranges into chunks even when the pipeline contained an `aggregate`/`window_aggregate` stage, then concatenated per-chunk responses. The backend merges group-bys only within one request, so the same group key appeared once per chunk (duplicate rows with split counts), and non-decomposable aggregates (`$avg`, `$median`, `$quantile`, `$stddev`) were mathematically wrong, not just duplicated. A 7-day aggregate query ran as 192 backend requests; a single failed chunk yielded silently incomplete groups. The dashboard never hits this — it sends one un-chunked request.
2. **FDE-286** — the sanitizer allowlisted `$exists` (and recommended it in its error message), but the backend has no such operator: unknown operators compile to `1=1`, so the condition was silently dropped and matched every span.

## Changes

- `internal/utils/pipeline_inspect.go`: shared `PipelineHasAggregateStage` helper (`aggregate` / `window_aggregate`).
- `internal/telemetry/traces/traces.go`: aggregate pipelines short-circuit to a single full-window request (mirrors the existing exact-trace-id path); 408 responses now tell the caller to narrow the time window.
- `internal/telemetry/logs/logs.go`: delegates its existing no-chunk-for-aggregates check to the shared helper (no behavior change — logs never had the bug).
- `internal/telemetry/traces/query_sanitize.go`: `$exists` is rewritten in place to the working idiom `{"$neq": [field, ""]}` (recurses `$and`/`$or`/`$not`); removed from the allowlist; error message now teaches the idiom.
- `internal/telemetry/traces/input_schema.go`: existence hint no longer advertises the backend-broken `$notnull`; points to `$neq`-empty-string (backend fix for `$notnull` is in flight separately as ENG-1537).
- `internal/prompts/descriptions/get_traces.md`: documents the `_last9_mcp.partial_result` annotation.

## Verification

- `go test -race ./...` green; new tests assert exactly one upstream request for aggregate pipelines over a 7-day window (and >1 for plain filters), plus `$exists` rewrite coverage (top-level, nested, arg-less rejection).
- Live check against production data: a 7-day group-by-session aggregate that previously returned duplicate keys and `partial_result` now issues a single request (chunking debug log confirms) and returns 54 rows / 54 distinct keys / 0 dupes.
- `eval:trace` suite from last9-mcp-evals against this checkout: 23/23 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)