### PR TITLE
feat(remapping): add MCP tools for remapping rules management

### DIFF
--- a/dump_test.go
+++ b/dump_test.go
@@ -31,8 +31,8 @@ func TestDumpTools(t *testing.T) {
 	// All registered tools must be covered — the whole point of dump-tools.
 	// A loose floor would let a regression silently drop tools. Tighten this
 	// when the committed snapshot + CI equality gate supersedes it.
-	if len(out.Tools) < 38 {
-		t.Fatalf("expected at least 38 tools, got %d", len(out.Tools))
+	if len(out.Tools) < 40 {
+		t.Fatalf("expected at least 40 tools, got %d", len(out.Tools))
 	}
 	if !sort.SliceIsSorted(out.Tools, func(i, j int) bool { return out.Tools[i].Name < out.Tools[j].Name }) {
 		t.Fatal("tools are not sorted by name (output must be deterministic for snapshot diffing)")

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -29,6 +29,11 @@ const (
 	EndpointDatasources          = "/datasources"
 	EndpointOAuthAccessToken     = "/api/v4/oauth/access_token"
 	EndpointLogsSettingsRouting  = "/logs_settings/routing"
+
+	// Remapping rule endpoints (otel_settings control plane)
+	EndpointRemappingLogsExtract = "/otel_settings/remapping/logs_extract"
+	EndpointRemappingLogsMap     = "/otel_settings/remapping/logs_map"
+	EndpointRemappingTracesMap   = "/otel_settings/remapping/traces_map"
 	EndpointAlertRules           = "/alert-rules"
 	EndpointAlertsMonitor        = "/alerts/monitor"
 	EndpointEntitiesList         = "/entities/list"

--- a/internal/deeplink/deeplink.go
+++ b/internal/deeplink/deeplink.go
@@ -19,6 +19,7 @@ const (
 	RouteAlertingGroups       = "alerting/groups"
 	RouteNotificationChannels = "settings/notification-channels"
 	RouteDropRules            = "control-plane/%s/drop" // requires clusterId
+	RouteRemapping            = "control-plane/%s/remapping"
 	RouteDashboards = "dashboards"
 )
 
@@ -102,6 +103,16 @@ func (b *Builder) BuildAlertingLink(fromMs, toMs int64, severity, ruleID string)
 		params.Set("rule_id", ruleID)
 	}
 	return fmt.Sprintf("/v2/organizations/%s/%s?%s", b.orgSlug, RouteAlerting, params.Encode())
+}
+
+// BuildRemappingLink creates a remapping rules dashboard deep link.
+func (b *Builder) BuildRemappingLink() string {
+	clusterID := b.clusterID
+	if clusterID == "" {
+		clusterID = "default"
+	}
+	route := fmt.Sprintf(RouteRemapping, url.PathEscape(clusterID))
+	return fmt.Sprintf("/v2/organizations/%s/%s", b.orgSlug, route)
 }
 
 // BuildDropRulesLink creates a drop rules dashboard deep link

--- a/internal/deeplink/deeplink_test.go
+++ b/internal/deeplink/deeplink_test.go
@@ -19,3 +19,12 @@ func TestBuildDashboardsIndexLink(t *testing.T) {
 		t.Fatalf("got %q want %q", got, want)
 	}
 }
+
+func TestBuildRemappingLink(t *testing.T) {
+	b := NewBuilder("acme", "cluster-1")
+	got := b.BuildRemappingLink()
+	want := "/v2/organizations/acme/control-plane/cluster-1/remapping"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}

--- a/internal/models/remapping.go
+++ b/internal/models/remapping.go
@@ -1,0 +1,36 @@
+package models
+
+// RemappingPrecondition scopes logs_extract rules to matching lines.
+type RemappingPrecondition struct {
+	Key      string `json:"key"`
+	Value    string `json:"value"`
+	Operator string `json:"operator"`
+}
+
+// RemappingLogsExtractProperties is the properties block for logs_extract rules.
+type RemappingLogsExtractProperties struct {
+	Type             string                   `json:"type"`
+	Preconditions    []RemappingPrecondition  `json:"preconditions,omitempty"`
+	RemapKeys        []string                 `json:"remap_keys"`
+	TargetAttributes string                   `json:"target_attribute"`
+	Action           string                   `json:"action"`
+	Prefix           string                   `json:"prefix,omitempty"`
+}
+
+// RemappingLogsExtractRequest is the POST/PUT body for logs_extract rules.
+type RemappingLogsExtractRequest struct {
+	Name       string                         `json:"name"`
+	Properties RemappingLogsExtractProperties `json:"properties"`
+}
+
+// RemappingMapProperties is the properties block for logs_map and traces_map rules.
+type RemappingMapProperties struct {
+	RemapKeys        []string `json:"remap_keys"`
+	TargetAttributes string   `json:"target_attribute"`
+}
+
+// RemappingMapRequest is the POST/PUT body for logs_map and traces_map rules.
+type RemappingMapRequest struct {
+	Name       string                 `json:"name"`
+	Properties RemappingMapProperties `json:"properties"`
+}

--- a/internal/prompts/descriptions/add_remapping_rule.md
+++ b/internal/prompts/descriptions/add_remapping_rule.md
@@ -1,35 +1,92 @@
-Create a remapping rule in the Last9 control plane.
+Create a remapping rule in the Last9 control plane (ingestion-time transform, before storage).
 
-Set `rule_type` to one of `logs_extract`, `logs_map`, or `traces_map`. Required for all types: `name`, `remap_keys`, and `target_attribute`.
+Each call creates **one** rule. Map rules (`logs_map`, `traces_map`) need a separate call per `target_attribute` — the UI batches these, the API does not.
+
+## Workflow
+
+1. Call `get_remapping_rules` for the target `rule_type` — check existing names and avoid duplicates.
+2. Discover source fields before writing:
+   - **logs_map / traces_map**: call `get_log_attributes` (or `get_trace_attributes` for traces) to find real attribute paths.
+   - **logs_extract (json)**: call `get_logs` on sample lines to identify JSON field names in the body (e.g. `level`, not `severity` on the attribute).
+   - **logs_extract (pattern)**: inspect raw log bodies in `get_logs` to craft the regex.
+3. Call `add_remapping_rule` with a unique `name`.
+
+## All types
+
+Required: `rule_type`, `name`, `remap_keys`, `target_attribute`.
+
+Optional: `region` (defaults to configured datasource region).
 
 ## logs_extract
 
-Extract fields from log line bodies into log or resource attributes.
+Extract fields from log line **bodies** into log or resource attributes.
 
-- `extract_type` (required): `json` to parse structured JSON bodies, or `pattern` for a regex with named capture groups (e.g. `\\[(?P<severity>DEBUG|INFO|WARN|ERROR)\\s*\\|`)
+- `extract_type` (required): `json` or `pattern`
 - `target_attribute` (required): `log_attributes` or `resource_attributes`
-- `action` (optional): `upsert` (default) or `insert`
-- `prefix` (optional): prefix added to extracted field names
-- `preconditions` (optional): at most one filter to scope extraction to matching lines. Operators: `equals`, `not_equals`, `like`
+- `action` (optional): `upsert` (default, replace existing values) or `insert` (keep history)
+- `prefix` (optional, json only): prepended to extracted field names (e.g. `ec2_` → `ec2_id`)
+- `preconditions` (optional): at most **one** scope filter. Omit for all lines; include one to match specific lines only.
 
-For JSON extraction, `remap_keys` lists the JSON field names to extract (e.g. `["level"]`).
+### remap_keys for logs_extract
 
-For pattern extraction, `remap_keys` must contain exactly one regex pattern.
+**json** — plain JSON field names from the log body, **not** `attributes["..."]` paths:
+
+```json
+["level"]
+["app_team", "app_name"]
+```
+
+**pattern** — exactly **one** regex with named capture groups:
+
+```json
+["\\[(?P<severity>DEBUG|INFO|WARN|ERROR)[ |]"]
+```
+
+### preconditions (logs_extract only)
+
+Scope extraction to matching lines. Keys use attribute paths:
+
+- Log attributes: `attributes["key_name"]`
+- Resource attributes: `resource.attributes["key_name"]`
+
+Operators: `equals`, `not_equals`, `like` (`like` value must be valid regex).
+
+Omit `preconditions` to apply to all lines (may increase ingestion delay — prefer scoping when possible).
 
 ## logs_map
 
-Map source attributes to standardized log fields. Evaluates `remap_keys` left to right and uses the first non-empty value.
+Promote existing attributes to standardized log fields. **One rule per target.**
 
 - `target_attribute` (required): `service`, `severity`, or `resource_deployment.environment`
+- `remap_keys`: attribute paths, evaluated **left to right** — first non-empty value wins
 - Do not pass `extract_type`, `action`, `prefix`, or `preconditions`
+
+Example — map service from two fallback attributes:
+
+```json
+{
+  "rule_type": "logs_map",
+  "name": "map-service-from-attrs",
+  "target_attribute": "service",
+  "remap_keys": ["attributes[\"service_name\"]", "attributes[\"app_name\"]"]
+}
+```
 
 ## traces_map
 
-Map source attributes to standardized trace service names. Evaluates `remap_keys` left to right and uses the first non-empty value.
+Promote trace attributes to standardized service name. **One rule per target.**
 
 - `target_attribute` (required): `service`
+- `remap_keys`: attribute paths, left-to-right priority (first non-empty wins)
 - Do not pass `extract_type`, `action`, `prefix`, or `preconditions`
 
-## Region
+Example:
 
-Pass `region` when not configured via the datasource. Defaults to the configured datasource region.
+```json
+{
+  "rule_type": "traces_map",
+  "name": "map-trace-service",
+  "target_attribute": "service",
+  "remap_keys": ["resource.attributes[\"service.name\"]", "attributes[\"service\"]"]
+}
+```

--- a/internal/prompts/descriptions/add_remapping_rule.md
+++ b/internal/prompts/descriptions/add_remapping_rule.md
@@ -1,0 +1,35 @@
+Create a remapping rule in the Last9 control plane.
+
+Set `rule_type` to one of `logs_extract`, `logs_map`, or `traces_map`. Required for all types: `name`, `remap_keys`, and `target_attribute`.
+
+## logs_extract
+
+Extract fields from log line bodies into log or resource attributes.
+
+- `extract_type` (required): `json` to parse structured JSON bodies, or `pattern` for a regex with named capture groups (e.g. `\\[(?P<severity>DEBUG|INFO|WARN|ERROR)\\s*\\|`)
+- `target_attribute` (required): `log_attributes` or `resource_attributes`
+- `action` (optional): `upsert` (default) or `insert`
+- `prefix` (optional): prefix added to extracted field names
+- `preconditions` (optional): at most one filter to scope extraction to matching lines. Operators: `equals`, `not_equals`, `like`
+
+For JSON extraction, `remap_keys` lists the JSON field names to extract (e.g. `["level"]`).
+
+For pattern extraction, `remap_keys` must contain exactly one regex pattern.
+
+## logs_map
+
+Map source attributes to standardized log fields. Evaluates `remap_keys` left to right and uses the first non-empty value.
+
+- `target_attribute` (required): `service`, `severity`, or `resource_deployment.environment`
+- Do not pass `extract_type`, `action`, `prefix`, or `preconditions`
+
+## traces_map
+
+Map source attributes to standardized trace service names. Evaluates `remap_keys` left to right and uses the first non-empty value.
+
+- `target_attribute` (required): `service`
+- Do not pass `extract_type`, `action`, `prefix`, or `preconditions`
+
+## Region
+
+Pass `region` when not configured via the datasource. Defaults to the configured datasource region.

--- a/internal/prompts/descriptions/get_remapping_rules.md
+++ b/internal/prompts/descriptions/get_remapping_rules.md
@@ -1,0 +1,9 @@
+List remapping rules configured in the Last9 control plane.
+
+Remapping rules transform telemetry at ingestion before storage. Use `rule_type` to select which rule set to return:
+
+- `logs_extract` — extract fields from log bodies using JSON or regex pattern matching
+- `logs_map` — map existing log attributes to standardized service, severity, or deployment environment fields
+- `traces_map` — map trace attributes to standardized service names
+
+Returns the API response as JSON. Use this before creating rules to check for existing names and avoid duplicates.

--- a/internal/prompts/descriptions/get_remapping_rules.md
+++ b/internal/prompts/descriptions/get_remapping_rules.md
@@ -1,9 +1,11 @@
 List remapping rules configured in the Last9 control plane.
 
-Remapping rules transform telemetry at ingestion before storage. Use `rule_type` to select which rule set to return:
+Remapping transforms telemetry at ingestion before storage. Use `rule_type` to select which rule set to return:
 
-- `logs_extract` — extract fields from log bodies using JSON or regex pattern matching
-- `logs_map` — map existing log attributes to standardized service, severity, or deployment environment fields
-- `traces_map` — map trace attributes to standardized service names
+- `logs_extract` — extract fields from log bodies (JSON or regex pattern)
+- `logs_map` — map log attributes to standardized `service`, `severity`, or `resource_deployment.environment`
+- `traces_map` — map trace attributes to standardized `service`
 
-Returns the API response as JSON. Use this before creating rules to check for existing names and avoid duplicates.
+Returns the API response as JSON.
+
+Call this before `add_remapping_rule` to check existing rule names and avoid duplicates. For map rules, note there is typically one rule per `target_attribute` (the UI shows them grouped, but the API stores them separately).

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -56,6 +56,12 @@ var GetDropRulesDescription string
 //go:embed descriptions/add_drop_rule.md
 var AddDropRuleDescription string
 
+//go:embed descriptions/get_remapping_rules.md
+var GetRemappingRulesDescription string
+
+//go:embed descriptions/add_remapping_rule.md
+var AddRemappingRuleDescription string
+
 //go:embed descriptions/get_notification_channels.md
 var GetNotificationChannelsDescription string
 

--- a/internal/remapping/integration_test.go
+++ b/internal/remapping/integration_test.go
@@ -1,0 +1,109 @@
+package remapping
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const integrationTestTimeout = 30 * time.Second
+const integrationTestRuleName = "mcp-local-integration-test"
+
+func TestGetRemappingRules_Integration_AllTypes(t *testing.T) {
+	cfg := utils.SetupTestConfigOrSkip(t)
+	handler := NewGetRemappingRulesHandler(http.DefaultClient, *cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)
+	defer cancel()
+
+	for _, ruleType := range []string{ruleTypeLogsExtract, ruleTypeLogsMap, ruleTypeTracesMap} {
+		t.Run(ruleType, func(t *testing.T) {
+			result, _, err := handler(ctx, &mcp.CallToolRequest{}, GetRemappingRulesArgs{
+				RuleType: ruleType,
+			})
+			if utils.CheckAPIError(t, err) {
+				return
+			}
+			if result == nil {
+				t.Fatal("expected result, got nil")
+			}
+
+			text := utils.GetTextContent(t, result)
+			if !json.Valid([]byte(text)) {
+				t.Fatalf("expected valid JSON response, got: %s", text)
+			}
+
+			if ref, ok := result.Meta["reference_url"].(string); !ok || ref == "" {
+				t.Fatal("expected reference_url in result meta")
+			} else if !strings.Contains(ref, "/remapping") {
+				t.Fatalf("expected remapping deep link, got %q", ref)
+			}
+
+			t.Logf("%s: response length %d bytes", ruleType, len(text))
+		})
+	}
+}
+
+func TestAddRemappingRule_Integration_IdempotentJSONExtract(t *testing.T) {
+	cfg := utils.SetupTestConfigOrSkip(t)
+	getHandler := NewGetRemappingRulesHandler(http.DefaultClient, *cfg)
+	addHandler := NewAddRemappingRuleHandler(http.DefaultClient, *cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), integrationTestTimeout)
+	defer cancel()
+
+	existing, _, err := getHandler(ctx, &mcp.CallToolRequest{}, GetRemappingRulesArgs{
+		RuleType: ruleTypeLogsExtract,
+	})
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+	if strings.Contains(utils.GetTextContent(t, existing), integrationTestRuleName) {
+		t.Skipf("rule %q already exists; skipping create", integrationTestRuleName)
+	}
+
+	result, _, err := addHandler(ctx, &mcp.CallToolRequest{}, AddRemappingRuleArgs{
+		RuleType:        ruleTypeLogsExtract,
+		Name:            integrationTestRuleName,
+		ExtractType:     "json",
+		RemapKeys:       []string{"level"},
+		TargetAttribute: "log_attributes",
+		Action:          "upsert",
+	})
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+
+	var created struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(utils.GetTextContent(t, result)), &created); err != nil {
+		t.Fatalf("failed to parse create response: %v", err)
+	}
+	if created.Name != integrationTestRuleName {
+		t.Fatalf("expected name %q, got %q", integrationTestRuleName, created.Name)
+	}
+	if created.ID == "" {
+		t.Fatal("expected non-empty rule id in create response")
+	}
+
+	after, _, err := getHandler(ctx, &mcp.CallToolRequest{}, GetRemappingRulesArgs{
+		RuleType: ruleTypeLogsExtract,
+	})
+	if utils.CheckAPIError(t, err) {
+		return
+	}
+	if !strings.Contains(utils.GetTextContent(t, after), integrationTestRuleName) {
+		t.Fatalf("created rule %q not found in subsequent list", integrationTestRuleName)
+	}
+
+	t.Logf("created remapping rule id=%s name=%s", created.ID, created.Name)
+}

