### PR TITLE
fix(logs): create drop rules via otel_settings/drop API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `add_drop_rule` now creates drop rules via `POST /otel_settings/drop` (with `region` and `cluster_id` query params) instead of the legacy `PUT /logs_settings/routing` endpoint, which the API now rejects with 405 (#TBD).
+
 ### Added
 
 - MCP **workflow prompts** on `prompts/list` / `prompts/get`: six structured investigation templates — `scoped-log-attribute-discovery`, `exception-root-cause-investigation`, `investigate-latency-spike`, `diagnose-error-rate`, `analyze-slow-queries`, and `on-call-runbook`. The last four take arguments to scope the investigation. New `dump-prompts` subcommand lists the served prompts and their argument schemas (#183).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `add_drop_rule` now creates drop rules via `POST /otel_settings/drop` (with `region` and `cluster_id` query params) instead of the legacy `PUT /logs_settings/routing` endpoint, which the API now rejects with 405 (#201).
+- `get_drop_rules` now lists drop rules via `GET /otel_settings/drop?region=...` instead of the legacy read path.
+- Drop-rule tools validate filter keys client-side (`attributes["..."]` / `resource.attributes["..."]`) and fail fast when the datasource is missing `cluster_id`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `add_drop_rule` now creates drop rules via `POST /otel_settings/drop` (with `region` and `cluster_id` query params) instead of the legacy `PUT /logs_settings/routing` endpoint, which the API now rejects with 405 (#201).
-- `get_drop_rules` now lists drop rules via `GET /otel_settings/drop?region=...` instead of the legacy read path.
-- Drop-rule tools validate filter keys client-side (`attributes["..."]` / `resource.attributes["..."]`) and fail fast when the datasource is missing `cluster_id`.
+- `add_drop_rule` and `get_drop_rules` use `/otel_settings/drop` instead of the legacy `logs_settings/routing` path, which the API rejects with 405 (#201).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `add_drop_rule` now creates drop rules via `POST /otel_settings/drop` (with `region` and `cluster_id` query params) instead of the legacy `PUT /logs_settings/routing` endpoint, which the API now rejects with 405 (#TBD).
+- `add_drop_rule` now creates drop rules via `POST /otel_settings/drop` (with `region` and `cluster_id` query params) instead of the legacy `PUT /logs_settings/routing` endpoint, which the API now rejects with 405 (#201).
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -544,12 +544,14 @@ Use `get_logs` for broad aggregate counts first; use `get_service_logs` only aft
 
 ### get_drop_rules
 
-No parameters.
+No parameters. Lists drop rules via `GET /otel_settings/drop?region=...`.
 
 ### add_drop_rule
 
 - `name` (string, required)
 - `filters` (array, required): Each filter: `key`, `value`, `operator` (`equals`/`not_equals`), `conjunction` (`and`).
+- Filter keys must use `attributes["key_name"]` or `resource.attributes["key_name"]` (required by last9-api).
+- Creates the rule via `POST /otel_settings/drop?region=...&cluster_id=...`.
 
 ### get_traces
 

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ No parameters. Lists drop rules via `GET /otel_settings/drop?region=...`.
 
 - `name` (string, required)
 - `filters` (array, required): Each filter: `key`, `value`, `operator` (`equals`/`not_equals`), `conjunction` (`and`).
-- Filter keys must use `attributes["key_name"]` or `resource.attributes["key_name"]` (required by last9-api).
+- Filter keys must use `attributes["key_name"]` or `resource.attributes["key_name"]` (required by the Last9 API).
 - Creates the rule via `POST /otel_settings/drop?region=...&cluster_id=...`.
 
 ### get_traces

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -28,8 +28,7 @@ const (
 	// Organization and configuration endpoints
 	EndpointDatasources          = "/datasources"
 	EndpointOAuthAccessToken     = "/api/v4/oauth/access_token"
-	EndpointLogsSettingsRouting = "/logs_settings/routing"
-	EndpointOTelSettingsDrop    = "/otel_settings/drop"
+	EndpointOTelSettingsDrop     = "/otel_settings/drop"
 	EndpointAlertRules           = "/alert-rules"
 	EndpointAlertsMonitor        = "/alerts/monitor"
 	EndpointEntitiesList         = "/entities/list"

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -28,7 +28,8 @@ const (
 	// Organization and configuration endpoints
 	EndpointDatasources          = "/datasources"
 	EndpointOAuthAccessToken     = "/api/v4/oauth/access_token"
-	EndpointLogsSettingsRouting  = "/logs_settings/routing"
+	EndpointLogsSettingsRouting = "/logs_settings/routing"
+	EndpointOTelSettingsDrop    = "/otel_settings/drop"
 	EndpointAlertRules           = "/alert-rules"
 	EndpointAlertsMonitor        = "/alerts/monitor"
 	EndpointEntitiesList         = "/entities/list"

--- a/internal/models/logs.go
+++ b/internal/models/logs.go
@@ -1,6 +1,6 @@
 package models
 
-// DropRuleFilter represents a single filter condition in a drop rule
+// DropRuleFilter represents a single filter condition in a drop rule.
 type DropRuleFilter struct {
 	Key         string `json:"key"`
 	Value       string `json:"value"`
@@ -8,17 +8,31 @@ type DropRuleFilter struct {
 	Conjunction string `json:"conjunction"`
 }
 
-// DropRuleAction represents the action configuration for a drop rule
+// DropRuleAction represents the action configuration for a drop rule.
 type DropRuleAction struct {
 	Name        string                 `json:"name"`
 	Destination string                 `json:"destination"`
 	Properties  map[string]interface{} `json:"properties"`
 }
 
-// DropRule represents a complete drop rule configuration
+// DropRule is the flat shape returned by legacy GET /logs_settings/routing.
+// Do not use for writes; use OTelDropSettingCreateRequest with POST /otel_settings/drop.
 type DropRule struct {
 	Name      string           `json:"name"`
 	Telemetry string           `json:"telemetry"`
 	Filters   []DropRuleFilter `json:"filters"`
 	Action    DropRuleAction   `json:"action"`
+}
+
+// OTelDropSettingProperties is the nested properties payload for POST /otel_settings/drop.
+type OTelDropSettingProperties struct {
+	Telemetry string           `json:"telemetry"`
+	Filters   []DropRuleFilter `json:"filters"`
+	Action    DropRuleAction   `json:"action"`
+}
+
+// OTelDropSettingCreateRequest is the POST /otel_settings/drop request body.
+type OTelDropSettingCreateRequest struct {
+	Name       string                    `json:"name"`
+	Properties OTelDropSettingProperties `json:"properties"`
 }

--- a/internal/models/logs.go
+++ b/internal/models/logs.go
@@ -10,18 +10,9 @@ type DropRuleFilter struct {
 
 // DropRuleAction represents the action configuration for a drop rule.
 type DropRuleAction struct {
-	Name        string                 `json:"name"`
-	Destination string                 `json:"destination"`
-	Properties  map[string]interface{} `json:"properties"`
-}
-
-// DropRule is the flat shape returned by legacy GET /logs_settings/routing.
-// Do not use for writes; use OTelDropSettingCreateRequest with POST /otel_settings/drop.
-type DropRule struct {
-	Name      string           `json:"name"`
-	Telemetry string           `json:"telemetry"`
-	Filters   []DropRuleFilter `json:"filters"`
-	Action    DropRuleAction   `json:"action"`
+	Name        string            `json:"name"`
+	Destination string            `json:"destination"`
+	Properties  map[string]string `json:"properties"`
 }
 
 // OTelDropSettingProperties is the nested properties payload for POST /otel_settings/drop.

--- a/internal/prompts/descriptions/add_drop_rule.md
+++ b/internal/prompts/descriptions/add_drop_rule.md
@@ -38,3 +38,6 @@
 	- Each filter requires a conjunction (and) to combine with other filters
 
 	The system only supports filtering on metadata about the logs, not the actual log content itself.
+
+	Rule Names
+	- Rule names are unique. Call get_drop_rules to check which names are already in use.

--- a/internal/telemetry/logs/drop_rule.go
+++ b/internal/telemetry/logs/drop_rule.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -71,8 +72,8 @@ func NewGetDropRulesHandler(client *http.Client, cfg models.Config) func(context
 
 // DropRuleFilter represents a filter for drop rules
 type DropRuleFilter struct {
-	Key         string `json:"key" jsonschema:"The field to filter on (e.g. service level severity)"`
-	Value       string `json:"value" jsonschema:"The value to match against (e.g. test-service)"`
+	Key         string `json:"key" jsonschema:"The field to filter on (e.g. attributes[\"level\"], resource.attributes[\"service.name\"])"`
+	Value       string `json:"value" jsonschema:"The value to match against (e.g. debug)"`
 	Operator    string `json:"operator" jsonschema:"The operator to use for comparison (default: equals, options: equals, not_equals)"`
 	Conjunction string `json:"conjunction" jsonschema:"How to combine with other filters (default: and, options: and)"`
 }
@@ -83,110 +84,141 @@ type AddDropRuleArgs struct {
 	Filters []DropRuleFilter `json:"filters" jsonschema:"Array of filter conditions to match logs for dropping"`
 }
 
+type dropOTelSettingCreateReq struct {
+	Name       string                    `json:"name"`
+	Properties dropOTelSettingProperties `json:"properties"`
+}
+
+type dropOTelSettingProperties struct {
+	Telemetry string                  `json:"telemetry"`
+	Filters   []models.DropRuleFilter `json:"filters"`
+	Action    models.DropRuleAction   `json:"action"`
+}
+
+func dropOTelSettingsCreateURL(cfg models.Config) (*url.URL, error) {
+	if cfg.Region == "" {
+		return nil, errors.New("region is not configured")
+	}
+	if cfg.ClusterID == "" {
+		return nil, errors.New("cluster_id is not configured")
+	}
+
+	u, err := url.Parse(cfg.APIBaseURL + constants.EndpointOTelSettingsDrop)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	q := u.Query()
+	q.Set("region", cfg.Region)
+	q.Set("cluster_id", cfg.ClusterID)
+	u.RawQuery = q.Encode()
+	return u, nil
+}
+
+func validateAndConvertDropRuleFilters(args AddDropRuleArgs) ([]models.DropRuleFilter, error) {
+	if args.Name == "" {
+		return nil, errors.New("rule name is required")
+	}
+	if len(args.Filters) == 0 {
+		return nil, errors.New("filters must be provided")
+	}
+
+	var filters []models.DropRuleFilter
+	for _, f := range args.Filters {
+		operator := f.Operator
+		if operator == "" {
+			operator = "equals"
+		}
+		conjunction := f.Conjunction
+		if conjunction == "" {
+			conjunction = "and"
+		}
+
+		if operator != "equals" && operator != "not_equals" {
+			return nil, fmt.Errorf("invalid operator: %s. Must be one of: [equals, not_equals]", operator)
+		}
+		if conjunction != "and" {
+			return nil, fmt.Errorf("invalid conjunction: %s. Must be: [and]", conjunction)
+		}
+		if f.Key == "" {
+			return nil, errors.New("key must be provided")
+		}
+		if f.Value == "" {
+			return nil, errors.New("value must be provided")
+		}
+
+		filters = append(filters, models.DropRuleFilter{
+			Key:         f.Key,
+			Value:       f.Value,
+			Operator:    operator,
+			Conjunction: conjunction,
+		})
+	}
+
+	return filters, nil
+}
+
 // NewAddDropRuleHandler creates a handler for adding new drop rules for logs
 func NewAddDropRuleHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, AddDropRuleArgs) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, args AddDropRuleArgs) (*mcp.CallToolResult, any, error) {
 		accessToken := cfg.TokenManager.GetAccessToken(ctx)
 
-		u, err := url.Parse(cfg.APIBaseURL + constants.EndpointLogsSettingsRouting)
+		u, err := dropOTelSettingsCreateURL(cfg)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to parse URL: %w", err)
+			return nil, nil, err
 		}
 
-		// Validate required parameters
-		if args.Name == "" {
-			return nil, nil, errors.New("rule name is required")
+		filters, err := validateAndConvertDropRuleFilters(args)
+		if err != nil {
+			return nil, nil, err
 		}
 
-		if len(args.Filters) == 0 {
-			return nil, nil, errors.New("filters must be provided")
-		}
-
-		// Convert filters and validate
-		var filters []models.DropRuleFilter
-		for _, f := range args.Filters {
-			// Set defaults if not provided
-			operator := f.Operator
-			if operator == "" {
-				operator = "equals"
-			}
-			conjunction := f.Conjunction
-			if conjunction == "" {
-				conjunction = "and"
-			}
-
-			// Validate operator
-			if operator != "equals" && operator != "not_equals" {
-				return nil, nil, fmt.Errorf("invalid operator: %s. Must be one of: [equals, not_equals]", operator)
-			}
-
-			// Validate conjunction
-			if conjunction != "and" {
-				return nil, nil, fmt.Errorf("invalid conjunction: %s. Must be: [and]", conjunction)
-			}
-
-			// Validate key and value
-			if f.Key == "" {
-				return nil, nil, errors.New("key must be provided")
-			}
-			if f.Value == "" {
-				return nil, nil, errors.New("value must be provided")
-			}
-
-			filter := models.DropRuleFilter{
-				Key:         f.Key,
-				Value:       f.Value,
-				Operator:    operator,
-				Conjunction: conjunction,
-			}
-			filters = append(filters, filter)
-		}
-
-		// Create the complete drop rule
-		dropRule := models.DropRule{
-			Name:      args.Name,
-			Telemetry: TELEMETRY_LOGS,
-			Filters:   filters,
-			Action: models.DropRuleAction{
-				Name:       DROP_RULE_ACTION_NAME,
-				Properties: make(map[string]interface{}),
+		payload := dropOTelSettingCreateReq{
+			Name: args.Name,
+			Properties: dropOTelSettingProperties{
+				Telemetry: TELEMETRY_LOGS,
+				Filters:   filters,
+				Action: models.DropRuleAction{
+					Name:        DROP_RULE_ACTION_NAME,
+					Destination: "",
+					Properties:  make(map[string]interface{}),
+				},
 			},
 		}
 
-		// Marshal the drop rule
-		jsonData, err := json.Marshal(dropRule)
+		jsonData, err := json.Marshal(payload)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to marshal drop rule: %w", err)
 		}
 
-		// Create request
-		httpReq, err := http.NewRequestWithContext(ctx, "PUT", u.String(), bytes.NewReader(jsonData))
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(jsonData))
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create request: %w", err)
 		}
 
-		// Use the new access token
 		httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+accessToken)
 		httpReq.Header.Set(constants.HeaderContentType, constants.HeaderContentTypeJSON)
 
-		// Execute request
 		resp, err := client.Do(httpReq)
 		if err != nil {
 			return nil, nil, fmt.Errorf("request failed: %w", err)
 		}
 		defer resp.Body.Close()
 
-		var result interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return nil, nil, fmt.Errorf("failed to decode response: %w", err)
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read response: %w", err)
 		}
 
-		responseData, err := json.Marshal(result)
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			return nil, nil, fmt.Errorf("drop rule API request failed with status %d: %s", resp.StatusCode, string(respBody))
+		}
+
+		responseData, err := json.Marshal(json.RawMessage(respBody))
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
 		}
 
-		// Build deep link URL for drop rules
 		dlBuilder := deeplink.NewBuilder(cfg.OrgSlug, cfg.ClusterID)
 		dashboardURL := dlBuilder.BuildDropRulesLink()
 

--- a/internal/telemetry/logs/drop_rule.go
+++ b/internal/telemetry/logs/drop_rule.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"last9-mcp/internal/constants"
 	"last9-mcp/internal/deeplink"
@@ -20,7 +21,8 @@ import (
 // GetDropRulesArgs represents the input arguments for getting drop rules (no arguments needed)
 type GetDropRulesArgs struct{}
 
-// NewGetDropRulesHandler creates a handler for getting drop rules for logs
+// NewGetDropRulesHandler creates a handler for getting drop rules for logs.
+// Reads still use GET /logs_settings/routing (legacy read path kept by last9-api for backward compat).
 func NewGetDropRulesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetDropRulesArgs) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, args GetDropRulesArgs) (*mcp.CallToolResult, any, error) {
 		accessToken := cfg.TokenManager.GetAccessToken(ctx)
@@ -145,6 +147,9 @@ func validateAndConvertDropRuleFilters(args AddDropRuleArgs) ([]models.DropRuleF
 		}
 		if f.Value == "" {
 			return nil, errors.New("value must be provided")
+		}
+		if !strings.HasPrefix(f.Key, "attributes[") && !strings.HasPrefix(f.Key, "resource.attributes[") {
+			return nil, errors.New(`filter key must use attributes["..."] or resource.attributes["..."] format`)
 		}
 
 		filters = append(filters, models.DropRuleFilter{

--- a/internal/telemetry/logs/drop_rule.go
+++ b/internal/telemetry/logs/drop_rule.go
@@ -21,58 +21,7 @@ import (
 // GetDropRulesArgs represents the input arguments for getting drop rules (no arguments needed)
 type GetDropRulesArgs struct{}
 
-// NewGetDropRulesHandler creates a handler for getting drop rules for logs.
-// Reads still use GET /logs_settings/routing (legacy read path kept by last9-api for backward compat).
-func NewGetDropRulesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetDropRulesArgs) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, args GetDropRulesArgs) (*mcp.CallToolResult, any, error) {
-		accessToken := cfg.TokenManager.GetAccessToken(ctx)
-
-		u, err := url.Parse(cfg.APIBaseURL + constants.EndpointLogsSettingsRouting)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to parse URL: %w", err)
-		}
-
-		httpReq, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create request: %w", err)
-		}
-
-		// Use the new access token
-		httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+accessToken)
-
-		// Execute request
-		resp, err := client.Do(httpReq)
-		if err != nil {
-			return nil, nil, fmt.Errorf("request failed: %w", err)
-		}
-		defer resp.Body.Close()
-
-		var result interface{}
-		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-			return nil, nil, fmt.Errorf("failed to decode response: %w", err)
-		}
-
-		jsonData, err := json.Marshal(result)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
-		}
-
-		// Build deep link URL for drop rules
-		dlBuilder := deeplink.NewBuilder(cfg.OrgSlug, cfg.ClusterID)
-		dashboardURL := dlBuilder.BuildDropRulesLink()
-
-		return &mcp.CallToolResult{
-			Meta: deeplink.ToMeta(dashboardURL),
-			Content: []mcp.Content{
-				&mcp.TextContent{
-					Text: string(jsonData),
-				},
-			},
-		}, nil, nil
-	}
-}
-
-// DropRuleFilter represents a filter for drop rules
+// DropRuleFilter represents a filter for drop rules in MCP tool arguments.
 type DropRuleFilter struct {
 	Key         string `json:"key" jsonschema:"The field to filter on (e.g. attributes[\"level\"], resource.attributes[\"service.name\"])"`
 	Value       string `json:"value" jsonschema:"The value to match against (e.g. debug)"`
@@ -86,15 +35,20 @@ type AddDropRuleArgs struct {
 	Filters []DropRuleFilter `json:"filters" jsonschema:"Array of filter conditions to match logs for dropping"`
 }
 
-type dropOTelSettingCreateReq struct {
-	Name       string                    `json:"name"`
-	Properties dropOTelSettingProperties `json:"properties"`
-}
+func dropOTelSettingsListURL(cfg models.Config) (*url.URL, error) {
+	if cfg.Region == "" {
+		return nil, errors.New("region is not configured")
+	}
 
-type dropOTelSettingProperties struct {
-	Telemetry string                  `json:"telemetry"`
-	Filters   []models.DropRuleFilter `json:"filters"`
-	Action    models.DropRuleAction   `json:"action"`
+	u, err := url.Parse(cfg.APIBaseURL + constants.EndpointOTelSettingsDrop)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	q := u.Query()
+	q.Set("region", cfg.Region)
+	u.RawQuery = q.Encode()
+	return u, nil
 }
 
 func dropOTelSettingsCreateURL(cfg models.Config) (*url.URL, error) {
@@ -117,16 +71,19 @@ func dropOTelSettingsCreateURL(cfg models.Config) (*url.URL, error) {
 	return u, nil
 }
 
-func validateAndConvertDropRuleFilters(args AddDropRuleArgs) ([]models.DropRuleFilter, error) {
+func validateAddDropRuleArgs(args AddDropRuleArgs) error {
 	if args.Name == "" {
-		return nil, errors.New("rule name is required")
+		return errors.New("rule name is required")
 	}
 	if len(args.Filters) == 0 {
-		return nil, errors.New("filters must be provided")
+		return errors.New("filters must be provided")
 	}
+	return nil
+}
 
-	var filters []models.DropRuleFilter
-	for _, f := range args.Filters {
+func convertDropRuleFilters(filters []DropRuleFilter) ([]models.DropRuleFilter, error) {
+	var converted []models.DropRuleFilter
+	for _, f := range filters {
 		operator := f.Operator
 		if operator == "" {
 			operator = "equals"
@@ -152,7 +109,7 @@ func validateAndConvertDropRuleFilters(args AddDropRuleArgs) ([]models.DropRuleF
 			return nil, errors.New(`filter key must use attributes["..."] or resource.attributes["..."] format`)
 		}
 
-		filters = append(filters, models.DropRuleFilter{
+		converted = append(converted, models.DropRuleFilter{
 			Key:         f.Key,
 			Value:       f.Value,
 			Operator:    operator,
@@ -160,7 +117,71 @@ func validateAndConvertDropRuleFilters(args AddDropRuleArgs) ([]models.DropRuleF
 		})
 	}
 
-	return filters, nil
+	return converted, nil
+}
+
+func readDropRuleAPIResponse(resp *http.Response) ([]byte, error) {
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("drop rule API request failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+	if !json.Valid(respBody) {
+		return nil, fmt.Errorf("drop rule API returned invalid JSON")
+	}
+	return respBody, nil
+}
+
+func dropRuleToolResult(cfg models.Config, responseBody []byte) (*mcp.CallToolResult, error) {
+	dlBuilder := deeplink.NewBuilder(cfg.OrgSlug, cfg.ClusterID)
+	dashboardURL := dlBuilder.BuildDropRulesLink()
+
+	return &mcp.CallToolResult{
+		Meta: deeplink.ToMeta(dashboardURL),
+		Content: []mcp.Content{
+			&mcp.TextContent{
+				Text: string(responseBody),
+			},
+		},
+	}, nil
+}
+
+// NewGetDropRulesHandler creates a handler for getting drop rules for logs.
+func NewGetDropRulesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetDropRulesArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, args GetDropRulesArgs) (*mcp.CallToolResult, any, error) {
+		accessToken := cfg.TokenManager.GetAccessToken(ctx)
+
+		u, err := dropOTelSettingsListURL(cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get_drop_rules: %w", err)
+		}
+
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get_drop_rules: failed to create request: %w", err)
+		}
+
+		httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+accessToken)
+
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get_drop_rules: request failed: %w", err)
+		}
+		defer resp.Body.Close()
+
+		respBody, err := readDropRuleAPIResponse(resp)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get_drop_rules: %w", err)
+		}
+
+		result, err := dropRuleToolResult(cfg, respBody)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get_drop_rules: %w", err)
+		}
+		return result, nil, nil
+	}
 }
 
 // NewAddDropRuleHandler creates a handler for adding new drop rules for logs
@@ -170,17 +191,21 @@ func NewAddDropRuleHandler(client *http.Client, cfg models.Config) func(context.
 
 		u, err := dropOTelSettingsCreateURL(cfg)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("add_drop_rule: %w", err)
 		}
 
-		filters, err := validateAndConvertDropRuleFilters(args)
+		if err := validateAddDropRuleArgs(args); err != nil {
+			return nil, nil, fmt.Errorf("add_drop_rule: %w", err)
+		}
+
+		filters, err := convertDropRuleFilters(args.Filters)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("add_drop_rule: %w", err)
 		}
 
-		payload := dropOTelSettingCreateReq{
+		payload := models.OTelDropSettingCreateRequest{
 			Name: args.Name,
-			Properties: dropOTelSettingProperties{
+			Properties: models.OTelDropSettingProperties{
 				Telemetry: TELEMETRY_LOGS,
 				Filters:   filters,
 				Action: models.DropRuleAction{
@@ -193,12 +218,12 @@ func NewAddDropRuleHandler(client *http.Client, cfg models.Config) func(context.
 
 		jsonData, err := json.Marshal(payload)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to marshal drop rule: %w", err)
+			return nil, nil, fmt.Errorf("add_drop_rule: failed to marshal drop rule: %w", err)
 		}
 
 		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(jsonData))
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create request: %w", err)
+			return nil, nil, fmt.Errorf("add_drop_rule: failed to create request: %w", err)
 		}
 
 		httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+accessToken)
@@ -206,34 +231,19 @@ func NewAddDropRuleHandler(client *http.Client, cfg models.Config) func(context.
 
 		resp, err := client.Do(httpReq)
 		if err != nil {
-			return nil, nil, fmt.Errorf("request failed: %w", err)
+			return nil, nil, fmt.Errorf("add_drop_rule: request failed: %w", err)
 		}
 		defer resp.Body.Close()
 
-		respBody, err := io.ReadAll(resp.Body)
+		respBody, err := readDropRuleAPIResponse(resp)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to read response: %w", err)
+			return nil, nil, fmt.Errorf("add_drop_rule: %w", err)
 		}
 
-		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-			return nil, nil, fmt.Errorf("drop rule API request failed with status %d: %s", resp.StatusCode, string(respBody))
-		}
-
-		responseData, err := json.Marshal(json.RawMessage(respBody))
+		result, err := dropRuleToolResult(cfg, respBody)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to marshal response: %w", err)
+			return nil, nil, fmt.Errorf("add_drop_rule: %w", err)
 		}
-
-		dlBuilder := deeplink.NewBuilder(cfg.OrgSlug, cfg.ClusterID)
-		dashboardURL := dlBuilder.BuildDropRulesLink()
-
-		return &mcp.CallToolResult{
-			Meta: deeplink.ToMeta(dashboardURL),
-			Content: []mcp.Content{
-				&mcp.TextContent{
-					Text: string(responseData),
-				},
-			},
-		}, nil, nil
+		return result, nil, nil
 	}
 }

