### PR TITLE
fix: cap log attribute discovery + enable body-search optimization (ENG-1689 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1-rc.1] - 2026-08-07
+
 ### Fixed
 
 - `add_drop_rule` and `get_drop_rules` use `/otel_settings/drop` instead of the legacy `logs_settings/routing` path, which the API rejects with 405 (#201).

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -61,6 +61,10 @@ type Config struct {
 	Toolsets string
 	// AllowedTools is the expanded allow-list from Toolsets. nil means all tools.
 	AllowedTools toolsets.Set
+
+	// OptimizeLineFilterQueries enables the dashboard's expensive-body search
+	// throttle (Rule 0: 1-2 parallel chunks) for chunked log/trace queries.
+	OptimizeLineFilterQueries bool
 }
 
 // ResolveDatasource looks up a datasource by name from the cached list.

--- a/internal/telemetry/logs/attributes_test.go
+++ b/internal/telemetry/logs/attributes_test.go
@@ -64,9 +64,9 @@ func TestFetchLogAttributeNames_UsesLabelsEndpoint(t *testing.T) {
 	}
 }
 
-// TestGetLogAttributesHandler_CapsTimeRangeAt1Hour verifies that when the caller
-// requests a window longer than 1 hour, the handler caps the API request to 1 hour.
-func TestGetLogAttributesHandler_CapsTimeRangeAt1Hour(t *testing.T) {
+// TestGetLogAttributesHandler_CapsTimeRangeAtFiveMinutes verifies that when the caller
+// requests a window longer than five minutes, the handler caps the API request.
+func TestGetLogAttributesHandler_CapsTimeRangeAtFiveMinutes(t *testing.T) {
 	var capturedStart, capturedEnd int64
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -84,7 +84,7 @@ func TestGetLogAttributesHandler_CapsTimeRangeAt1Hour(t *testing.T) {
 	cfg := testAttrConfig(server.URL)
 	handler := NewGetLogAttributesHandler(server.Client(), cfg)
 
-	// Request a 3-hour lookback — handler should cap to 1 hour internally.
+	// Request a 3-hour lookback — handler should cap to five minutes internally.
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLogAttributesArgs{
 		LookbackMinutes: 180,
 	})

--- a/internal/telemetry/logs/logs.go
+++ b/internal/telemetry/logs/logs.go
@@ -118,18 +118,11 @@ func fetchLogJSONQuery(ctx context.Context, client *http.Client, cfg models.Conf
 		return result, nil
 	}
 
-	// ShouldOptimizeLineFilterQuery is intentionally left at the zero value
-	// (false). The frontend toggles it via a feature flag to engage Rule 0
-	// (1–2 parallel chunks for expensive body searches with line-filter
-	// optimization). MCP has no equivalent flag today, so Rule 0 is dormant
-	// and expensive body-search queries fall through to the time-range rules.
-	// If we ever want to match the frontend's most aggressive throttle, wire
-	// a config / env var into this field and the adaptive cascade picks it up
-	// without further changes.
 	adaptiveCfg := utils.GetAdaptiveLoadingConfig(utils.AdaptiveLoadingInput{
-		StartMs:  startTime,
-		EndMs:    endTime,
-		Pipeline: args.LogjsonQuery,
+		StartMs:                       startTime,
+		EndMs:                         endTime,
+		Pipeline:                      args.LogjsonQuery,
+		ShouldOptimizeLineFilterQuery: cfg.OptimizeLineFilterQueries,
 	})
 	chunks := utils.GetAdaptiveChunks(startTime, endTime, adaptiveCfg)
 	if len(chunks) == 0 {

--- a/internal/telemetry/logs/service_logs.go
+++ b/internal/telemetry/logs/service_logs.go
@@ -225,18 +225,11 @@ func addServiceLogsEnvFilter(query []map[string]interface{}, env string) []map[s
 func fetchServiceLogs(ctx context.Context, client *http.Client, cfg models.Config, service string, startTime, endTime time.Time, limit int, logjsonQuery []map[string]interface{}, index string) (*ServiceLogsResponse, error) {
 	startMs := startTime.UnixMilli()
 	endMs := endTime.UnixMilli()
-	// ShouldOptimizeLineFilterQuery is intentionally left at the zero value
-	// (false). The frontend toggles it via a feature flag to engage Rule 0
-	// (1–2 parallel chunks for expensive body searches with line-filter
-	// optimization). MCP has no equivalent flag today, so Rule 0 is dormant
-	// and expensive body-search queries fall through to the time-range rules.
-	// If we ever want to match the frontend's most aggressive throttle, wire
-	// a config / env var into this field and the adaptive cascade picks it up
-	// without further changes.
 	adaptiveCfg := utils.GetAdaptiveLoadingConfig(utils.AdaptiveLoadingInput{
-		StartMs:  startMs,
-		EndMs:    endMs,
-		Pipeline: logjsonQuery,
+		StartMs:                       startMs,
+		EndMs:                         endMs,
+		Pipeline:                      logjsonQuery,
+		ShouldOptimizeLineFilterQuery: cfg.OptimizeLineFilterQueries,
 	})
 	chunks := utils.GetAdaptiveChunks(startMs, endMs, adaptiveCfg)
 	chunkingDebug := chunkingDebugEnabled()

--- a/internal/telemetry/traces/traces.go
+++ b/internal/telemetry/traces/traces.go
@@ -121,20 +121,11 @@ func fetchTraceJSONQuery(ctx context.Context, client *http.Client, cfg models.Co
 		return executeTraceJSONQuery(ctx, client, cfg, tracejsonQuery, startMs, endMs, effectiveLimit)
 	}
 
-	// Trace pipelines never reference the Body field, so HasExpensiveBodyParsing
-	// is always false here — adaptive config falls through to the time-range
-	// rules, exactly as the frontend would treat a non-body-search query.
-	//
-	// ShouldOptimizeLineFilterQuery is intentionally left at the zero value
-	// (false). The frontend toggles it via a feature flag to engage Rule 0
-	// (1–2 parallel chunks for expensive body searches with line-filter
-	// optimization). MCP has no equivalent flag today, so Rule 0 is dormant.
-	// For traces this is doubly moot — there's no Body field — but the
-	// comment is kept for parity with the logs call sites.
 	adaptiveCfg := utils.GetAdaptiveLoadingConfig(utils.AdaptiveLoadingInput{
-		StartMs:  startMs,
-		EndMs:    endMs,
-		Pipeline: args.TracejsonQuery,
+		StartMs:                       startMs,
+		EndMs:                         endMs,
+		Pipeline:                      args.TracejsonQuery,
+		ShouldOptimizeLineFilterQuery: cfg.OptimizeLineFilterQueries,
 	})
 	chunks := utils.GetAdaptiveChunks(startMs, endMs, adaptiveCfg)
 	if len(chunks) == 0 {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -35,7 +35,7 @@ const (
 	DefaultLookbackMinutes = 60
 	// MaxLogAttributeLookbackMinutes caps the time window for attribute discovery
 	// queries. Longer windows return the same label set at higher cost.
-	MaxLogAttributeLookbackMinutes = 60
+	MaxLogAttributeLookbackMinutes = 5
 	// TokenRefreshBuffer is the percentage of token lifetime to refresh before expiry (50%)
 	TokenRefreshBufferPercent = 50
 )

--- a/main.go
+++ b/main.go
@@ -50,6 +50,12 @@ func SetupConfig(defaults models.Config) (models.Config, error) {
 	fs.Float64Var(&cfg.RequestRateLimit, "rate", 1, "Requests per second limit")
 	fs.IntVar(&cfg.RequestRateBurst, "burst", 1, "Request burst capacity")
 	fs.IntVar(&cfg.MaxGetLogsEntries, "max_get_logs_entries", models.DefaultMaxGetLogsEntries, "Maximum number of entries returned by chunked raw get_logs requests")
+	fs.BoolVar(
+		&cfg.OptimizeLineFilterQueries,
+		"optimize_line_filter_queries",
+		os.Getenv("LAST9_OPTIMIZE_LINE_FILTER_QUERIES") == "true",
+		"Enable expensive-body line-filter optimization for chunked log/trace queries",
+	)
 	fs.BoolVar(&cfg.HTTPMode, "http", false, "Run as HTTP server instead of STDIO")
 	fs.StringVar(&cfg.Port, "port", "8080", "HTTP server port")
 	fs.StringVar(&cfg.Host, "host", "localhost", "HTTP server host")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.14.0",
+  "version": "0.14.1-rc.1",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
## Summary
- Cap `get_log_attributes` / pipeline discovery windows to **5 minutes** (was 60m) — matches ENG-1689 evidence where 1h discovery took ~89s vs 0.6s for 5m
- Wire `LAST9_OPTIMIZE_LINE_FILTER_QUERIES=true` into adaptive chunking Rule 0 for expensive body searches (`get_logs`, `get_service_logs`)

## Deploy notes (Credit+)
Set on `creditplus` and `cpluseuc1` MCP deployments:
```yaml
env:
  LAST9_OPTIMIZE_LINE_FILTER_QUERIES: "true"
```

## Test plan
- [x] `go test ./internal/telemetry/logs/... ./internal/utils/...`
- [ ] Roll MCP image to Credit+ APAC + EUC1
- [ ] Replay ENG-1689 reference query shape; confirm discovery <2s and full-day body search uses optimized chunking

Linear: ENG-1689

Made with [Cursor](https://cursor.com)