--- a/internal/remapping/remapping.go
+++ b/internal/remapping/remapping.go
@@ -1,0 +1,378 @@
+package remapping
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"last9-mcp/internal/constants"
+	"last9-mcp/internal/deeplink"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	ruleTypeLogsExtract = "logs_extract"
+	ruleTypeLogsMap     = "logs_map"
+	ruleTypeTracesMap   = "traces_map"
+)
+
+// GetRemappingRulesArgs lists remapping rules for a given rule type.
+type GetRemappingRulesArgs struct {
+	RuleType string `json:"rule_type" jsonschema:"(Required) Remapping rule type: logs_extract, logs_map, or traces_map"`
+	Region   string `json:"region,omitempty" jsonschema:"AWS region (defaults to configured datasource region)"`
+}
+
+// RemappingPrecondition scopes logs_extract rules to matching lines.
+type RemappingPrecondition struct {
+	Key      string `json:"key" jsonschema:"(Required) Attribute key to match (e.g. attributes[\"severity\"])"`
+	Value    string `json:"value" jsonschema:"(Required) Value to compare against"`
+	Operator string `json:"operator" jsonschema:"Comparison operator: equals, not_equals, or like (default: equals)"`
+}
+
+// AddRemappingRuleArgs creates a remapping rule.
+type AddRemappingRuleArgs struct {
+	RuleType        string                  `json:"rule_type" jsonschema:"(Required) Remapping rule type: logs_extract, logs_map, or traces_map"`
+	Name            string                  `json:"name" jsonschema:"(Required) Descriptive name for the rule"`
+	RemapKeys       []string                `json:"remap_keys" jsonschema:"(Required) Source field(s) to remap from, evaluated left to right for map rules"`
+	TargetAttribute string                  `json:"target_attribute" jsonschema:"(Required) Target attribute. logs_extract: log_attributes or resource_attributes. logs_map: service, severity, or resource_deployment.environment. traces_map: service"`
+	Region          string                  `json:"region,omitempty" jsonschema:"AWS region (defaults to configured datasource region)"`
+	ExtractType     string                  `json:"extract_type,omitempty" jsonschema:"logs_extract only. Extraction method: json or pattern (regex with named capture groups)"`
+	Action          string                  `json:"action,omitempty" jsonschema:"logs_extract only. insert or upsert (default: upsert)"`
+	Prefix          string                  `json:"prefix,omitempty" jsonschema:"logs_extract only. Optional prefix added to extracted field names"`
+	Preconditions   []RemappingPrecondition `json:"preconditions,omitempty" jsonschema:"logs_extract only. At most one scope filter; apply extraction only to matching lines"`
+}
+
+func resolveRegion(cfg models.Config, arg string) (string, error) {
+	if arg != "" {
+		return arg, nil
+	}
+	if cfg.Region != "" {
+		return cfg.Region, nil
+	}
+	return "", errors.New("region is required: pass region or configure LAST9_DATASOURCE with a region")
+}
+
+func remappingEndpoint(ruleType string) (string, error) {
+	switch ruleType {
+	case ruleTypeLogsExtract:
+		return constants.EndpointRemappingLogsExtract, nil
+	case ruleTypeLogsMap:
+		return constants.EndpointRemappingLogsMap, nil
+	case ruleTypeTracesMap:
+		return constants.EndpointRemappingTracesMap, nil
+	default:
+		return "", fmt.Errorf("invalid rule_type %q: must be one of [%s, %s, %s]", ruleType, ruleTypeLogsExtract, ruleTypeLogsMap, ruleTypeTracesMap)
+	}
+}
+
+func remappingURL(cfg models.Config, ruleType, region string) (string, error) {
+	endpoint, err := remappingEndpoint(ruleType)
+	if err != nil {
+		return "", err
+	}
+	u, err := url.Parse(cfg.APIBaseURL + endpoint)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("region", region)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func doRemappingRequest(ctx context.Context, client *http.Client, cfg models.Config, method, requestURL string, body []byte) ([]byte, error) {
+	accessToken := cfg.TokenManager.GetAccessToken(ctx)
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set(constants.HeaderContentType, constants.HeaderContentTypeJSON)
+	}
+	req.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+accessToken)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		msg := strings.TrimSpace(string(respBody))
+		if msg == "" {
+			msg = http.StatusText(resp.StatusCode)
+		}
+		return nil, fmt.Errorf("remapping API returned status %d: %s", resp.StatusCode, msg)
+	}
+
+	return respBody, nil
+}
+
+func remappingResult(cfg models.Config, respBody []byte) (*mcp.CallToolResult, error) {
+	dlBuilder := deeplink.NewBuilder(cfg.OrgSlug, cfg.ClusterID)
+	dashboardURL := dlBuilder.BuildRemappingLink()
+
+	var pretty json.RawMessage
+	if err := json.Unmarshal(respBody, &pretty); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	formatted, err := json.Marshal(pretty)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal response: %w", err)
+	}
+
+	return &mcp.CallToolResult{
+		Meta: deeplink.ToMeta(dashboardURL),
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(formatted)},
+		},
+	}, nil
+}
+
+// NewGetRemappingRulesHandler lists remapping rules for the requested type.
+func NewGetRemappingRulesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetRemappingRulesArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args GetRemappingRulesArgs) (*mcp.CallToolResult, any, error) {
+		if args.RuleType == "" {
+			return nil, nil, errors.New("rule_type is required")
+		}
+
+		region, err := resolveRegion(cfg, args.Region)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		requestURL, err := remappingURL(cfg, args.RuleType, region)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		respBody, err := doRemappingRequest(ctx, client, cfg, http.MethodGet, requestURL, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		result, err := remappingResult(cfg, respBody)
+		if err != nil {
+			return nil, nil, err
+		}
+		return result, nil, nil
+	}
+}
+
+func validateRemapKeys(remapKeys []string) error {
+	for i, key := range remapKeys {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("remap_keys[%d] must not be empty", i)
+		}
+	}
+	return nil
+}
+
+func validatePatternRemapKey(pattern string) error {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return fmt.Errorf("invalid pattern regex: %w", err)
+	}
+	for _, name := range re.SubexpNames() {
+		if name != "" {
+			return nil
+		}
+	}
+	return errors.New("pattern must include at least one named capture group (e.g. (?P<severity>DEBUG|INFO))")
+}
+
+func validateLikePreconditionValue(value string) error {
+	if _, err := regexp.Compile(value); err != nil {
+		return fmt.Errorf("invalid like precondition value regex: %w", err)
+	}
+	return nil
+}
+
+func validateAddRemappingRuleArgs(args AddRemappingRuleArgs) error {
+	if args.RuleType == "" {
+		return errors.New("rule_type is required")
+	}
+	if _, err := remappingEndpoint(args.RuleType); err != nil {
+		return err
+	}
+	if args.Name == "" {
+		return errors.New("name is required")
+	}
+	if len(args.RemapKeys) == 0 {
+		return errors.New("remap_keys must be provided")
+	}
+	if err := validateRemapKeys(args.RemapKeys); err != nil {
+		return err
+	}
+	if args.TargetAttribute == "" {
+		return errors.New("target_attribute is required")
+	}
+
+	switch args.RuleType {
+	case ruleTypeLogsExtract:
+		if args.ExtractType == "" {
+			return errors.New("extract_type is required for logs_extract rules")
+		}
+		if args.ExtractType != "json" && args.ExtractType != "pattern" {
+			return fmt.Errorf("invalid extract_type %q: must be json or pattern", args.ExtractType)
+		}
+		if args.ExtractType == "pattern" {
+			if len(args.RemapKeys) != 1 {
+				return errors.New("pattern extraction requires exactly one remap_keys entry")
+			}
+			if err := validatePatternRemapKey(args.RemapKeys[0]); err != nil {
+				return err
+			}
+		}
+		if args.TargetAttribute != "log_attributes" && args.TargetAttribute != "resource_attributes" {
+			return errors.New("target_attribute must be log_attributes or resource_attributes for logs_extract rules")
+		}
+		action := args.Action
+		if action == "" {
+			action = "upsert"
+		}
+		if action != "insert" && action != "upsert" {
+			return fmt.Errorf("invalid action %q: must be insert or upsert", action)
+		}
+		if len(args.Preconditions) > 1 {
+			return errors.New("only one precondition is supported for logs_extract rules")
+		}
+		for _, p := range args.Preconditions {
+			if p.Key == "" {
+				return errors.New("precondition key is required")
+			}
+			if p.Value == "" {
+				return errors.New("precondition value is required")
+			}
+			operator := p.Operator
+			if operator == "" {
+				operator = "equals"
+			}
+			if operator != "equals" && operator != "not_equals" && operator != "like" {
+				return fmt.Errorf("invalid precondition operator %q: must be equals, not_equals, or like", operator)
+			}
+			if operator == "like" {
+				if err := validateLikePreconditionValue(p.Value); err != nil {
+					return err
+				}
+			}
+		}
+	case ruleTypeLogsMap:
+		if args.ExtractType != "" || args.Action != "" || args.Prefix != "" || len(args.Preconditions) > 0 {
+			return errors.New("extract_type, action, prefix, and preconditions are only valid for logs_extract rules")
+		}
+		switch args.TargetAttribute {
+		case "service", "severity", "resource_deployment.environment":
+		default:
+			return errors.New("target_attribute must be service, severity, or resource_deployment.environment for logs_map rules")
+		}
+	case ruleTypeTracesMap:
+		if args.ExtractType != "" || args.Action != "" || args.Prefix != "" || len(args.Preconditions) > 0 {
+			return errors.New("extract_type, action, prefix, and preconditions are only valid for logs_extract rules")
+		}
+		if args.TargetAttribute != "service" {
+			return errors.New("target_attribute must be service for traces_map rules")
+		}
+	}
+
+	return nil
+}
+
+func buildRemappingRequestBody(args AddRemappingRuleArgs) ([]byte, error) {
+	switch args.RuleType {
+	case ruleTypeLogsExtract:
+		action := args.Action
+		if action == "" {
+			action = "upsert"
+		}
+		props := models.RemappingLogsExtractProperties{
+			Type:             args.ExtractType,
+			RemapKeys:        args.RemapKeys,
+			TargetAttributes: args.TargetAttribute,
+			Action:           action,
+		}
+		if args.Prefix != "" {
+			props.Prefix = args.Prefix
+		}
+		for _, p := range args.Preconditions {
+			operator := p.Operator
+			if operator == "" {
+				operator = "equals"
+			}
+			props.Preconditions = append(props.Preconditions, models.RemappingPrecondition{
+				Key:      p.Key,
+				Value:    p.Value,
+				Operator: operator,
+			})
+		}
+		return json.Marshal(models.RemappingLogsExtractRequest{
+			Name:       args.Name,
+			Properties: props,
+		})
+	case ruleTypeLogsMap, ruleTypeTracesMap:
+		return json.Marshal(models.RemappingMapRequest{
+			Name: args.Name,
+			Properties: models.RemappingMapProperties{
+				RemapKeys:        args.RemapKeys,
+				TargetAttributes: args.TargetAttribute,
+			},
+		})
+	default:
+		return nil, fmt.Errorf("unsupported rule_type %q", args.RuleType)
+	}
+}
+
+// NewAddRemappingRuleHandler creates a remapping rule.
+func NewAddRemappingRuleHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, AddRemappingRuleArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args AddRemappingRuleArgs) (*mcp.CallToolResult, any, error) {
+		if err := validateAddRemappingRuleArgs(args); err != nil {
+			return nil, nil, err
+		}
+
+		region, err := resolveRegion(cfg, args.Region)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		body, err := buildRemappingRequestBody(args)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		requestURL, err := remappingURL(cfg, args.RuleType, region)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		respBody, err := doRemappingRequest(ctx, client, cfg, http.MethodPost, requestURL, body)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		result, err := remappingResult(cfg, respBody)
+		if err != nil {
+			return nil, nil, err
+		}
+		return result, nil, nil
+	}
+}