--- a/internal/telemetry/logs/drop_rule.go
+++ b/internal/telemetry/logs/drop_rule.go
@@ -115,7 +115,9 @@ func convertDropRuleFilters(filters []DropRuleFilter) ([]models.DropRuleFilter, 
 	return converted, nil
 }
 
-func readDropRuleAPIResponse(resp *http.Response) ([]byte, error) {
+// readDropRuleAPIResponse returns emptyBody when the API answers 2xx with no
+// content, so each caller keeps the JSON shape its populated responses have.
+func readDropRuleAPIResponse(resp *http.Response, emptyBody string) ([]byte, error) {
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
@@ -125,7 +127,7 @@ func readDropRuleAPIResponse(resp *http.Response) ([]byte, error) {
 	}
 	// json.Valid rejects an empty body, so a 201/204 would read as a failure.
 	if len(bytes.TrimSpace(respBody)) == 0 {
-		return []byte("{}"), nil
+		return []byte(emptyBody), nil
 	}
 	if !json.Valid(respBody) {
 		return nil, errors.New("drop rule API returned invalid JSON")
@@ -170,7 +172,7 @@ func NewGetDropRulesHandler(client *http.Client, cfg models.Config) func(context
 		}
 		defer resp.Body.Close()
 
-		respBody, err := readDropRuleAPIResponse(resp)
+		respBody, err := readDropRuleAPIResponse(resp, "[]")
 		if err != nil {
 			return nil, nil, fmt.Errorf("get_drop_rules: %w", err)
 		}
@@ -230,7 +232,7 @@ func NewAddDropRuleHandler(client *http.Client, cfg models.Config) func(context.
 		}
 		defer resp.Body.Close()
 
-		respBody, err := readDropRuleAPIResponse(resp)
+		respBody, err := readDropRuleAPIResponse(resp, "{}")
 		if err != nil {
 			return nil, nil, fmt.Errorf("add_drop_rule: %w", err)
 		}

--- a/internal/telemetry/logs/drop_rule.go
+++ b/internal/telemetry/logs/drop_rule.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"last9-mcp/internal/constants"
 	"last9-mcp/internal/deeplink"
@@ -105,10 +104,6 @@ func convertDropRuleFilters(filters []DropRuleFilter) ([]models.DropRuleFilter, 
 		if f.Value == "" {
 			return nil, errors.New("value must be provided")
 		}
-		if !strings.HasPrefix(f.Key, "attributes[") && !strings.HasPrefix(f.Key, "resource.attributes[") {
-			return nil, errors.New(`filter key must use attributes["..."] or resource.attributes["..."] format`)
-		}
-
 		converted = append(converted, models.DropRuleFilter{
 			Key:         f.Key,
 			Value:       f.Value,
@@ -128,13 +123,17 @@ func readDropRuleAPIResponse(resp *http.Response) ([]byte, error) {
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, fmt.Errorf("drop rule API request failed with status %d: %s", resp.StatusCode, string(respBody))
 	}
+	// json.Valid rejects an empty body, so a 201/204 would read as a failure.
+	if len(bytes.TrimSpace(respBody)) == 0 {
+		return []byte("{}"), nil
+	}
 	if !json.Valid(respBody) {
-		return nil, fmt.Errorf("drop rule API returned invalid JSON")
+		return nil, errors.New("drop rule API returned invalid JSON")
 	}
 	return respBody, nil
 }
 
-func dropRuleToolResult(cfg models.Config, responseBody []byte) (*mcp.CallToolResult, error) {
+func dropRuleToolResult(cfg models.Config, responseBody []byte) *mcp.CallToolResult {
 	dlBuilder := deeplink.NewBuilder(cfg.OrgSlug, cfg.ClusterID)
 	dashboardURL := dlBuilder.BuildDropRulesLink()
 
@@ -145,7 +144,7 @@ func dropRuleToolResult(cfg models.Config, responseBody []byte) (*mcp.CallToolRe
 				Text: string(responseBody),
 			},
 		},
-	}, nil
+	}
 }
 
 // NewGetDropRulesHandler creates a handler for getting drop rules for logs.
@@ -176,11 +175,7 @@ func NewGetDropRulesHandler(client *http.Client, cfg models.Config) func(context
 			return nil, nil, fmt.Errorf("get_drop_rules: %w", err)
 		}
 
-		result, err := dropRuleToolResult(cfg, respBody)
-		if err != nil {
-			return nil, nil, fmt.Errorf("get_drop_rules: %w", err)
-		}
-		return result, nil, nil
+		return dropRuleToolResult(cfg, respBody), nil, nil
 	}
 }
 
@@ -211,7 +206,7 @@ func NewAddDropRuleHandler(client *http.Client, cfg models.Config) func(context.
 				Action: models.DropRuleAction{
 					Name:        DROP_RULE_ACTION_NAME,
 					Destination: "",
-					Properties:  make(map[string]interface{}),
+					Properties:  make(map[string]string),
 				},
 			},
 		}
