### PR TITLE
feat(mcp): add get_service_profile tool (ENG-1411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `get_service_profile` returns a per-service telemetry profile — signal presence, language/runtime, deployment envs, log `signal_shape`, and a recommended ingest fix — as a short brief followed by raw JSON. Call it before a service-scoped investigation to skip trace tools when traces are absent and to parse severity from the log body when `severity_set` is `none` or `partial`.
+
 ## [0.16.0] - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -671,6 +671,15 @@ No parameters. Returns all configured notification channels (Slack, PagerDuty, e
 
 Returns up to 3 closest matches with similarity scores. Use this before any tool call where the entity name is uncertain. If a previous call returned empty results, try this before retrying.
 
+### get_service_profile
+
+- `service_name` (string, required): Service to derive a telemetry profile for.
+- `datasource` (string, optional): Datasource name. Omit for the default.
+
+Returns a short investigation brief followed by the full profile as raw JSON: signal presence (`logs`/`traces`/`metrics` as `present`, `absent`, or `unknown`), language and runtime, deployment environments, log `signal_shape` (`log_format`, `severity_set`, `level_field`), and a recommended ingest fix where one applies. Derived upstream and cached with a ~15 minute TTL.
+
+Call it before any service-scoped investigation so tool selection matches the service's actual telemetry — skip trace tools when `traces` is `absent`, and when `severity_set` is `none` or `partial` parse severity from `level_field` in the log body rather than using `severity_filters`. `metrics` is always `unknown` and `dependencies` is unpopulated in v1. When `logs` and `traces` are both `absent`, confirm the name with `did_you_mean` before concluding the service is unmonitored.
+
 ### list_dashboards
 
 No parameters. Returns all custom dashboards in the org as a JSON array with `id`, `name`, and metadata.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ Point these at a different datasource/cluster than the default by setting `LAST9
 
 - **`did_you_mean`** — When the agent isn't sure about an entity name, this returns the closest matches from your catalog (services, environments, hosts, databases, K8s deployments/namespaces, jobs). Up to 3 suggestions with similarity scores. The server calls this automatically before most tools when a name lookup returns empty.
 
+### Service Profile
+
+- **`get_service_profile`** — What a service's telemetry actually looks like, before you query it: which signals exist, language and runtime, deployment environments, the shape of its logs, and a recommended ingest fix where one applies. Lets the agent skip trace tools when a service has no traces, and parse severity from the log body when `SeverityText` is empty instead of filtering on it and finding nothing.
+
 ---
 
 ## How It Works

--- a/dump_test.go
+++ b/dump_test.go
@@ -164,7 +164,7 @@ func TestDumpToolsInvestigate(t *testing.T) {
 	for _, tool := range out.Tools {
 		byName[tool.Name] = true
 	}
-	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources"} {
+	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "get_service_profile", "list_datasources"} {
 		if !byName[want] {
 			t.Errorf("investigate dump missing %q", want)
 		}

--- a/internal/apm/service_profile.go
+++ b/internal/apm/service_profile.go
@@ -16,10 +16,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// maxServiceProfileBodyBytes caps the success body. A profile is small and
-// bounded; anything larger is drift, not data worth buffering.
-const maxServiceProfileBodyBytes = 5 * 1024 * 1024
-
 // briefUnavailableMarker replaces the brief when the response no longer parses,
 // so a dropped routing hint is visible rather than silent.
 const briefUnavailableMarker = "Service profile: brief unavailable — the response did not match the expected schema. Raw profile follows; derive routing from it directly."
@@ -90,7 +86,7 @@ func NewGetServiceProfileHandler(client *http.Client, cfg models.Config) func(co
 			return nil, nil, utils.NewUpstreamHTTPError(resp, "service profile")
 		}
 
-		rawJSON, err := io.ReadAll(io.LimitReader(resp.Body, maxServiceProfileBodyBytes))
+		rawJSON, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to read response: %w", err)
 		}

--- a/internal/apm/service_profile.go
+++ b/internal/apm/service_profile.go
@@ -1,0 +1,109 @@
+package apm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"last9-mcp/internal/constants"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const maxServiceProfileErrorBodyBytes = 2048
+
+// GetServiceProfileArgs are the input parameters for the get_service_profile tool.
+type GetServiceProfileArgs struct {
+	ServiceName string `json:"service_name" jsonschema:"(Required) Service to derive a telemetry profile for"`
+	Datasource  string `json:"datasource,omitempty" jsonschema:"Datasource name. Omit for default."`
+}
+
+type serviceProfileRequest struct {
+	Service  string `json:"service"`
+	ReadURL  string `json:"read_url"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Region   string `json:"region"`
+}
+
+// NewGetServiceProfileHandler returns the handler for the get_service_profile MCP tool.
+func NewGetServiceProfileHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetServiceProfileArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args GetServiceProfileArgs) (*mcp.CallToolResult, any, error) {
+		service := strings.TrimSpace(args.ServiceName)
+		if service == "" {
+			return nil, nil, fmt.Errorf("service_name is required")
+		}
+
+		queryCfg, err := resolveDatasourceCfg(cfg, strings.TrimSpace(args.Datasource))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		payload := serviceProfileRequest{
+			Service:  service,
+			ReadURL:  queryCfg.PrometheusReadURL,
+			Username: queryCfg.PrometheusUsername,
+			Password: queryCfg.PrometheusPassword,
+			Region:   queryCfg.Region,
+		}
+
+		bodyBytes, err := json.Marshal(payload)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal request: %w", err)
+		}
+
+		apiURL := fmt.Sprintf("%s%s", queryCfg.APIBaseURL, constants.EndpointServiceProfile)
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(bodyBytes))
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		if queryCfg.TokenManager == nil {
+			return nil, nil, fmt.Errorf("token manager is not configured")
+		}
+
+		httpReq.Header.Set(constants.HeaderAccept, constants.HeaderAcceptJSON)
+		httpReq.Header.Set(constants.HeaderContentType, constants.HeaderContentTypeJSON)
+		httpReq.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+queryCfg.TokenManager.GetAccessToken(ctx))
+
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to fetch service profile: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, maxServiceProfileErrorBodyBytes))
+			msg := strings.TrimSpace(string(body))
+			if msg == "" {
+				msg = http.StatusText(resp.StatusCode)
+			}
+			return nil, nil, fmt.Errorf("service profile API returned status %d: %s", resp.StatusCode, msg)
+		}
+
+		rawJSON, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read response: %w", err)
+		}
+
+		var profile serviceProfileResponse
+		if err := json.Unmarshal(rawJSON, &profile); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse response: %w", err)
+		}
+
+		text := formatInvestigationBrief(profile) + "\n\n" + string(rawJSON)
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: text,
+				},
+			},
+		}, nil, nil
+	}
+}