--- a/internal/remapping/remapping_test.go
+++ b/internal/remapping/remapping_test.go
@@ -1,0 +1,352 @@
+package remapping
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func testRemappingConfig(actionURL string) models.Config {
+	return models.Config{
+		APIBaseURL: actionURL,
+		ActionURL:  actionURL,
+		Region:     "us-east-1",
+		OrgSlug:    "test-org",
+		ClusterID:  "cluster-1",
+		TokenManager: &auth.TokenManager{
+			AccessToken: "test-token",
+			ExpiresAt:   time.Now().Add(24 * time.Hour),
+		},
+	}
+}
+
+func TestGetRemappingRulesHandlerContextCancellation(t *testing.T) {
+	blocked := make(chan struct{})
+	defer close(blocked)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	handler := NewGetRemappingRulesHandler(server.Client(), testRemappingConfig(server.URL))
+	_, _, err := handler(ctx, &mcp.CallToolRequest{}, GetRemappingRulesArgs{RuleType: ruleTypeLogsExtract})
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+}
+
+func TestGetRemappingRulesHandlerRequiresRuleType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be called for invalid input")
+	}))
+	defer server.Close()
+
+	handler := NewGetRemappingRulesHandler(server.Client(), testRemappingConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetRemappingRulesArgs{})
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+}
+
+func TestGetRemappingRulesHandlerSendsGETWithRegion(t *testing.T) {
+	var capturedMethod, capturedRegion string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedRegion = r.URL.Query().Get("region")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]string{{"id": "rule-1", "name": "test"}})
+	}))
+	defer server.Close()
+
+	handler := NewGetRemappingRulesHandler(server.Client(), testRemappingConfig(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetRemappingRulesArgs{
+		RuleType: ruleTypeLogsMap,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if capturedMethod != http.MethodGet {
+		t.Fatalf("expected GET, got %s", capturedMethod)
+	}
+	if capturedRegion != "us-east-1" {
+		t.Fatalf("expected region=us-east-1, got %q", capturedRegion)
+	}
+}
+
+func TestAddRemappingRuleHandlerSendsLogsExtractPayload(t *testing.T) {
+	var capturedMethod string
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": "rule-123"})
+	}))
+	defer server.Close()
+
+	handler := NewAddRemappingRuleHandler(server.Client(), testRemappingConfig(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AddRemappingRuleArgs{
+		RuleType:        ruleTypeLogsExtract,
+		Name:            "json-severity",
+		RemapKeys:       []string{"level"},
+		TargetAttribute: "log_attributes",
+		ExtractType:     "json",
+		Action:          "upsert",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if capturedMethod != http.MethodPost {
+		t.Fatalf("expected POST, got %s", capturedMethod)
+	}
+	if capturedBody["name"] != "json-severity" {
+		t.Fatalf("expected name=json-severity, got %v", capturedBody["name"])
+	}
+	props, ok := capturedBody["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected properties object, got %T", capturedBody["properties"])
+	}
+	if props["type"] != "json" {
+		t.Fatalf("expected properties.type=json, got %v", props["type"])
+	}
+	if props["target_attribute"] != "log_attributes" {
+		t.Fatalf("expected target_attribute=log_attributes, got %v", props["target_attribute"])
+	}
+}
+
+func TestAddRemappingRuleHandlerSendsLogsMapPayload(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": "rule-456"})
+	}))
+	defer server.Close()
+
+	handler := NewAddRemappingRuleHandler(server.Client(), testRemappingConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AddRemappingRuleArgs{
+		RuleType:        ruleTypeLogsMap,
+		Name:            "map-service",
+		RemapKeys:       []string{`attributes["service_name"]`, `attributes["app_name"]`},
+		TargetAttribute: "service",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	props, ok := capturedBody["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected properties object, got %T", capturedBody["properties"])
+	}
+	if props["target_attribute"] != "service" {
+		t.Fatalf("expected target_attribute=service, got %v", props["target_attribute"])
+	}
+}
+
+func TestAddRemappingRuleHandlerSendsTracesMapPayload(t *testing.T) {
+	var capturedBody map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": "rule-789"})
+	}))
+	defer server.Close()
+
+	handler := NewAddRemappingRuleHandler(server.Client(), testRemappingConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AddRemappingRuleArgs{
+		RuleType:        ruleTypeTracesMap,
+		Name:            "map-trace-service",
+		RemapKeys:       []string{`resource.attributes["service.name"]`},
+		TargetAttribute: "service",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	props, ok := capturedBody["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected properties object, got %T", capturedBody["properties"])
+	}
+	if props["target_attribute"] != "service" {
+		t.Fatalf("expected target_attribute=service, got %v", props["target_attribute"])
+	}
+}
+
+func TestAddRemappingRuleHandlerAcceptsValidPatternExtract(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": "rule-pattern"})
+	}))
+	defer server.Close()
+
+	handler := NewAddRemappingRuleHandler(server.Client(), testRemappingConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AddRemappingRuleArgs{
+		RuleType:        ruleTypeLogsExtract,
+		Name:            "ansi-severity",
+		ExtractType:     "pattern",
+		RemapKeys:       []string{`\[(?P<severity>DEBUG|INFO|WARN|ERROR)[ |]`},
+		TargetAttribute: "log_attributes",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAddRemappingRuleHandlerValidation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be called for invalid input")
+	}))
+	defer server.Close()
+
+	handler := NewAddRemappingRuleHandler(server.Client(), testRemappingConfig(server.URL))
+
+	tests := []struct {
+		name string
+		args AddRemappingRuleArgs
+	}{
+		{
+			name: "missing rule type",
+			args: AddRemappingRuleArgs{Name: "rule", RemapKeys: []string{"k"}, TargetAttribute: "service"},
+		},
+		{
+			name: "invalid rule type",
+			args: AddRemappingRuleArgs{RuleType: "invalid", Name: "rule", RemapKeys: []string{"k"}, TargetAttribute: "service"},
+		},
+		{
+			name: "logs_extract missing extract_type",
+			args: AddRemappingRuleArgs{
+				RuleType: ruleTypeLogsExtract, Name: "rule",
+				RemapKeys: []string{"level"}, TargetAttribute: "log_attributes",
+			},
+		},
+		{
+			name: "logs_extract invalid target",
+			args: AddRemappingRuleArgs{
+				RuleType: ruleTypeLogsExtract, Name: "rule", ExtractType: "json",
+				RemapKeys: []string{"level"}, TargetAttribute: "service",
+			},
+		},
+		{
+			name: "logs_map rejects extract fields",
+			args: AddRemappingRuleArgs{
+				RuleType: ruleTypeLogsMap, Name: "rule", ExtractType: "json",
+				RemapKeys: []string{"level"}, TargetAttribute: "service",
+			},
+		},
+		{
+			name: "logs_map invalid target",
+			args: AddRemappingRuleArgs{
+				RuleType: ruleTypeLogsMap, Name: "rule",
+				RemapKeys: []string{"level"}, TargetAttribute: "log_attributes",
+			},
+		},
+		{
+			name: "traces_map invalid target",
+			args: AddRemappingRuleArgs{
+				RuleType: ruleTypeTracesMap, Name: "rule",
+				RemapKeys: []string{"svc"}, TargetAttribute: "severity",
+			},
+		},
+		{
+			name: "pattern requires single remap key",
+			args: AddRemappingRuleArgs{
+				RuleType: ruleTypeLogsExtract, Name: "rule", ExtractType: "pattern",
+				RemapKeys: []string{`(?P<a>\w+)`, `(?P<b>\w+)`}, TargetAttribute: "log_attributes",
+			},
+		},
+		{
+			name: "pattern requires valid regex",
+			args: AddRemappingRuleArgs{
+				RuleType: ruleTypeLogsExtract, Name: "rule", ExtractType: "pattern",
+				RemapKeys: []string{"[unclosed"}, TargetAttribute: "log_attributes",
+			},
+		},
+		{
+			name: "pattern requires named capture group",
+			args: AddRemappingRuleArgs{
+				RuleType: ruleTypeLogsExtract, Name: "rule", ExtractType: "pattern",
+				RemapKeys: []string{`\[DEBUG\]`}, TargetAttribute: "log_attributes",
+			},
+		},
+		{
+			name: "like precondition requires valid regex",
+			args: AddRemappingRuleArgs{
+				RuleType: ruleTypeLogsExtract, Name: "rule", ExtractType: "json",
+				RemapKeys: []string{"level"}, TargetAttribute: "log_attributes",
+				Preconditions: []RemappingPrecondition{
+					{Key: `attributes["service"]`, Value: "[unclosed", Operator: "like"},
+				},
+			},
+		},
+		{
+			name: "empty remap key rejected",
+			args: AddRemappingRuleArgs{
+				RuleType: ruleTypeLogsMap, Name: "rule",
+				RemapKeys: []string{" "}, TargetAttribute: "service",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, tc.args)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+		})
+	}
+}
+
+func TestAddRemappingRuleHandlerContextCancellation(t *testing.T) {
+	blocked := make(chan struct{})
+	defer close(blocked)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	handler := NewAddRemappingRuleHandler(server.Client(), testRemappingConfig(server.URL))
+	_, _, err := handler(ctx, &mcp.CallToolRequest{}, AddRemappingRuleArgs{
+		RuleType:        ruleTypeLogsExtract,
+		Name:            "rule",
+		RemapKeys:       []string{"level"},
+		TargetAttribute: "log_attributes",
+		ExtractType:     "json",
+	})
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+}