@@ -240,10 +235,6 @@ func NewAddDropRuleHandler(client *http.Client, cfg models.Config) func(context.
 			return nil, nil, fmt.Errorf("add_drop_rule: %w", err)
 		}
 
-		result, err := dropRuleToolResult(cfg, respBody)
-		if err != nil {
-			return nil, nil, fmt.Errorf("add_drop_rule: %w", err)
-		}
-		return result, nil, nil
+		return dropRuleToolResult(cfg, respBody), nil, nil
 	}
 }

--- a/internal/telemetry/logs/drop_rule_test.go
+++ b/internal/telemetry/logs/drop_rule_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -44,7 +45,7 @@ func TestAddDropRuleHandlerContextCancellation(t *testing.T) {
 	_, _, err := handler(ctx, &mcp.CallToolRequest{}, AddDropRuleArgs{
 		Name: "test-rule",
 		Filters: []DropRuleFilter{
-			{Key: "service_name", Value: "test-service", Operator: "equals", Conjunction: "and"},
+			{Key: `attributes["service_name"]`, Value: "test-service", Operator: "equals", Conjunction: "and"},
 		},
 	})
 
@@ -55,24 +56,30 @@ func TestAddDropRuleHandlerContextCancellation(t *testing.T) {
 
 func TestAddDropRuleHandlerSendsCorrectPayload(t *testing.T) {
 	var capturedMethod string
+	var capturedPath string
+	var capturedQuery url.Values
 	var capturedBody map[string]interface{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.Query()
 		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
 			http.Error(w, "bad body", http.StatusBadRequest)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(map[string]interface{}{"id": "rule-123"})
 	}))
 	defer server.Close()
 
-	handler := NewAddDropRuleHandler(server.Client(), testDropRuleConfig(server.URL))
+	cfg := testDropRuleConfig(server.URL)
+	handler := NewAddDropRuleHandler(server.Client(), cfg)
 	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AddDropRuleArgs{
 		Name: "drop-test-service",
 		Filters: []DropRuleFilter{
-			{Key: "service_name", Value: "test-service", Operator: "equals", Conjunction: "and"},
+			{Key: `attributes["service_name"]`, Value: "test-service", Operator: "equals", Conjunction: "and"},
 		},
 	})
 