--- a/internal/apm/service_profile.go
+++ b/internal/apm/service_profile.go
@@ -16,10 +16,18 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// maxServiceProfileBodyBytes caps the success body. A profile is small and
+// bounded; anything larger is drift, not data worth buffering.
+const maxServiceProfileBodyBytes = 5 * 1024 * 1024
+
+// briefUnavailableMarker replaces the brief when the response no longer parses,
+// so a dropped routing hint is visible rather than silent.
+const briefUnavailableMarker = "Service profile: brief unavailable — the response did not match the expected schema. Raw profile follows; derive routing from it directly."
+
 // GetServiceProfileArgs are the input parameters for the get_service_profile tool.
 type GetServiceProfileArgs struct {
 	ServiceName string `json:"service_name" jsonschema:"(Required) Service to derive a telemetry profile for"`
-	Datasource  string `json:"datasource,omitempty" jsonschema:"Datasource name. Omit for default."`
+	Datasource  string `json:"datasource,omitempty" jsonschema:"Name of the datasource to query. If omitted, uses the default configured datasource."`
 }
 
 type serviceProfileRequest struct {
@@ -82,16 +90,23 @@ func NewGetServiceProfileHandler(client *http.Client, cfg models.Config) func(co
 			return nil, nil, utils.NewUpstreamHTTPError(resp, "service profile")
 		}
 
-		rawJSON, err := io.ReadAll(resp.Body)
+		rawJSON, err := io.ReadAll(io.LimitReader(resp.Body, maxServiceProfileBodyBytes))
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to read response: %w", err)
 		}
 
 		// The raw JSON is the payload of record; parsing only builds the brief.
-		// Backend schema drift must not fail a call the agent could still use.
+		// Backend schema drift must not fail a call the agent could still use —
+		// but dropping the brief silently would hide that the routing guidance,
+		// the reason to call this tool, is missing.
 		text := string(rawJSON)
 		var profile serviceProfileResponse