--- a/tools.go
+++ b/tools.go
@@ -11,6 +11,7 @@ import (
 	"last9-mcp/internal/dashboards"
 	"last9-mcp/internal/models"
 	"last9-mcp/internal/prompts"
+	"last9-mcp/internal/remapping"
 	"last9-mcp/internal/suggest"
 	"last9-mcp/internal/telemetry/logs"
 	"last9-mcp/internal/telemetry/traces"
@@ -140,6 +141,17 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config, attrCa
 		Name:        "add_drop_rule",
 		Description: prompts.AddDropRuleDescription,
 	}, logs.NewAddDropRuleHandler(client, cfg))
+
+	// Register remapping rules tools
+	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+		Name:        "get_remapping_rules",
+		Description: prompts.GetRemappingRulesDescription,
+	}, remapping.NewGetRemappingRulesHandler(client, cfg))
+
+	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{
+		Name:        "add_remapping_rule",
+		Description: prompts.AddRemappingRuleDescription,
+	}, remapping.NewAddRemappingRuleHandler(client, cfg))
 
 	// Register notification channels tool
 	last9mcp.RegisterInstrumentedTool(server, &mcp.Tool{


### PR DESCRIPTION
## Summary
- Add `get_remapping_rules` to list control-plane remapping rules by type (`logs_extract`, `logs_map`, `traces_map`)
- Add `add_remapping_rule` to create remapping rules with client-side validation (pattern single-key, regex/named-capture checks, `like` precondition validation)
- Add remapping deep link and API endpoint constants

## Test plan
- [x] `go test ./...` (655 tests pass)
- [x] `go run . dump-tools` includes both new tools
- [ ] Ship together with last9 proxy denylist PR for hosted MCP read-only tokens


Made with [Cursor](https://cursor.com)