@@ -82,14 +89,28 @@ func TestAddDropRuleHandlerSendsCorrectPayload(t *testing.T) {
 	if result == nil {
 		t.Fatal("expected result, got nil")
 	}
-	if capturedMethod != http.MethodPut {
-		t.Fatalf("expected PUT, got %s", capturedMethod)
+	if capturedMethod != http.MethodPost {
+		t.Fatalf("expected POST, got %s", capturedMethod)
+	}
+	if capturedPath != "/otel_settings/drop" {
+		t.Fatalf("expected path /otel_settings/drop, got %s", capturedPath)
+	}
+	if capturedQuery.Get("region") != cfg.Region {
+		t.Fatalf("expected region=%s, got %s", cfg.Region, capturedQuery.Get("region"))
+	}
+	if capturedQuery.Get("cluster_id") != cfg.ClusterID {
+		t.Fatalf("expected cluster_id=%s, got %s", cfg.ClusterID, capturedQuery.Get("cluster_id"))
 	}
 	if capturedBody["name"] != "drop-test-service" {
 		t.Fatalf("expected name=drop-test-service, got %v", capturedBody["name"])
 	}
-	if capturedBody["telemetry"] != TELEMETRY_LOGS {
-		t.Fatalf("expected telemetry=%s, got %v", TELEMETRY_LOGS, capturedBody["telemetry"])
+
+	properties, ok := capturedBody["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected properties object, got %T", capturedBody["properties"])
+	}
+	if properties["telemetry"] != TELEMETRY_LOGS {
+		t.Fatalf("expected telemetry=%s, got %v", TELEMETRY_LOGS, properties["telemetry"])
 	}
 }
 
@@ -108,7 +129,7 @@ func TestAddDropRuleHandlerValidation(t *testing.T) {
 		{
 			name: "missing rule name",
 			args: AddDropRuleArgs{
-				Filters: []DropRuleFilter{{Key: "service_name", Value: "svc"}},
+				Filters: []DropRuleFilter{{Key: `attributes["service_name"]`, Value: "svc"}},
 			},
 		},
 		{
@@ -123,7 +144,7 @@ func TestAddDropRuleHandlerValidation(t *testing.T) {
 			args: AddDropRuleArgs{
 				Name: "my-rule",
 				Filters: []DropRuleFilter{
-					{Key: "service_name", Value: "svc", Operator: "contains"},
+					{Key: `attributes["service_name"]`, Value: "svc", Operator: "contains"},
 				},
 			},
 		},
@@ -132,7 +153,7 @@ func TestAddDropRuleHandlerValidation(t *testing.T) {
 			args: AddDropRuleArgs{
 				Name: "my-rule",
 				Filters: []DropRuleFilter{
-					{Key: "service_name", Value: "svc", Conjunction: "or"},
+					{Key: `attributes["service_name"]`, Value: "svc", Conjunction: "or"},
 				},
 			},
 		},
@@ -147,7 +168,7 @@ func TestAddDropRuleHandlerValidation(t *testing.T) {
 			name: "missing filter value",
 			args: AddDropRuleArgs{
 				Name:    "my-rule",
-				Filters: []DropRuleFilter{{Key: "service_name"}},
+				Filters: []DropRuleFilter{{Key: `attributes["service_name"]`}},
 			},
 		},
 	}
@@ -159,6 +180,39 @@ func TestAddDropRuleHandlerValidation(t *testing.T) {
 				t.Fatal("expected validation error, got nil")
 			}
 		})