-		if err := json.Unmarshal(rawJSON, &profile); err == nil {
+		if err := json.Unmarshal(rawJSON, &profile); err != nil {
+			text = briefUnavailableMarker + "\n\n" + text
+		} else {
+			if profile.Service == "" {
+				profile.Service = service
+			}
 			text = formatInvestigationBrief(profile) + "\n\n" + text
 		}
 

--- a/internal/apm/service_profile.go
+++ b/internal/apm/service_profile.go
@@ -11,11 +11,10 @@ import (
 
 	"last9-mcp/internal/constants"
 	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
-
-const maxServiceProfileErrorBodyBytes = 2048
 
 // GetServiceProfileArgs are the input parameters for the get_service_profile tool.
 type GetServiceProfileArgs struct {
@@ -77,13 +76,10 @@ func NewGetServiceProfileHandler(client *http.Client, cfg models.Config) func(co
 		}
 		defer resp.Body.Close()
 
+		// Request body carries Prometheus credentials; a raw echo of the upstream
+		// error would surface them to the model.
 		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(io.LimitReader(resp.Body, maxServiceProfileErrorBodyBytes))
-			msg := strings.TrimSpace(string(body))
-			if msg == "" {
-				msg = http.StatusText(resp.StatusCode)
-			}
-			return nil, nil, fmt.Errorf("service profile API returned status %d: %s", resp.StatusCode, msg)
+			return nil, nil, utils.NewUpstreamHTTPError(resp, "service profile")
 		}
 
 		rawJSON, err := io.ReadAll(resp.Body)
@@ -91,12 +87,13 @@ func NewGetServiceProfileHandler(client *http.Client, cfg models.Config) func(co
 			return nil, nil, fmt.Errorf("failed to read response: %w", err)
 		}
 
+		// The raw JSON is the payload of record; parsing only builds the brief.
+		// Backend schema drift must not fail a call the agent could still use.
+		text := string(rawJSON)
 		var profile serviceProfileResponse
-		if err := json.Unmarshal(rawJSON, &profile); err != nil {
-			return nil, nil, fmt.Errorf("failed to parse response: %w", err)
+		if err := json.Unmarshal(rawJSON, &profile); err == nil {
+			text = formatInvestigationBrief(profile) + "\n\n" + text
 		}
-
-		text := formatInvestigationBrief(profile) + "\n\n" + string(rawJSON)
 
 		return &mcp.CallToolResult{
 			Content: []mcp.Content{

--- a/internal/apm/service_profile_brief.go
+++ b/internal/apm/service_profile_brief.go
@@ -81,13 +81,23 @@ func formatInvestigationBrief(p serviceProfileResponse) string {
 		fmt.Fprintf(&b, " | level_field: %s", p.SignalShape.LevelField)
 	}
 
-	switch severity {
-	case "none", "partial":
-		fmt.Fprintf(&b, "\n  → parse %s from body; do not use severity_filters", firstNonEmpty(p.SignalShape.LevelField, "level"))
-	case "unknown":
-		// Silence here would leave severity_filters looking safe on a service
-		// where nobody has established that it works.
-		fmt.Fprintf(&b, "\n  → severity coverage undetermined; verify before relying on severity_filters")
+	// Severity routing is advice about querying logs; with no logs to query it
+	// is noise competing with the name-check hint below.
+	if logs != "absent" {
+		switch severity {
+		case "none", "partial":
+			if p.SignalShape.LevelField != "" {
+				fmt.Fprintf(&b, "\n  → parse %s from body; do not use severity_filters", p.SignalShape.LevelField)
+			} else {
+				// Naming a field the profile did not report would be a guess the
+				// model then queries on.
+				fmt.Fprintf(&b, "\n  → parse the level from the log body; do not use severity_filters")
+			}
+		case "unknown":
+			// Silence here would leave severity_filters looking safe on a service
+			// where nobody has established that it works.
+			fmt.Fprintf(&b, "\n  → severity coverage undetermined; verify before relying on severity_filters")
+		}
 	}
 
 	if p.Derivation.LogTier == "failed" {

--- a/internal/apm/service_profile_brief.go
+++ b/internal/apm/service_profile_brief.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+// Fields the brief does not render are still decoded so the shape stays
+// documented here; the agent reads them from the raw JSON that follows.
 type serviceProfileResponse struct {
 	Service        string                    `json:"service"`
 	DerivedAt      string                    `json:"derived_at"`
@@ -61,29 +63,40 @@ type dependenciesResponse struct {
 	Downstream []string `json:"downstream,omitempty"`
 }
 
-func nullCoalesce(value, fallback string) string {
-	if value != "" {
-		return value
-	}
-	return fallback
-}
-
 func formatInvestigationBrief(p serviceProfileResponse) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Service profile: %s", p.Service)
 	if p.DerivedAt != "" {
 		fmt.Fprintf(&b, " (derived %s)", p.DerivedAt)
 	}
-	fmt.Fprintf(&b, "\n  logs: %s | traces: %s | severity_set: %s",
-		p.Telemetry.Logs, p.Telemetry.Traces, p.SignalShape.SeveritySet)
+
+	// Absent tri-state fields render as "unknown" rather than a blank gap the
+	// model would have to guess at.
+	logs := firstNonEmpty(p.Telemetry.Logs, "unknown")
+	traces := firstNonEmpty(p.Telemetry.Traces, "unknown")
+	severity := firstNonEmpty(p.SignalShape.SeveritySet, "unknown")
+
+	fmt.Fprintf(&b, "\n  logs: %s | traces: %s | severity_set: %s", logs, traces, severity)
 	if p.SignalShape.LevelField != "" {
 		fmt.Fprintf(&b, " | level_field: %s", p.SignalShape.LevelField)
 	}
-	if p.SignalShape.SeveritySet == "none" || p.SignalShape.SeveritySet == "partial" {
-		fmt.Fprintf(&b, "\n  → parse %s from body; do not use severity_filters", nullCoalesce(p.SignalShape.LevelField, "level"))
+
+	switch severity {
+	case "none", "partial":
+		fmt.Fprintf(&b, "\n  → parse %s from body; do not use severity_filters", firstNonEmpty(p.SignalShape.LevelField, "level"))
+	case "unknown":
+		// Silence here would leave severity_filters looking safe on a service
+		// where nobody has established that it works.
+		fmt.Fprintf(&b, "\n  → severity coverage undetermined; verify before relying on severity_filters")
 	}
+
 	if p.Derivation.LogTier == "failed" {
 		fmt.Fprintf(&b, "\n  → log_tier: failed — fall back to get_log_attributes_for_pipeline")
+	}
+	// A typo'd service name derives the same empty profile as a real unmonitored
+	// service; only the name check separates them.
+	if logs == "absent" && traces == "absent" {
+		fmt.Fprintf(&b, "\n  → no telemetry under this exact name; confirm the spelling with did_you_mean before concluding the service is unmonitored")
 	}
 	if p.ErrorDetection != nil && p.ErrorDetection.RecommendedIngestFix != "" {
 		fmt.Fprintf(&b, "\n  ingest fix: %s", p.ErrorDetection.RecommendedIngestFix)

--- a/internal/apm/service_profile_brief.go
+++ b/internal/apm/service_profile_brief.go
@@ -1,0 +1,92 @@
+package apm
+
+import (
+	"fmt"
+	"strings"
+)
+
+type serviceProfileResponse struct {
+	Service        string                    `json:"service"`
+	DerivedAt      string                    `json:"derived_at"`
+	Derivation     derivationStatusResponse  `json:"derivation"`
+	Telemetry      telemetryPresenceResponse `json:"telemetry"`
+	Deployment     deploymentInfoResponse    `json:"deployment"`
+	Language       string                    `json:"language,omitempty"`
+	Runtime        *runtimeInfoResponse      `json:"runtime,omitempty"`
+	SignalShape    signalShapeResponse       `json:"signal_shape"`
+	ErrorDetection *errorDetectionResponse   `json:"error_detection,omitempty"`
+	Dependencies   *dependenciesResponse     `json:"dependencies,omitempty"`
+	Sources        []string                  `json:"sources,omitempty"`
+}
+
+type derivationStatusResponse struct {
+	MetricsTier string `json:"metrics_tier"`
+	LogTier     string `json:"log_tier"`
+}
+
+type telemetryPresenceResponse struct {
+	Logs    string `json:"logs"`
+	Metrics string `json:"metrics"`
+	Traces  string `json:"traces"`
+}
+
+type deploymentInfoResponse struct {
+	Envs       []string `json:"envs,omitempty"`
+	Namespaces []string `json:"namespaces,omitempty"`
+}
+
+type runtimeInfoResponse struct {
+	Names    []string `json:"names,omitempty"`
+	Versions []string `json:"versions,omitempty"`
+}
+
+type signalShapeResponse struct {
+	LogFormat          string `json:"log_format,omitempty"`
+	SeveritySet        string `json:"severity_set"`
+	LevelField         string `json:"level_field,omitempty"`
+	TraceContextInLogs string `json:"trace_context_in_logs"`
+	ParseHint          string `json:"parse_hint,omitempty"`
+}
+
+type errorDetectionResponse struct {
+	SignaturePack        string `json:"signature_pack,omitempty"`
+	ManifestsAs          string `json:"manifests_as,omitempty"`
+	RankBy               string `json:"rank_by,omitempty"`
+	RecommendedIngestFix string `json:"recommended_ingest_fix,omitempty"`
+}
+
+type dependenciesResponse struct {
+	DB         []string `json:"db,omitempty"`
+	Queue      []string `json:"queue,omitempty"`
+	Downstream []string `json:"downstream,omitempty"`
+}
+
+func nullCoalesce(value, fallback string) string {
+	if value != "" {
+		return value
+	}
+	return fallback
+}
+
+func formatInvestigationBrief(p serviceProfileResponse) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Service profile: %s", p.Service)
+	if p.DerivedAt != "" {
+		fmt.Fprintf(&b, " (derived %s)", p.DerivedAt)
+	}
+	fmt.Fprintf(&b, "\n  logs: %s | traces: %s | severity_set: %s",
+		p.Telemetry.Logs, p.Telemetry.Traces, p.SignalShape.SeveritySet)
+	if p.SignalShape.LevelField != "" {
+		fmt.Fprintf(&b, " | level_field: %s", p.SignalShape.LevelField)
+	}
+	if p.SignalShape.SeveritySet == "none" || p.SignalShape.SeveritySet == "partial" {
+		fmt.Fprintf(&b, "\n  → parse %s from body; do not use severity_filters", nullCoalesce(p.SignalShape.LevelField, "level"))
+	}
+	if p.Derivation.LogTier == "failed" {
+		fmt.Fprintf(&b, "\n  → log_tier: failed — fall back to get_log_attributes_for_pipeline")
+	}
+	if p.ErrorDetection != nil && p.ErrorDetection.RecommendedIngestFix != "" {
+		fmt.Fprintf(&b, "\n  ingest fix: %s", p.ErrorDetection.RecommendedIngestFix)
+	}
+	return b.String()
+}

--- a/internal/apm/service_profile_brief_test.go
+++ b/internal/apm/service_profile_brief_test.go
@@ -1,0 +1,56 @@
+package apm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatInvestigationBrief_SeverityNone(t *testing.T) {
+	p := serviceProfileResponse{
+		Service:   "payment-service",
+		DerivedAt: "2026-08-05T12:00:00Z",
+		SignalShape: signalShapeResponse{
+			SeveritySet: "none",
+			LevelField:  "level",
+		},
+		Telemetry: telemetryPresenceResponse{Logs: "present", Traces: "present"},
+		ErrorDetection: &errorDetectionResponse{
+			RecommendedIngestFix: `promote body field "level" to SeverityText`,
+		},
+	}
+	got := formatInvestigationBrief(p)
+	for _, want := range []string{
+		"payment-service",
+		"severity_set: none",
+		"level_field: level",
+		"do not use severity_filters",
+		"parse",
+		"ingest fix:",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("brief missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatInvestigationBrief_SeverityPartial(t *testing.T) {
+	p := serviceProfileResponse{
+		Service: "api",
+		SignalShape: signalShapeResponse{SeveritySet: "partial", LevelField: "level"},
+	}
+	got := formatInvestigationBrief(p)
+	if !strings.Contains(got, "do not use severity_filters") {
+		t.Fatalf("partial should route like none:\n%s", got)
+	}
+}
+
+func TestFormatInvestigationBrief_LogTierFailed(t *testing.T) {
+	p := serviceProfileResponse{
+		Service: "api",
+		Derivation: derivationStatusResponse{LogTier: "failed"},
+	}
+	got := formatInvestigationBrief(p)
+	if !strings.Contains(got, "log_tier: failed") {
+		t.Fatalf("expected failed tier warning:\n%s", got)
+	}
+}

--- a/internal/apm/service_profile_brief_test.go
+++ b/internal/apm/service_profile_brief_test.go
@@ -83,6 +83,35 @@ func TestFormatInvestigationBrief_MissingFieldsRenderUnknown(t *testing.T) {
 	}
 }
 
+// Severity advice is about querying logs; with none to query it competes with
+// the name-check hint.
+func TestFormatInvestigationBrief_NoSeverityAdviceWhenLogsAbsent(t *testing.T) {
+	p := serviceProfileResponse{
+		Service:   "api",
+		Telemetry: telemetryPresenceResponse{Logs: "absent", Traces: "present"},
+	}
+	got := formatInvestigationBrief(p)
+	if strings.Contains(got, "severity coverage undetermined") {
+		t.Fatalf("no logs means no severity advice:\n%s", got)
+	}
+}
+
+// Naming a field the profile never reported is a guess the model then queries on.
+func TestFormatInvestigationBrief_NoLevelFieldStaysGeneric(t *testing.T) {
+	p := serviceProfileResponse{
+		Service:     "api",
+		Telemetry:   telemetryPresenceResponse{Logs: "present"},
+		SignalShape: signalShapeResponse{SeveritySet: "none"},
+	}
+	got := formatInvestigationBrief(p)
+	if strings.Contains(got, "parse level from body") {
+		t.Fatalf("must not invent a level field name:\n%s", got)
+	}
+	if !strings.Contains(got, "parse the level from the log body") {
+		t.Fatalf("want generic body-parse guidance:\n%s", got)
+	}
+}
+
 func TestFormatInvestigationBrief_NoTelemetrySuggestsNameCheck(t *testing.T) {
 	p := serviceProfileResponse{
 		Service:    "typoed-svc",

--- a/internal/apm/service_profile_brief_test.go
+++ b/internal/apm/service_profile_brief_test.go
@@ -35,7 +35,7 @@ func TestFormatInvestigationBrief_SeverityNone(t *testing.T) {
 
 func TestFormatInvestigationBrief_SeverityPartial(t *testing.T) {
 	p := serviceProfileResponse{
-		Service: "api",
+		Service:     "api",
 		SignalShape: signalShapeResponse{SeveritySet: "partial", LevelField: "level"},
 	}
 	got := formatInvestigationBrief(p)
@@ -44,9 +44,60 @@ func TestFormatInvestigationBrief_SeverityPartial(t *testing.T) {
 	}
 }
 
+// The routing hint firing on a service with usable severity would send every
+// investigation down the body-parse path; presence-only assertions miss it.
+func TestFormatInvestigationBrief_SeverityFullOmitsRoutingHint(t *testing.T) {
+	p := serviceProfileResponse{
+		Service:     "api",
+		SignalShape: signalShapeResponse{SeveritySet: "full"},
+		Telemetry:   telemetryPresenceResponse{Logs: "present", Traces: "present"},
+	}
+	got := formatInvestigationBrief(p)
+	for _, unwanted := range []string{
+		"do not use severity_filters",
+		"severity coverage undetermined",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("severity_set full must not emit %q:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestFormatInvestigationBrief_SeverityUnknownWarns(t *testing.T) {
+	p := serviceProfileResponse{
+		Service:   "api",
+		Telemetry: telemetryPresenceResponse{Logs: "present", Traces: "present"},
+	}
+	got := formatInvestigationBrief(p)
+	if !strings.Contains(got, "severity coverage undetermined") {
+		t.Fatalf("undetermined severity must warn rather than stay silent:\n%s", got)
+	}
+}
+
+// Missing tri-state fields used to render "logs:  | traces:  | severity_set: ".
+func TestFormatInvestigationBrief_MissingFieldsRenderUnknown(t *testing.T) {
+	got := formatInvestigationBrief(serviceProfileResponse{Service: "api"})
+	want := "logs: unknown | traces: unknown | severity_set: unknown"
+	if !strings.Contains(got, want) {
+		t.Fatalf("want %q in:\n%s", want, got)
+	}
+}
+
+func TestFormatInvestigationBrief_NoTelemetrySuggestsNameCheck(t *testing.T) {
+	p := serviceProfileResponse{
+		Service:    "typoed-svc",
+		Telemetry:  telemetryPresenceResponse{Logs: "absent", Traces: "absent"},
+		Derivation: derivationStatusResponse{LogTier: "skipped"},
+	}
+	got := formatInvestigationBrief(p)
+	if !strings.Contains(got, "did_you_mean") {
+		t.Fatalf("empty profile should suggest a name check:\n%s", got)
+	}
+}
+
 func TestFormatInvestigationBrief_LogTierFailed(t *testing.T) {
 	p := serviceProfileResponse{
-		Service: "api",
+		Service:    "api",
 		Derivation: derivationStatusResponse{LogTier: "failed"},
 	}
 	got := formatInvestigationBrief(p)

--- a/internal/apm/service_profile_test.go
+++ b/internal/apm/service_profile_test.go
@@ -91,8 +91,36 @@ func TestGetServiceProfileHandler_UnparsableBodyStillReturnsRawJSON(t *testing.T
 	if err != nil {
 		t.Fatalf("schema drift must not fail the call: %v", err)
 	}
-	if text := utils.GetTextContent(t, result); !strings.Contains(text, drifted) {
+	text := utils.GetTextContent(t, result)
+	if !strings.Contains(text, drifted) {
 		t.Fatalf("want raw JSON passed through, got:\n%s", text)
+	}
+	// A dropped brief must announce itself; silently returning bare JSON hides
+	// that the routing guidance is gone.
+	if !strings.Contains(text, "brief unavailable") {
+		t.Fatalf("dropped brief must be marked, got:\n%s", text)
+	}
+}
+
+// A null or empty body unmarshals into a zero struct, which used to render
+// "Service profile: " with no name at all.
+func TestGetServiceProfileHandler_EmptyBodyKeepsServiceName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`null`))
+	}))
+	defer server.Close()
+
+	cfg := models.Config{APIBaseURL: server.URL}
+	cfg.TokenManager = &auth.TokenManager{AccessToken: "tok", ExpiresAt: time.Now().Add(time.Hour)}
+
+	handler := NewGetServiceProfileHandler(server.Client(), cfg)
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceProfileArgs{ServiceName: "pay-svc"})
+	if err != nil {
+		t.Fatalf("empty body must not fail the call: %v", err)
+	}
+	if text := utils.GetTextContent(t, result); !strings.Contains(text, "Service profile: pay-svc") {
+		t.Fatalf("want the requested name echoed, got:\n%s", text)
 	}
 }
 

--- a/internal/apm/service_profile_test.go
+++ b/internal/apm/service_profile_test.go
@@ -1,0 +1,111 @@
+package apm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/constants"
+	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestGetServiceProfileHandler_ForwardsRegionAndService(t *testing.T) {
+	var captured serviceProfileRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != constants.EndpointServiceProfile {
+			t.Errorf("path %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(serviceProfileResponse{
+			Service: captured.Service,
+			SignalShape: signalShapeResponse{
+				SeveritySet: "none",
+				LevelField:  "level",
+			},
+			Telemetry: telemetryPresenceResponse{Logs: "present", Traces: "present"},
+		})
+	}))
+	defer server.Close()
+
+	cfg := models.Config{
+		APIBaseURL:         server.URL,
+		PrometheusReadURL:  "https://prom.example.com",
+		PrometheusUsername: "u",
+		PrometheusPassword: "p",
+		Region:             "ap-south-1",
+	}
+	cfg.TokenManager = &auth.TokenManager{AccessToken: "tok", ExpiresAt: time.Now().Add(time.Hour)}
+
+	handler := NewGetServiceProfileHandler(server.Client(), cfg)
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceProfileArgs{ServiceName: "pay-svc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured.Service != "pay-svc" || captured.Region != "ap-south-1" || captured.ReadURL != "https://prom.example.com" {
+		t.Fatalf("body %+v", captured)
+	}
+	text := utils.GetTextContent(t, result)
+	if !strings.Contains(text, "severity_set: none") || !strings.Contains(text, "{") {
+		t.Fatalf("want brief + JSON, got:\n%s", text)
+	}
+}
+
+func TestGetServiceProfileHandler_EmptyServiceName(t *testing.T) {
+	cfg := models.Config{APIBaseURL: "https://example.com"}
+	cfg.TokenManager = &auth.TokenManager{
+		AccessToken: "test-token",
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+	}
+
+	handler := NewGetServiceProfileHandler(http.DefaultClient, cfg)
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceProfileArgs{ServiceName: ""})
+	if err == nil {
+		t.Fatal("expected error for empty service_name, got nil")
+	}
+	if !strings.Contains(err.Error(), "service_name is required") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestGetServiceProfileHandler_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != constants.EndpointServiceProfile {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := models.Config{
+		APIBaseURL:         server.URL,
+		PrometheusReadURL:  "https://prom.example.com",
+		PrometheusUsername: "u",
+		PrometheusPassword: "p",
+		Region:             "ap-south-1",
+	}
+	cfg.TokenManager = &auth.TokenManager{
+		AccessToken: "test-token",
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+	}
+
+	handler := NewGetServiceProfileHandler(server.Client(), cfg)
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceProfileArgs{ServiceName: "pay-svc"})
+	if err == nil {
+		t.Fatal("expected error on API 500, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected HTTP status in error message, got: %v", err)
+	}
+}

--- a/internal/apm/service_profile_test.go
+++ b/internal/apm/service_profile_test.go
@@ -57,8 +57,68 @@ func TestGetServiceProfileHandler_ForwardsRegionAndService(t *testing.T) {
 		t.Fatalf("body %+v", captured)
 	}
 	text := utils.GetTextContent(t, result)
-	if !strings.Contains(text, "severity_set: none") || !strings.Contains(text, "{") {
-		t.Fatalf("want brief + JSON, got:\n%s", text)
+	brief, rawJSON, found := strings.Cut(text, "\n\n")
+	if !found {
+		t.Fatalf("want brief and JSON separated by a blank line, got:\n%s", text)
+	}
+	if !strings.Contains(brief, "severity_set: none") {
+		t.Fatalf("brief missing severity routing:\n%s", brief)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(rawJSON), &decoded); err != nil {
+		t.Fatalf("trailing payload is not valid JSON (%v):\n%s", err, rawJSON)
+	}
+	if decoded["service"] != "pay-svc" {
+		t.Fatalf("raw JSON lost the service field: %v", decoded["service"])
+	}
+}
+
+// dependencies is null in v1 and will be populated later; a shape change there
+// must not take the whole tool down when the raw JSON is still usable.
+func TestGetServiceProfileHandler_UnparsableBodyStillReturnsRawJSON(t *testing.T) {
+	const drifted = `{"service":"pay-svc","dependencies":[{"db":"pg"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(drifted))
+	}))
+	defer server.Close()
+
+	cfg := models.Config{APIBaseURL: server.URL}
+	cfg.TokenManager = &auth.TokenManager{AccessToken: "tok", ExpiresAt: time.Now().Add(time.Hour)}
+
+	handler := NewGetServiceProfileHandler(server.Client(), cfg)
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceProfileArgs{ServiceName: "pay-svc"})
+	if err != nil {
+		t.Fatalf("schema drift must not fail the call: %v", err)
+	}
+	if text := utils.GetTextContent(t, result); !strings.Contains(text, drifted) {
+		t.Fatalf("want raw JSON passed through, got:\n%s", text)
+	}
+}
+
+func TestGetServiceProfileHandler_ErrorBodyIsSanitized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`invalid request: {"password":"hunter2","read_url":"https://prom.example.com"}`))
+	}))
+	defer server.Close()
+
+	cfg := models.Config{
+		APIBaseURL:         server.URL,
+		PrometheusPassword: "hunter2",
+		PrometheusReadURL:  "https://prom.example.com",
+	}
+	cfg.TokenManager = &auth.TokenManager{AccessToken: "tok", ExpiresAt: time.Now().Add(time.Hour)}
+
+	handler := NewGetServiceProfileHandler(server.Client(), cfg)
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceProfileArgs{ServiceName: "pay-svc"})
+	if err == nil {
+		t.Fatal("expected error on API 400, got nil")
+	}
+	for _, leaked := range []string{"hunter2", "prom.example.com"} {
+		if strings.Contains(err.Error(), leaked) {
+			t.Fatalf("upstream error leaked %q: %v", leaked, err)
+		}
 	}
 }
 

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -37,6 +37,8 @@ const (
 	EndpointNotificationSettings = "/notification_settings"
 	// EndpointSuggest returns fuzzy entity-name suggestions for the did_you_mean tool.
 	EndpointSuggest = "/suggest"
+	// EndpointServiceProfile derives per-service telemetry shape (POST body mirrors /suggest + region).
+	EndpointServiceProfile = "/service_profile"
 
 	// Dashboard API endpoints (v4)
 	EndpointDashboards            = "/dashboards"

--- a/internal/prompts/descriptions/get_service_profile.md
+++ b/internal/prompts/descriptions/get_service_profile.md
@@ -1,0 +1,13 @@
+Call this tool before any service-scoped investigation (logs, traces, exceptions, latency, errors). Returns a telemetry profile for one service: signal presence, severity routing, dependencies, and ingest hints.
+
+**Tri-state semantics:** telemetry fields use `present`, `absent`, or `unknown`. `unknown` means not yet derived — not the same as `absent`. Do not treat unknown as missing data.
+
+**severity_set routing:** when `severity_set` is `partial` or `none`, parse severity from the body field (`level_field` in the response). Do not use `severity_filters` on get_service_logs — route like `none`.
+
+**Trust but verify:** the profile is derived from recent telemetry (~15 minute TTL). If a later tool call contradicts the profile, trust the fresh evidence and note the mismatch.
+
+Full investigation orchestration guide: `last9://reference/investigation`
+
+Parameters:
+- service_name: (Required) Service to derive a telemetry profile for
+- datasource: (Optional) Datasource name. Omit for default.

--- a/internal/prompts/descriptions/get_service_profile.md
+++ b/internal/prompts/descriptions/get_service_profile.md
@@ -6,6 +6,8 @@ Call this tool before any service-scoped investigation (logs, traces, exceptions
 
 **Trust but verify:** the profile is derived from recent telemetry (~15 minute TTL). If a later tool call contradicts the profile, trust the fresh evidence and note the mismatch.
 
+**Output:** a short investigation brief followed by a blank line and the full profile as raw JSON. When logs and traces are both `absent`, the name may simply be wrong — confirm it with `did_you_mean` before concluding the service is unmonitored.
+
 Full investigation orchestration guide: `last9://reference/investigation`
 
 Parameters:

--- a/internal/prompts/descriptions/get_service_profile.md
+++ b/internal/prompts/descriptions/get_service_profile.md
@@ -1,4 +1,4 @@
-Call this tool before any service-scoped investigation (logs, traces, exceptions, latency, errors). Returns a telemetry profile for one service: signal presence, severity routing, dependencies, and ingest hints.
+Call this tool before any service-scoped investigation (logs, traces, exceptions, latency, errors). Returns a telemetry profile for one service: signal presence, severity routing, and ingest hints.
 
 **Tri-state semantics:** telemetry fields use `present`, `absent`, or `unknown`. `unknown` means not yet derived — not the same as `absent`. Do not treat unknown as missing data.
 

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -107,6 +107,9 @@ var GetDatabaseServerMetricsDescription string
 //go:embed descriptions/did_you_mean.md
 var DidYouMeanDescription string
 
+//go:embed descriptions/get_service_profile.md
+var GetServiceProfileDescription string
+
 //go:embed descriptions/list_dashboards.md
 var ListDashboardsDescription string
 

--- a/internal/toolsets/toolsets.go
+++ b/internal/toolsets/toolsets.go
@@ -69,6 +69,7 @@ var named = map[string][]string{
 // discovery tools included in the investigate composite (R9a).
 var investigateExtras = []string{
 	"did_you_mean",
+	"get_service_profile",
 	"list_datasources",
 }
 

--- a/internal/toolsets/toolsets_test.go
+++ b/internal/toolsets/toolsets_test.go
@@ -52,7 +52,7 @@ func TestParseInvestigate(t *testing.T) {
 	if set == nil {
 		t.Fatal("investigate must not expand to nil/all")
 	}
-	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources", "get_apm_service_deviations"} {
+	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "get_service_profile", "list_datasources", "get_apm_service_deviations"} {
 		if !set.Allows(want) {
 			t.Errorf("investigate missing %q", want)
 		}

--- a/tools.go
+++ b/tools.go
@@ -277,6 +277,12 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config) error 
 		Description: prompts.DidYouMeanDescription,
 	}, suggest.NewDidYouMeanHandler(client, cfg)))
 
+	// Register service profile tool
+	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
+		Name:        "get_service_profile",
+		Description: prompts.GetServiceProfileDescription,
+	}, apm.NewGetServiceProfileHandler(client, cfg)))
+
 	// Register dashboard tools
 	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
 		Name:        "list_dashboards",


### PR DESCRIPTION
## Summary
- Adds `get_service_profile` MCP tool calling `POST /service_profile` with an investigation brief plus the raw JSON profile.
- Registers the tool in the `investigate` toolset only. logs/traces/metrics membership is stacked in #209.
- Description is `go:embed`'d from `internal/prompts/descriptions/get_service_profile.md` (P2: does not advertise v1-unavailable `dependencies`).

## Test plan
- [x] `go test ./...` (1040 passed)
- [x] `dump-tools --toolsets=investigate` includes `get_service_profile`; absent from logs/traces/metrics/alerts
- [x] dump-tools vs main: only delta is `get_service_profile`; other 44 tool descriptions and schemas are byte-identical
- [x] Live smoke via `scripts/start-local.sh` (`last9-api`, `data-api` — both `severity_set: none`)
- [x] R10 `--use-server`: log_query 50/50, trace_query 27/27; log_tool_selection 12/15 matching main (pre-existing, not this PR)
- [x] `service_profile_routing` pb-001..003 skip until #209 adds `last9://reference/investigation`

## Follow-up
#209 (`feat/eng-1411-profile-orchestration`) stacks profile-first workflow rewrites, firing rules, logs/traces/metrics membership, and the load-bearing routing evals.

Linear: ENG-1411