### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-08-10
+
 ### Fixed
 
 - `get_database_slow_queries` trace filters now use bracket map syntax — `db_system`, `host` and `env` previously returned a 400 from the traces API. The trace pipeline sanitizer also rewrites legacy `events.`, `resources.` and `resource.` dot notation (#202).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
Bump version to 0.15.0 and stamp the changelog entries for this cycle as released.

Minor rather than patch: the cycle ships a new served MCP primitive — workflow prompts on `prompts/list` / `prompts/get` plus a `dump-prompts` subcommand (#183).

## Changes since v0.14.0

- ENG-1543: Fix slow query trace filters to use bracket map notation (#202)
- fix(logs): create drop rules via `otel_settings/drop` API (#201)
- feat(prompts): add observability workflow prompts (#183)

All three already carried CHANGELOG entries under `[Unreleased]`; this PR only inserts the `## [0.15.0]` heading below the empty `[Unreleased]` section — no entry text changed.

## Release checklist

- [ ] `tag-and-release` — tag `v0.15.0` + GoReleaser artifacts
- [ ] `publish-docker` — `docker-registry.last9.io` + ECR, tags `v0.15.0` and `latest`
- [ ] `publish-npm` — `@last9/mcp-server@0.15.0`
- [ ] homebrew-tap formula PR opened and auto-merged