+	}
+}
+
+func TestAddDropRuleHandlerRequiresRegionAndCluster(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("server should not be called when config is incomplete")
+	}))
+	defer server.Close()
+
+	cfg := testDropRuleConfig(server.URL)
+	cfg.Region = ""
+	handler := NewAddDropRuleHandler(server.Client(), cfg)
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AddDropRuleArgs{
+		Name: "my-rule",
+		Filters: []DropRuleFilter{
+			{Key: `attributes["level"]`, Value: "debug"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing region, got nil")
+	}
+
+	cfg = testDropRuleConfig(server.URL)
+	cfg.ClusterID = ""
+	handler = NewAddDropRuleHandler(server.Client(), cfg)
+	_, _, err = handler(context.Background(), &mcp.CallToolRequest{}, AddDropRuleArgs{
+		Name: "my-rule",
+		Filters: []DropRuleFilter{
+			{Key: `attributes["level"]`, Value: "debug"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing cluster_id, got nil")
 	}
 }
 

--- a/internal/telemetry/logs/drop_rule_test.go
+++ b/internal/telemetry/logs/drop_rule_test.go
@@ -68,11 +68,37 @@ func TestConvertDropRuleFilters(t *testing.T) {
 		t.Fatalf("expected default conjunction and, got %q", filters[0].Conjunction)
 	}
 
-	_, err = convertDropRuleFilters([]DropRuleFilter{
-		{Key: "service_name", Value: "checkout"},
-	})
-	if err == nil {
-		t.Fatal("expected invalid key format error")
+	// Key format is the API's contract; only non-empty is checked here.
+	if _, err := convertDropRuleFilters([]DropRuleFilter{
+		{Key: "", Value: "checkout"},
+	}); err == nil {
+		t.Fatal("expected missing key error")
+	}
+}
+
+func TestReadDropRuleAPIResponseEmptyBodyOnSuccess(t *testing.T) {
+	for _, status := range []int{http.StatusCreated, http.StatusNoContent, http.StatusOK} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+		}))
+
+		handler := NewAddDropRuleHandler(server.Client(), testDropRuleConfig(server.URL))
+		result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AddDropRuleArgs{
+			Name:    "drop-test-service",
+			Filters: []DropRuleFilter{{Key: `attributes["level"]`, Value: "debug"}},
+		})
+		server.Close()
+
+		if err != nil {
+			t.Fatalf("status %d: expected empty 2xx body to be a success, got %v", status, err)
+		}
+		text, ok := result.Content[0].(*mcp.TextContent)
+		if !ok {
+			t.Fatalf("status %d: expected text content, got %T", status, result.Content[0])
+		}
+		if text.Text != "{}" {
+			t.Fatalf("status %d: expected {}, got %q", status, text.Text)
+		}
 	}
 }
 
@@ -265,15 +291,6 @@ func TestAddDropRuleHandlerValidation(t *testing.T) {
 			args: AddDropRuleArgs{
 				Name:    "my-rule",
 				Filters: []DropRuleFilter{{Key: `attributes["service_name"]`}},
-			},
-		},
-		{
-			name: "invalid filter key format",
-			args: AddDropRuleArgs{
-				Name: "my-rule",
-				Filters: []DropRuleFilter{
-					{Key: "service_name", Value: "svc"},
-				},
 			},
 		},
 	}

--- a/internal/telemetry/logs/drop_rule_test.go
+++ b/internal/telemetry/logs/drop_rule_test.go
@@ -77,27 +77,45 @@ func TestConvertDropRuleFilters(t *testing.T) {
 }
 
 func TestReadDropRuleAPIResponseEmptyBodyOnSuccess(t *testing.T) {
-	for _, status := range []int{http.StatusCreated, http.StatusNoContent, http.StatusOK} {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(status)
-		}))
+	// Each handler keeps the JSON shape its populated responses have: a list for
+	// get_drop_rules, an object for add_drop_rule.
+	call := map[string]func(*testing.T, *httptest.Server) *mcp.CallToolResult{
+		"[]": func(t *testing.T, server *httptest.Server) *mcp.CallToolResult {
+			handler := NewGetDropRulesHandler(server.Client(), testDropRuleConfig(server.URL))
+			result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetDropRulesArgs{})
+			if err != nil {
+				t.Fatalf("get_drop_rules: expected empty 2xx body to be a success, got %v", err)
+			}
+			return result
+		},
+		"{}": func(t *testing.T, server *httptest.Server) *mcp.CallToolResult {
+			handler := NewAddDropRuleHandler(server.Client(), testDropRuleConfig(server.URL))
+			result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AddDropRuleArgs{
+				Name:    "drop-test-service",
+				Filters: []DropRuleFilter{{Key: `attributes["level"]`, Value: "debug"}},
+			})
+			if err != nil {
+				t.Fatalf("add_drop_rule: expected empty 2xx body to be a success, got %v", err)
+			}
+			return result
+		},
+	}
 
-		handler := NewAddDropRuleHandler(server.Client(), testDropRuleConfig(server.URL))
-		result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AddDropRuleArgs{
-			Name:    "drop-test-service",
-			Filters: []DropRuleFilter{{Key: `attributes["level"]`, Value: "debug"}},
-		})
-		server.Close()
+	for want, invoke := range call {
+		for _, status := range []int{http.StatusCreated, http.StatusNoContent, http.StatusOK} {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+			}))
+			result := invoke(t, server)
+			server.Close()
 
-		if err != nil {
-			t.Fatalf("status %d: expected empty 2xx body to be a success, got %v", status, err)
-		}
-		text, ok := result.Content[0].(*mcp.TextContent)
-		if !ok {
-			t.Fatalf("status %d: expected text content, got %T", status, result.Content[0])
-		}
-		if text.Text != "{}" {
-			t.Fatalf("status %d: expected {}, got %q", status, text.Text)
+			text, ok := result.Content[0].(*mcp.TextContent)
+			if !ok {
+				t.Fatalf("status %d: expected text content, got %T", status, result.Content[0])
+			}
+			if text.Text != want {
+				t.Fatalf("status %d: expected %s, got %q", status, want, text.Text)
+			}
 		}
 	}
 }

--- a/internal/telemetry/logs/drop_rule_test.go
+++ b/internal/telemetry/logs/drop_rule_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -112,6 +113,56 @@ func TestAddDropRuleHandlerSendsCorrectPayload(t *testing.T) {
 	if properties["telemetry"] != TELEMETRY_LOGS {
 		t.Fatalf("expected telemetry=%s, got %v", TELEMETRY_LOGS, properties["telemetry"])
 	}
+
+	filters, ok := properties["filters"].([]interface{})
+	if !ok || len(filters) != 1 {
+		t.Fatalf("expected one filter, got %v", properties["filters"])
+	}
+	filter, ok := filters[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected filter object, got %T", filters[0])
+	}
+	if filter["key"] != `attributes["service_name"]` {
+		t.Fatalf("unexpected filter key: %v", filter["key"])
+	}
+	if filter["operator"] != "equals" {
+		t.Fatalf("unexpected filter operator: %v", filter["operator"])
+	}
+
+	action, ok := properties["action"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected action object, got %T", properties["action"])
+	}
+	if action["name"] != DROP_RULE_ACTION_NAME {
+		t.Fatalf("expected action name=%s, got %v", DROP_RULE_ACTION_NAME, action["name"])
+	}
+	if action["destination"] != "" {
+		t.Fatalf("expected empty destination, got %v", action["destination"])
+	}
+}
+
+func TestAddDropRuleHandlerAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}))
+	defer server.Close()
+
+	handler := NewAddDropRuleHandler(server.Client(), testDropRuleConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, AddDropRuleArgs{
+		Name: "drop-test-service",
+		Filters: []DropRuleFilter{
+			{Key: `attributes["level"]`, Value: "debug"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected API error, got nil")
+	}
+	if !strings.Contains(err.Error(), "405") {
+		t.Fatalf("expected status in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "method not allowed") {
+		t.Fatalf("expected response body in error, got %v", err)
+	}
 }
 
 func TestAddDropRuleHandlerValidation(t *testing.T) {
@@ -171,6 +222,15 @@ func TestAddDropRuleHandlerValidation(t *testing.T) {
 				Filters: []DropRuleFilter{{Key: `attributes["service_name"]`}},
 			},
 		},
+		{
+			name: "invalid filter key format",
+			args: AddDropRuleArgs{
+				Name: "my-rule",
+				Filters: []DropRuleFilter{
+					{Key: "service_name", Value: "svc"},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -201,6 +261,9 @@ func TestAddDropRuleHandlerRequiresRegionAndCluster(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing region, got nil")
 	}
+	if !strings.Contains(err.Error(), "region") {
+		t.Fatalf("expected region error, got %v", err)
+	}
 
 	cfg = testDropRuleConfig(server.URL)
 	cfg.ClusterID = ""
@@ -213,6 +276,9 @@ func TestAddDropRuleHandlerRequiresRegionAndCluster(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for missing cluster_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "cluster_id") {
+		t.Fatalf("expected cluster_id error, got %v", err)
 	}
 }
 

--- a/internal/telemetry/logs/drop_rule_test.go
+++ b/internal/telemetry/logs/drop_rule_test.go
@@ -30,8 +30,53 @@ func testDropRuleConfig(actionURL string) models.Config {
 	}
 }
 
+func TestValidateAddDropRuleArgs(t *testing.T) {
+	if err := validateAddDropRuleArgs(AddDropRuleArgs{
+		Filters: []DropRuleFilter{{Key: `attributes["level"]`, Value: "debug"}},
+	}); err == nil {
+		t.Fatal("expected missing name error")
+	}
+
+	if err := validateAddDropRuleArgs(AddDropRuleArgs{
+		Name: "rule",
+	}); err == nil {
+		t.Fatal("expected missing filters error")
+	}
+
+	if err := validateAddDropRuleArgs(AddDropRuleArgs{
+		Name:    "rule",
+		Filters: []DropRuleFilter{{Key: `attributes["level"]`, Value: "debug"}},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConvertDropRuleFilters(t *testing.T) {
+	filters, err := convertDropRuleFilters([]DropRuleFilter{
+		{Key: `attributes["level"]`, Value: "debug"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(filters) != 1 {
+		t.Fatalf("expected one filter, got %d", len(filters))
+	}
+	if filters[0].Operator != "equals" {
+		t.Fatalf("expected default operator equals, got %q", filters[0].Operator)
+	}
+	if filters[0].Conjunction != "and" {
+		t.Fatalf("expected default conjunction and, got %q", filters[0].Conjunction)
+	}
+
+	_, err = convertDropRuleFilters([]DropRuleFilter{
+		{Key: "service_name", Value: "checkout"},
+	})
+	if err == nil {
+		t.Fatal("expected invalid key format error")
+	}
+}
+
 func TestAddDropRuleHandlerContextCancellation(t *testing.T) {
-	// Server that blocks — proves context cancellation aborts the request.
 	blocked := make(chan struct{})
 	defer close(blocked)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -40,7 +85,7 @@ func TestAddDropRuleHandlerContextCancellation(t *testing.T) {
 	defer server.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // already cancelled
+	cancel()
 
 	handler := NewAddDropRuleHandler(server.Client(), testDropRuleConfig(server.URL))
 	_, _, err := handler(ctx, &mcp.CallToolRequest{}, AddDropRuleArgs{
@@ -239,6 +284,9 @@ func TestAddDropRuleHandlerValidation(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected validation error, got nil")
 			}
+			if !strings.Contains(err.Error(), "add_drop_rule:") {
+				t.Fatalf("expected wrapped add_drop_rule error, got %v", err)
+			}
 		})
 	}
 }
@@ -279,6 +327,62 @@ func TestAddDropRuleHandlerRequiresRegionAndCluster(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cluster_id") {
 		t.Fatalf("expected cluster_id error, got %v", err)
+	}
+}
+
+func TestGetDropRulesHandlerUsesOTelEndpoint(t *testing.T) {
+	var capturedMethod string
+	var capturedPath string
+	var capturedQuery url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]interface{}{{"id": "rule-1"}})
+	}))
+	defer server.Close()
+
+	cfg := testDropRuleConfig(server.URL)
+	handler := NewGetDropRulesHandler(server.Client(), cfg)
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetDropRulesArgs{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if capturedMethod != http.MethodGet {
+		t.Fatalf("expected GET, got %s", capturedMethod)
+	}
+	if capturedPath != "/otel_settings/drop" {
+		t.Fatalf("expected path /otel_settings/drop, got %s", capturedPath)
+	}
+	if capturedQuery.Get("region") != cfg.Region {
+		t.Fatalf("expected region=%s, got %s", cfg.Region, capturedQuery.Get("region"))
+	}
+	if capturedQuery.Get("cluster_id") != "" {
+		t.Fatalf("did not expect cluster_id on list request, got %s", capturedQuery.Get("cluster_id"))
+	}
+}
+
+func TestGetDropRulesHandlerAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	handler := NewGetDropRulesHandler(server.Client(), testDropRuleConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetDropRulesArgs{})
+	if err == nil {
+		t.Fatal("expected API error, got nil")
+	}
+	if !strings.Contains(err.Error(), "get_drop_rules:") {
+		t.Fatalf("expected wrapped get_drop_rules error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Fatalf("expected status in error, got %v", err)
 	}
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -442,8 +442,8 @@ func PopulateAPICfg(cfg *models.Config) error {
 	cfg.Region = selectedDatasource.Region
 	cfg.ClusterID = selectedDatasource.Properties.LevitateClusterID
 
-	if cfg.PrometheusReadURL == "" || cfg.PrometheusUsername == "" || cfg.PrometheusPassword == "" || cfg.Region == "" {
-		return errors.New("selected datasource missing required properties")
+	if err := validatePopulatedDatasourceCfg(cfg); err != nil {
+		return err
 	}
 
 	// Cache all datasources so handlers can resolve per-query datasource credentials
@@ -461,5 +461,15 @@ func PopulateAPICfg(cfg *models.Config) error {
 		})
 	}
 
+	return nil
+}
+
+func validatePopulatedDatasourceCfg(cfg *models.Config) error {
+	if cfg.PrometheusReadURL == "" || cfg.PrometheusUsername == "" || cfg.PrometheusPassword == "" || cfg.Region == "" {
+		return errors.New("selected datasource missing required properties")
+	}
+	if cfg.ClusterID == "" {
+		return errors.New("selected datasource missing cluster_id")
+	}
 	return nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -465,11 +465,9 @@ func PopulateAPICfg(cfg *models.Config) error {
 }
 
 func validatePopulatedDatasourceCfg(cfg *models.Config) error {
-	if cfg.PrometheusReadURL == "" || cfg.PrometheusUsername == "" || cfg.PrometheusPassword == "" || cfg.Region == "" {
+	if cfg.PrometheusReadURL == "" || cfg.PrometheusUsername == "" ||
+		cfg.PrometheusPassword == "" || cfg.Region == "" || cfg.ClusterID == "" {
 		return errors.New("selected datasource missing required properties")
-	}
-	if cfg.ClusterID == "" {
-		return errors.New("selected datasource missing cluster_id")
 	}
 	return nil
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -408,7 +408,7 @@ func TestValidatePopulatedDatasourceCfg(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected missing cluster_id error")
 	}
-	if !strings.Contains(err.Error(), "cluster_id") {
+	if !strings.Contains(err.Error(), "missing required properties") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"last9-mcp/internal/models"
 )
 
 func TestGetTimeRange_TimezoneHandling(t *testing.T) {
@@ -386,5 +388,27 @@ func TestParseToolTimestamp(t *testing.T) {
 				t.Fatalf("ParseToolTimestamp() expected UTC, got %v", parsed.Location())
 			}
 		})
+	}
+}
+
+func TestValidatePopulatedDatasourceCfg(t *testing.T) {
+	cfg := &models.Config{
+		PrometheusReadURL:  "https://prom.example",
+		PrometheusUsername: "user",
+		PrometheusPassword: "pass",
+		Region:             "us-east-1",
+		ClusterID:          "cluster-1",
+	}
+	if err := validatePopulatedDatasourceCfg(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cfg.ClusterID = ""
+	err := validatePopulatedDatasourceCfg(cfg)
+	if err == nil {
+		t.Fatal("expected missing cluster_id error")
+	}
+	if !strings.Contains(err.Error(), "cluster_id") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Route `add_drop_rule` through `POST /otel_settings/drop?region=...&cluster_id=...` instead of the legacy `PUT /logs_settings/routing` endpoint
- Send the nested `{ name, properties: { telemetry, filters, action } }` payload expected by the OTel settings API
- Return a clear HTTP error when the API rejects the request (instead of failing on JSON decode)

## Context
Alpha human-approval testing showed approvals working end-to-end, but drop rule creation failed with `PUT [405] /logs_settings/routing`. The API blocked write access to that route in favor of `/otel_settings/drop`.

## Test plan
- [x] `go test ./internal/telemetry/logs/... -run DropRule`
- [x] Approve an `add_drop_rule` action in alpha chat after deploying this build

Made with [Cursor](https://cursor.com)