### PR TITLE
fix(logs): align get_logs whale + fail-closed pipeline validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `get_logs` whale description (`get_logs_base.md`) now aligns with `window_aggregate` behavior: stage schema uses `anyOf` (not `oneOf`), stage-level `additionalProperties: false` is removed, and parse/window_aggregate schema `required` is only `type` so handler tips (`window_minutes`, `format`, …) remain reachable after SDK schema validation (#212).
-- `get_logs` parse stage `field` now defaults to `"Body"` when omitted, eliminating a common model mistake without a hard error (#212).
-- `TraceId`, `SpanId`, and `ParentSpanId` are now accepted as valid log field references (canonical fields for log↔trace correlation); previously they were incorrectly rejected as trace-only fields (#212).
-- `get_logs` parse stage `labels` keys now allow dotted names (e.g. `http.status_code`) — previously only plain identifiers were accepted, breaking JSON body-derived attribute hints (#212).
-- Sanitize-layer validation errors now use typed `LogPipelineValidationError` (with stable `Category` and `Path` fields) for model self-correction, matching the validate layer (#212).
-- `tracejson.md` reference corrected: `lookback_minutes` default changed from 5 to 60, matching `get_traces_base.md` and eliminating the internal contradiction (#212).
+- `get_logs` fail-closed logjson validation with self-correcting tips (wrong keys/types, bare fields, NOT-SQL, bad parse/`window_aggregate` shapes); whale description aligned with API `window_aggregate`; missing parse `field` defaults to `Body`; `TraceId`/`SpanId`/`ParentSpanId` allowed for log↔trace correlation; dotted parse labels accepted; `tracejson.md` lookback default corrected to 60 (#212).
 
 ### Changed
 
-- `get_logs` InputSchema uses `anyOf` for stage discriminator instead of `oneOf`; stage-level `additionalProperties: false` removed (root remains false). This widens schema validation to let handler-level tip errors fire correctly (#212).
+- `get_logs` InputSchema uses a permissive stage `anyOf` (plus catch-all) so handler validation tips reach the model instead of opaque SDK `anyOf` errors (#212).
 - **Breaking:** `get_service_summary` response shape is now a ranked `{rows: [...]}` envelope with snake_case fields (`request_count`, `throughput_rpm`, `http_4xx_count`, `http_5xx_count`, `grpc_error_count`) instead of a `map[string]ServiceSummary` with PascalCase keys (`ErrorRate`, etc.). Rows are `(service, env)` pairs sorted and limited server-side; clients that unmarshal the old map shape will fail and should be updated (#210).
 
 ## [0.15.0] - 2026-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `get_logs` whale description (`get_logs_base.md`) now aligns with `window_aggregate` behavior: stage schema uses `anyOf` (not `oneOf`), stage-level `additionalProperties: false` is removed, and parse/window_aggregate schema `required` is only `type` so handler tips (`window_minutes`, `format`, …) remain reachable after SDK schema validation (#212).
+- `get_logs` parse stage `field` now defaults to `"Body"` when omitted, eliminating a common model mistake without a hard error (#212).
+- `TraceId`, `SpanId`, and `ParentSpanId` are now accepted as valid log field references (canonical fields for log↔trace correlation); previously they were incorrectly rejected as trace-only fields (#212).
+- `get_logs` parse stage `labels` keys now allow dotted names (e.g. `http.status_code`) — previously only plain identifiers were accepted, breaking JSON body-derived attribute hints (#212).
+- Sanitize-layer validation errors now use typed `LogPipelineValidationError` (with stable `Category` and `Path` fields) for model self-correction, matching the validate layer (#212).
+- `tracejson.md` reference corrected: `lookback_minutes` default changed from 5 to 60, matching `get_traces_base.md` and eliminating the internal contradiction (#212).
+
+### Changed
+
+- `get_logs` InputSchema uses `anyOf` for stage discriminator instead of `oneOf`; stage-level `additionalProperties: false` removed (root remains false). This widens schema validation to let handler-level tip errors fire correctly (#212).
+
 ## [0.15.0] - 2026-08-10
 
 ### Fixed

--- a/dump_test.go
+++ b/dump_test.go
@@ -61,8 +61,14 @@ func TestDumpTools(t *testing.T) {
 		t.Fatal("get_logs description still contains unsubstituted {{labels}} placeholder")
 	}
 	for _, whale := range []string{"get_logs", "get_traces", "get_service_logs"} {
-		if len(out.Tools[byName[whale]].Description) > 2000 {
-			t.Fatalf("%s served description length %d exceeds 2000-char tripwire", whale, len(out.Tools[byName[whale]].Description))
+		whaleBudgets := map[string]int{
+			"get_logs":         4500,
+			"get_traces":       2200,
+			"get_service_logs": 2000,
+		}
+		budget := whaleBudgets[whale]
+		if len(out.Tools[byName[whale]].Description) > budget {
+			t.Fatalf("%s served description length %d exceeds %d-char budget", whale, len(out.Tools[byName[whale]].Description), budget)
 		}
 		if !strings.Contains(out.Tools[byName[whale]].Description, "last9://reference/") {
 			t.Fatalf("%s description missing resource URI pointer", whale)

--- a/dump_test.go
+++ b/dump_test.go
@@ -60,12 +60,12 @@ func TestDumpTools(t *testing.T) {
 	if strings.Contains(out.Tools[byName["get_logs"]].Description, "{{labels}}") {
 		t.Fatal("get_logs description still contains unsubstituted {{labels}} placeholder")
 	}
+	whaleBudgets := map[string]int{
+		"get_logs":         2600,
+		"get_traces":       2200,
+		"get_service_logs": 2000,
+	}
 	for _, whale := range []string{"get_logs", "get_traces", "get_service_logs"} {
-		whaleBudgets := map[string]int{
-			"get_logs":         4500,
-			"get_traces":       2200,
-			"get_service_logs": 2000,
-		}
 		budget := whaleBudgets[whale]
 		if len(out.Tools[byName[whale]].Description) > budget {
 			t.Fatalf("%s served description length %d exceeds %d-char budget", whale, len(out.Tools[byName[whale]].Description), budget)

--- a/dump_test.go
+++ b/dump_test.go
@@ -105,12 +105,29 @@ func TestDumpTools(t *testing.T) {
 	if strings.Contains(out.Tools[byName["get_logs"]].Description, "{{labels}}") {
 		t.Fatal("get_logs description still contains unsubstituted {{labels}} placeholder")
 	}
+	// get_logs: budget covers combined (description + inputSchema JSON) served size
+	// because get_logs ships a hand-crafted schema that contributes meaningfully to
+	// the context window. Budget is 7000 with headroom over the baseline ~6283.
+	logsIdx := byName["get_logs"]
+	logsSchemaBytes, err := json.Marshal(out.Tools[logsIdx].InputSchema)
+	if err != nil {
+		t.Fatalf("marshal get_logs inputSchema: %v", err)
+	}
+	logsServedSize := len(out.Tools[logsIdx].Description) + len(logsSchemaBytes)
+	const logsServedBudget = 7000
+	if logsServedSize > logsServedBudget {
+		t.Fatalf("get_logs combined (description + inputSchema) served size %d exceeds %d-char budget", logsServedSize, logsServedBudget)
+	}
+	if !strings.Contains(out.Tools[logsIdx].Description, "last9://reference/") {
+		t.Fatal("get_logs description missing resource URI pointer")
+	}
+
+	// Description-only budgets for other whales (main tripwire values restored to 2000).
 	whaleBudgets := map[string]int{
-		"get_logs":         2600,
-		"get_traces":       2200,
+		"get_traces":       2000,
 		"get_service_logs": 2000,
 	}
-	for _, whale := range []string{"get_logs", "get_traces", "get_service_logs"} {
+	for _, whale := range []string{"get_traces", "get_service_logs"} {
 		budget := whaleBudgets[whale]
 		if len(out.Tools[byName[whale]].Description) > budget {
 			t.Fatalf("%s served description length %d exceeds %d-char budget", whale, len(out.Tools[byName[whale]].Description), budget)

--- a/internal/prompts/descriptions/get_logs.md
+++ b/internal/prompts/descriptions/get_logs.md
@@ -1,1 +1,0 @@
-Manual moved to `internal/prompts/references/logjson.md` (resource `last9://reference/logjson`). Served description is `get_logs_base.md`.

--- a/internal/prompts/descriptions/get_logs_base.md
+++ b/internal/prompts/descriptions/get_logs_base.md
@@ -1,21 +1,28 @@
-Query logs with `logjson_query` — JSON **array of stages**. Each stage `"type"`: `filter`|`parse`|`aggregate`|`window_aggregate`. No `"stage"`/`"conditions"`.
+`logjson_query` is a JSON **array of stages** — NOT SQL, NOT a query string. Each stage sets `"type"`: `filter`|`parse`|`aggregate`|`window_aggregate`. No `"stage"`/`"conditions"`.
 
-**Filter:** `{"type":"filter","query":{"$and":[{"$eq":["SeverityText","ERROR"]}]}}` — `$eq|$neq|$contains|$gt|$gte|$lt|$lte|$regex` on `[field, value]` strings. Always `$and`-wrap.
+**Order rule:** filter first → parse (before using extracted attrs) → aggregate or window_aggregate only for counts/trends. Never use SpanKind/StatusCode/Duration/SpanName as log filters.
 
-**Parse / aggregate:** parse Body (`json`/`logfmt`/`regexp`), then filter `attributes['…']`. **Aggregate:** `{"type":"aggregate","aggregates":[{"function":{"$count":[]},"as":"_count"}],"groupby":{"ServiceName":"service"}}` — `function` uses `{"$count":[]}`, `{"$max":["field"]}`, or `{"$avg":["field"]}`. **window_aggregate** for trends/per-minute counts — `aggregates`+`window_minutes`, not `TimeBucket`.
+**Filter:** `{"type":"filter","query":{"$and":[{"$eq":["SeverityText","ERROR"]}]}}` — operators: `$eq|$neq|$ieq|$contains|$containsWords|$gt|$gte|$lt|$lte|$regex`. Always `$and`-wrap. Values are strings.
 
-**Severity-less logs:** empty `SeverityText` → parse Body `level`, gate `$eq`/`$ieq` on `ERROR` before counting.
+**Parse:** `{"type":"parse","parser":"json","field":"Body","labels":{"key":"key"}}` — `parser` is `json`/`logfmt`/`regexp` (never `"format"`). Parse Body first; then filter on `attributes['key']`.
 
-**Existence / attrs:** exists → `{"$neq":["field",""]}` (never `$exists`). Structured fields → `attributes['key']` — not Body `$contains`.
+**Aggregate:** `{"type":"aggregate","aggregates":[{"function":{"$count":[]},"as":"_count"}],"groupby":{"ServiceName":"service"}}` — `aggregates` (plural), `function` as object.
+
+**window_aggregate** for per-minute/trend counts — use `function`+`as`+`window` (NOT the aggregate stage, NOT `TimeBucket`):
+`[{"type":"filter","query":{"$and":[{"$eq":["SeverityText","ERROR"]}]}},{"type":"window_aggregate","function":{"$count":[]},"as":"errors","window":["1","minutes"]}]`
+
+**Severity-less logs:** empty `SeverityText` → parse Body `level`, gate `$ieq` on `ERROR` before counting.
+
+**Existence / attrs:** exists → `{"$neq":["field",""]}` (never `$exists`). Never bare field names — dotted (`http.status_code`) OR single-token (`community_member_id`) — wrap as `attributes['key']`/`resources['key']`. Only top-level `ServiceName`/`Body`/`SeverityText`/`Timestamp` may be bare.
 
 **Scope:** tenant → `resources['last9.tenant']`; env → `resources['deployment.environment']`. User `service.name` → `ServiceName`; `k8s.*` → `resources['k8s.…']`.
 
 **Free-text IDs** (EPL_…) → `{"$contains":["Body","…"]}` — not `ServiceName`.
 
-**HTTP 5xx:** filter status field with literal code (e.g. `$eq` on `attributes['status_code']`,`"500"`) — never `SeverityText`/`ERROR`; avoid regex-only when user names a code.
+**HTTP 5xx:** filter status field with literal code (e.g. `$eq` on `attributes['status_code']`, `"500"`) — never `SeverityText`/`ERROR`; avoid regex-only when user names a code.
 
-**Time:** `lookback_minutes` (default **5**). **Absolute ISO bounds** → `start_time_iso`+`end_time_iso` on the tool call — never `Timestamp`/`$gte`/`$lte` in the pipeline (pipeline filters log data only).
+**Time:** `lookback_minutes` (default **5**). **Absolute ISO bounds** → `start_time_iso`+`end_time_iso` on the tool call — never `Timestamp`/`$gte`/`$lte` in the pipeline.
 
-**l9_sanity:** high `ratio` or "filter likely too broad" → next call `get_logs` with `aggregate`+`$count` and an ERROR/`SeverityText` gate — not discovery-only.
+**l9_sanity:** high `ratio` or "filter likely too broad" → next call `get_logs` with `aggregate`+`$count` and an ERROR/`SeverityText` gate.
 
 Full manual: `last9://reference/logjson`

--- a/internal/prompts/descriptions/get_service_logs.md
+++ b/internal/prompts/descriptions/get_service_logs.md
@@ -1,1 +1,0 @@
-Manual moved to `internal/prompts/references/service_logs.md` (resource `last9://reference/service_logs`). Served description is `get_service_logs_base.md`.

--- a/internal/prompts/descriptions/get_service_traces.md
+++ b/internal/prompts/descriptions/get_service_traces.md
@@ -1,1 +1,0 @@
-Served description is `get_service_traces_base.md`.

--- a/internal/prompts/descriptions/get_traces.md
+++ b/internal/prompts/descriptions/get_traces.md
@@ -1,1 +1,0 @@
-Manual moved to `internal/prompts/references/tracejson.md` (resource `last9://reference/tracejson`). Served description is `get_traces_base.md`.

--- a/internal/prompts/descriptions/get_traces_base.md
+++ b/internal/prompts/descriptions/get_traces_base.md
@@ -12,7 +12,7 @@ Query traces with `tracejson_query` — a JSON **array of stages**. Each stage M
 
 **Scope:** tenant name → `resources['last9.tenant']`; deployment env → `resources['deployment.environment']`.
 
-**Time (tool args):** Prefer `lookback_minutes` (default **5**). Absolute → `start_time_iso`+`end_time_iso` (RFC3339). Never put the window as a `Timestamp` filter in the pipeline.
+**Time (tool args):** Prefer `lookback_minutes` (default **60**). Absolute → `start_time_iso`+`end_time_iso` (RFC3339). Never put the window as a `Timestamp` filter in the pipeline.
 
 **Fields:** Top-level: `TraceId`, `SpanId`, `ServiceName`, `SpanName`, `SpanKind`, `StatusCode`, `Duration`, `Timestamp`, `ParentSpanId`. SpanKind/StatusCode need full OTel prefixes (`SPAN_KIND_SERVER`, `STATUS_CODE_ERROR`—not `SERVER`/`ERROR`). **`Duration` is nanoseconds** (1000ms = `1000000000`). Span/resource attrs → `get_trace_attributes*`; use `attributes['key']` / `resources['key']` (never `SpanAttributes.foo`).
 

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -53,7 +53,7 @@ func TestGetTracesDescriptionCriticalRules(t *testing.T) {
 		{"groupby", "must document groupby key name"},
 		{"resources['last9.tenant']", "must document tenant scoping"},
 		{"last9://reference/tracejson", "must point at the tracejson resource"},
-		{"60", "must document default lookback of 60 minutes"},
+		{"default **60**", "must document default lookback of 60 minutes"},
 	}
 	for _, c := range checks {
 		if !strings.Contains(desc, c.phrase) {
@@ -85,7 +85,7 @@ func TestGetServiceLogsDescriptionCriticalRules(t *testing.T) {
 
 func TestWhaleDescriptionsBounded(t *testing.T) {
 	budgets := map[string]int{
-		"get_logs_base":         4500,
+		"get_logs_base":         2600,
 		"get_traces_base":       2200,
 		"get_service_logs_base": 2000,
 	}

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -17,16 +17,24 @@ func TestGetLogsDescriptionCriticalRules(t *testing.T) {
 		reason string
 	}{
 		{"window_aggregate", "must document time-bucketed counts"},
+		{"window", "must document window key for window_aggregate"},
+		{"function", "must document function key for window_aggregate"},
+		{"NOT SQL", "must clarify logjson_query is not SQL"},
 		{"$neq", "must document existence idiom"},
 		{"start_time_iso", "must document absolute time on tool args"},
 		{"resources['last9.tenant']", "must document tenant scoping"},
 		{"resources['deployment.environment']", "must document env scoping"},
 		{"last9://reference/logjson", "must point at the logjson resource"},
+		{"community_member_id", "must document bare single-token field mistake"},
+		{"attributes['key']", "must require attributes/resources wrapping"},
 	}
 	for _, c := range checks {
 		if !strings.Contains(desc, c.phrase) {
 			t.Errorf("GetLogsDescription missing %q: %s", c.phrase, c.reason)
 		}
+	}
+	if strings.Contains(desc, "window_minutes") {
+		t.Error("GetLogsDescription must NOT contain deprecated 'window_minutes' key")
 	}
 }
 
@@ -45,6 +53,7 @@ func TestGetTracesDescriptionCriticalRules(t *testing.T) {
 		{"groupby", "must document groupby key name"},
 		{"resources['last9.tenant']", "must document tenant scoping"},
 		{"last9://reference/tracejson", "must point at the tracejson resource"},
+		{"60", "must document default lookback of 60 minutes"},
 	}
 	for _, c := range checks {
 		if !strings.Contains(desc, c.phrase) {
@@ -75,16 +84,23 @@ func TestGetServiceLogsDescriptionCriticalRules(t *testing.T) {
 }
 
 func TestWhaleDescriptionsBounded(t *testing.T) {
-	for name, body := range map[string]string{
+	budgets := map[string]int{
+		"get_logs_base":         4500,
+		"get_traces_base":       2200,
+		"get_service_logs_base": 2000,
+	}
+	bodies := map[string]string{
 		"get_logs_base":         prompts.GetLogsDescription,
 		"get_traces_base":       prompts.GetTracesDescription,
 		"get_service_logs_base": prompts.GetServiceLogsDescription,
-	} {
+	}
+	for name, body := range bodies {
 		if len(body) == 0 {
 			t.Errorf("%s empty", name)
 		}
-		if len(body) > 2000 {
-			t.Errorf("%s length %d exceeds 2000-char tripwire", name, len(body))
+		budget := budgets[name]
+		if len(body) > budget {
+			t.Errorf("%s length %d exceeds %d-char budget", name, len(body), budget)
 		}
 	}
 }

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -86,7 +86,7 @@ func TestGetServiceLogsDescriptionCriticalRules(t *testing.T) {
 func TestWhaleDescriptionsBounded(t *testing.T) {
 	budgets := map[string]int{
 		"get_logs_base":         2600,
-		"get_traces_base":       2200,
+		"get_traces_base":       2000,
 		"get_service_logs_base": 2000,
 	}
 	bodies := map[string]string{

--- a/internal/prompts/references/tracejson.md
+++ b/internal/prompts/references/tracejson.md
@@ -35,13 +35,11 @@ These are instructions for constructing natural language trace analytics queries
 5. Translate the query to JSON pipeline format using the correct field references
 6. Call the `get_traces` tool with canonical time params:
    - Use `start_time_iso` + `end_time_iso` when the user gave explicit absolute dates/times
-   - Otherwise use `lookback_minutes` (default: 5 when no time is specified)
+   - Otherwise use `lookback_minutes` (default: 60 when no time is specified)
 7. Analyze the results and provide insights to the user
 
 **CRITICAL TIME PARAMETER RULES:**
-- **ALWAYS use lookback_minutes: 5 when no time range is specified**
-- **NEVER use 60 minutes unless explicitly requested**
-- **Default means 5 minutes, not 60 minutes**
+- **ALWAYS use lookback_minutes: 60 when no time range is specified**
 - **`start_time_iso` and `end_time_iso` are top-level request parameters — NEVER put them inside the pipeline as `Timestamp` filter conditions**
 - When the user gives absolute dates/times → set `start_time_iso` + `end_time_iso` on the tool call, leave the pipeline for data filtering only
 - `{"$gte": ["Timestamp", "..."]}` in the pipeline is WRONG for time range queries — use the request-level params instead
@@ -426,14 +424,13 @@ Note: `ServiceName` is a top-level field — never `resources['service.name']`. 
 ## Default Parameters:
 
 **CRITICAL TIME LOOKBACK RULES:**
-- **DEFAULT IS ALWAYS 5 MINUTES when no time is specified**
-- When the user says "recent" or doesn't specify a time range → **USE 5 MINUTES**
-- For "last hour" or similar → use 60 minutes
+- **DEFAULT IS ALWAYS 60 MINUTES when no time is specified**
+- When the user says "recent" or doesn't specify a time range → **USE 60 MINUTES**
 - For specific timeframes → use the specified duration
 
 **MANDATORY time window parsing:**
-- NO TIME SPECIFIED → **5 minutes (NOT 60!)**
-- "recent", "latest", "current" → **5 minutes**
+- NO TIME SPECIFIED → **60 minutes**
+- "recent", "latest", "current" → **60 minutes**
 
 **ISO TIME FALLBACK RULE:**
 - If you receive a lookback-related validation error,
@@ -444,7 +441,7 @@ Note: `ServiceName` is a top-level field — never `resources['service.name']`. 
 ## Execution Instructions:
 
 When a user asks about traces:
-1. **CRITICAL: When no time is specified, MUST use lookback_minutes: 5 (NOT 60!)**
+1. **CRITICAL: When no time is specified, MUST use lookback_minutes: 60**
 2. **CRITICAL: When using window_aggregate without explicit time range, set lookback_minutes equal to window duration**
 3. **Never return raw JSON** to the user
 4. **Use type specified in the JSON query** (filter, parse, aggregate, window_aggregate), don't use anything else.

--- a/internal/telemetry/logs/attributes_for_pipeline.go
+++ b/internal/telemetry/logs/attributes_for_pipeline.go
@@ -477,6 +477,11 @@ func NewGetLogAttributesForPipelineHandler(client *http.Client, cfg models.Confi
 			return nil, nil, fmt.Errorf("pipeline parameter is required. Provide at least one filter stage to scope discovery, e.g. [{\"type\":\"filter\",\"query\":{\"$eq\":[\"ServiceName\",\"<service>\"]}}]")
 		}
 
+		validatedPipeline, err := prepareLogJSONQuery(args.Pipeline, "pipeline")
+		if err != nil {
+			return nil, nil, err
+		}
+
 		params := make(map[string]interface{})
 		if args.LookbackMinutes > 0 {
 			params["lookback_minutes"] = args.LookbackMinutes
@@ -526,10 +531,10 @@ func NewGetLogAttributesForPipelineHandler(client *http.Client, cfg models.Confi
 		samplingCfg.Region = region
 		bodyCh := make(chan []LogAttribute, 1)
 		go func() {
-			bodyCh <- sampleBodyDerivedAttributes(ctx, client, samplingCfg, args.Pipeline, startTime, endTime, normalizedIndex)
+			bodyCh <- sampleBodyDerivedAttributes(ctx, client, samplingCfg, validatedPipeline, startTime, endTime, normalizedIndex)
 		}()
 
-		names, err := fetchLogSeriesFieldNames(ctx, client, cfg, args.Pipeline, queryParams)
+		names, err := fetchLogSeriesFieldNames(ctx, client, cfg, validatedPipeline, queryParams)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/telemetry/logs/attributes_for_pipeline_test.go
+++ b/internal/telemetry/logs/attributes_for_pipeline_test.go
@@ -748,3 +748,68 @@ func TestGetLogAttributesForPipeline_EmptyData(t *testing.T) {
 		t.Errorf("expected empty attribute list, got: %v", attrs)
 	}
 }
+
+// TestGetLogAttributesForPipeline_InvalidPipelineRejectsBeforeHTTP verifies that
+// invalid pipelines (SpanKind filter, window_minutes WA) are rejected by
+// prepareLogJSONQuery before any HTTP request is made.
+func TestGetLogAttributesForPipeline_InvalidPipelineRejectsBeforeHTTP(t *testing.T) {
+	cases := []struct {
+		name      string
+		pipeline  []map[string]interface{}
+		errSubstr string
+	}{
+		{
+			name: "SpanKind filter",
+			pipeline: []map[string]interface{}{
+				{
+					"type": "filter",
+					"query": map[string]interface{}{
+						"$and": []interface{}{
+							map[string]interface{}{"$eq": []interface{}{"SpanKind", "SPAN_KIND_SERVER"}},
+						},
+					},
+				},
+			},
+			errSubstr: "SpanKind",
+		},
+		{
+			name: "window_minutes on window_aggregate",
+			pipeline: []map[string]interface{}{
+				{
+					"type":           "window_aggregate",
+					"function":       map[string]interface{}{"$count": []interface{}{}},
+					"as":             "errors",
+					"window_minutes": 1,
+				},
+			},
+			errSubstr: "window_minutes",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				http.Error(w, "should not be called", http.StatusBadRequest)
+			}))
+			defer server.Close()
+
+			cfg := testAttrConfig(server.URL)
+			handler := NewGetLogAttributesForPipelineHandler(server.Client(), cfg)
+
+			_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLogAttributesForPipelineArgs{
+				Pipeline: c.pipeline,
+			})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if c.errSubstr != "" && !strings.Contains(err.Error(), c.errSubstr) {
+				t.Errorf("error %q missing expected substring %q", err.Error(), c.errSubstr)
+			}
+			if requestCount != 0 {
+				t.Errorf("expected 0 HTTP requests for invalid pipeline, got %d", requestCount)
+			}
+		})
+	}
+}

--- a/internal/telemetry/logs/chunking_test.go
+++ b/internal/telemetry/logs/chunking_test.go
@@ -200,7 +200,15 @@ func TestGetLogsHandlerDoesNotChunkAggregateQueries(t *testing.T) {
 				"type":  "filter",
 				"query": map[string]interface{}{"$contains": []interface{}{"Body", "error"}},
 			},
-			{"type": "aggregate"},
+			{
+				"type": "aggregate",
+				"aggregates": []interface{}{
+					map[string]interface{}{
+						"function": map[string]interface{}{"$count": []interface{}{}},
+						"as":       "count",
+					},
+				},
+			},
 		},
 		StartTimeISO: "1970-01-01T00:00:00Z",
 		EndTimeISO:   "1970-01-01T01:30:00Z",

--- a/internal/telemetry/logs/input_schema.go
+++ b/internal/telemetry/logs/input_schema.go
@@ -60,7 +60,9 @@ func logFilterStageSchema() map[string]interface{} {
 	return map[string]interface{}{
 		"type":        "object",
 		"description": "Filter stage: narrows the dataset by condition. Always wrap in $and.",
-		"required":    []string{"type", "query"},
+		// Only "type" is schema-required; validateLogJSONQuery owns "query" tips so
+		// {"type":"filter","conditions":{...}} mistakes reach the conditions tip.
+		"required": []string{"type"},
 		"properties": map[string]interface{}{
 			"type": logStringEnum("filter"),
 			"query": map[string]interface{}{
@@ -94,10 +96,11 @@ func logParseStageSchema() map[string]interface{} {
 }
 
 func logAggregateStageSchema() map[string]interface{} {
+	// No required on aggregateFuncSchema; validateLogJSONQuery owns function/as/alias
+	// tips so {"function":{...},"alias":"count"} mistakes reach the alias tip.
 	aggregateFuncSchema := map[string]interface{}{
 		"type":        "object",
 		"description": "Aggregate entry. Use 'aggregates' (plural) and 'as'. Function MUST be an object like {\"$count\": []} — never a string.",
-		"required":    []string{"function", "as"},
 		"properties": map[string]interface{}{
 			"function": map[string]interface{}{
 				"type":        "object",
@@ -113,7 +116,9 @@ func logAggregateStageSchema() map[string]interface{} {
 	return map[string]interface{}{
 		"type":        "object",
 		"description": "Aggregate stage. Use 'aggregates' (NOT 'aggregations') and 'groupby' (NOT 'group_by').",
-		"required":    []string{"type", "aggregates"},
+		// Only "type" is schema-required; validateLogJSONQuery owns "aggregates" tips
+		// so {"type":"aggregate","aggs":[...]} mistakes reach the aggs tip.
+		"required": []string{"type"},
 		"properties": map[string]interface{}{
 			"type": logStringEnum("aggregate"),
 			"aggregates": map[string]interface{}{

--- a/internal/telemetry/logs/input_schema.go
+++ b/internal/telemetry/logs/input_schema.go
@@ -41,6 +41,12 @@ func GetLogsInputSchema() map[string]interface{} {
 	}
 }
 
+// logjsonQuerySchema returns the JSON Schema for the logjson_query array.
+// The anyOf branches are descriptive guidance — they do NOT own rejection.
+// The permissive catch-all at the end ensures that wrong types, unknown enums,
+// and partial stages (e.g. SQL strings as query, type "sort", parser "grok",
+// function as string) pass schema validation and reach validateLogJSONQuery,
+// which returns actionable tip errors instead of opaque anyOf failures.
 func logjsonQuerySchema() map[string]interface{} {
 	return map[string]interface{}{
 		"type":        "array",
@@ -51,6 +57,7 @@ func logjsonQuerySchema() map[string]interface{} {
 				logParseStageSchema(),
 				logAggregateStageSchema(),
 				logWindowAggregateStageSchema(),
+				map[string]interface{}{"type": "object"}, // catch-all: wrong types/enums reach validate tips
 			},
 		},
 	}

--- a/internal/telemetry/logs/input_schema.go
+++ b/internal/telemetry/logs/input_schema.go
@@ -6,8 +6,10 @@ func logStringEnum(values ...string) map[string]interface{} {
 
 // GetLogsInputSchema returns a hand-crafted JSON Schema for the get_logs tool.
 // This replaces the auto-generated schema from GetLogsArgs so that logjson_query
-// items have a detailed oneOf definition — constraining the LLM to use correct
-// stage shapes and preventing wrong-key mistakes (window_minutes, format, etc.).
+// items have a detailed anyOf definition guiding stage shapes. Schema stays
+// deliberately loose on stage required/additionalProperties so wrong-key
+// mistakes (window_minutes, format, …) reach validateLogJSONQuery tip errors
+// instead of an opaque anyOf failure from the SDK.
 func GetLogsInputSchema() map[string]interface{} {
 	return map[string]interface{}{
 		"type": "object",
@@ -34,7 +36,7 @@ func GetLogsInputSchema() map[string]interface{} {
 				"description": "Optional log index in the form physical_index:<name> or rehydration_index:<block_name>. Omit when the user did not specify an index.",
 			},
 		},
-		"required":              []string{"logjson_query"},
+		"required":             []string{"logjson_query"},
 		"additionalProperties": false,
 	}
 }
@@ -44,7 +46,7 @@ func logjsonQuerySchema() map[string]interface{} {
 		"type":        "array",
 		"description": "JSON pipeline query for logs. An ordered list of stages: filter → parse → aggregate/window_aggregate. NOT SQL, NOT a query string. Each stage is an object with a 'type' field.",
 		"items": map[string]interface{}{
-			"oneOf": []interface{}{
+			"anyOf": []interface{}{
 				logFilterStageSchema(),
 				logParseStageSchema(),
 				logAggregateStageSchema(),
@@ -78,15 +80,16 @@ func logParseStageSchema() map[string]interface{} {
 	return map[string]interface{}{
 		"type":        "object",
 		"description": "Parse stage: extracts fields from Body using json, logfmt, or regexp parsers. Never use 'format' — key is 'parser'.",
-		"required":    []string{"type", "parser"},
+		// Only "type" is schema-required; validateLogJSONQuery owns "parser" so a
+		// {"type":"parse","format":"json"} mistake reaches the format tip.
+		"required": []string{"type"},
 		"properties": map[string]interface{}{
 			"type":    logStringEnum("parse"),
 			"parser":  logStringEnum("json", "logfmt", "regexp"),
-			"field":   map[string]interface{}{"type": "string", "description": "Field to parse (typically Body)."},
+			"field":   map[string]interface{}{"type": "string", "description": "Field to parse (typically Body). Defaults to Body when omitted."},
 			"pattern": map[string]interface{}{"type": "string", "description": "Regexp pattern with named capture groups (regexp parser only)."},
 			"labels":  map[string]interface{}{"type": "object", "description": "Field mappings for json/logfmt parsing."},
 		},
-		"additionalProperties": false,
 	}
 }
 
@@ -105,7 +108,6 @@ func logAggregateStageSchema() map[string]interface{} {
 				"description": "Output field name. Use 'as', NOT 'alias'.",
 			},
 		},
-		"additionalProperties": false,
 	}
 
 	return map[string]interface{}{
@@ -123,7 +125,6 @@ func logAggregateStageSchema() map[string]interface{} {
 				"description": "Group-by fields as {\"FieldName\": \"alias\"}.",
 			},
 		},
-		"additionalProperties": false,
 	}
 }
 
@@ -131,7 +132,9 @@ func logWindowAggregateStageSchema() map[string]interface{} {
 	return map[string]interface{}{
 		"type":        "object",
 		"description": "Window aggregate stage: time-bucketed counts/trends. CRITICAL: use 'function'+'as'+'window' — NOT 'aggregates', NOT 'window_minutes', NOT 'TimeBucket'.",
-		"required":    []string{"type", "function", "as", "window"},
+		// Only "type" is schema-required; validateLogJSONQuery owns function/as/window
+		// so {"type":"window_aggregate","window_minutes":1,...} reaches the tip.
+		"required": []string{"type"},
 		"properties": map[string]interface{}{
 			"type": logStringEnum("window_aggregate"),
 			"function": map[string]interface{}{
@@ -151,6 +154,5 @@ func logWindowAggregateStageSchema() map[string]interface{} {
 				"description": "Optional group-by fields as {\"FieldName\": \"alias\"}.",
 			},
 		},
-		"additionalProperties": false,
 	}
 }

--- a/internal/telemetry/logs/input_schema.go
+++ b/internal/telemetry/logs/input_schema.go
@@ -1,0 +1,156 @@
+package logs
+
+func logStringEnum(values ...string) map[string]interface{} {
+	return map[string]interface{}{"type": "string", "enum": values}
+}
+
+// GetLogsInputSchema returns a hand-crafted JSON Schema for the get_logs tool.
+// This replaces the auto-generated schema from GetLogsArgs so that logjson_query
+// items have a detailed oneOf definition — constraining the LLM to use correct
+// stage shapes and preventing wrong-key mistakes (window_minutes, format, etc.).
+func GetLogsInputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"logjson_query": logjsonQuerySchema(),
+			"start_time_iso": map[string]interface{}{
+				"type":        []string{"string", "null"},
+				"description": "Start time in RFC3339/ISO8601 format (e.g. 2026-02-09T15:04:05Z). Use with end_time_iso for absolute windows.",
+			},
+			"end_time_iso": map[string]interface{}{
+				"type":        []string{"string", "null"},
+				"description": "End time in RFC3339/ISO8601 format (e.g. 2026-02-09T16:04:05Z). Defaults to current time.",
+			},
+			"lookback_minutes": map[string]interface{}{
+				"type":        []string{"integer", "null"},
+				"description": "Number of minutes to look back from now (default: 5, minimum: 1). Use for relative windows.",
+			},
+			"limit": map[string]interface{}{
+				"type":        []string{"integer", "null"},
+				"description": "Maximum number of rows to return (optional, default: 5000 for chunked raw queries).",
+			},
+			"index": map[string]interface{}{
+				"type":        []string{"string", "null"},
+				"description": "Optional log index in the form physical_index:<name> or rehydration_index:<block_name>. Omit when the user did not specify an index.",
+			},
+		},
+		"required":              []string{"logjson_query"},
+		"additionalProperties": false,
+	}
+}
+
+func logjsonQuerySchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type":        "array",
+		"description": "JSON pipeline query for logs. An ordered list of stages: filter → parse → aggregate/window_aggregate. NOT SQL, NOT a query string. Each stage is an object with a 'type' field.",
+		"items": map[string]interface{}{
+			"oneOf": []interface{}{
+				logFilterStageSchema(),
+				logParseStageSchema(),
+				logAggregateStageSchema(),
+				logWindowAggregateStageSchema(),
+			},
+		},
+	}
+}
+
+func logFilterStageSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type":        "object",
+		"description": "Filter stage: narrows the dataset by condition. Always wrap in $and.",
+		"required":    []string{"type", "query"},
+		"properties": map[string]interface{}{
+			"type": logStringEnum("filter"),
+			"query": map[string]interface{}{
+				"type": "object",
+				"description": "Condition object. " +
+					"Logical: $and, $or, $not. " +
+					"Equality: $eq, $neq, $ieq (case-insensitive eq). " +
+					"Numeric: $gt, $lt, $gte, $lte. " +
+					"String: $contains, $containsWords, $notcontains, $icontains, $regex. " +
+					"Example: {\"$and\": [{\"$eq\": [\"SeverityText\", \"ERROR\"]}, {\"$eq\": [\"ServiceName\", \"api\"]}]}",
+			},
+		},
+	}
+}
+
+func logParseStageSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type":        "object",
+		"description": "Parse stage: extracts fields from Body using json, logfmt, or regexp parsers. Never use 'format' — key is 'parser'.",
+		"required":    []string{"type", "parser"},
+		"properties": map[string]interface{}{
+			"type":    logStringEnum("parse"),
+			"parser":  logStringEnum("json", "logfmt", "regexp"),
+			"field":   map[string]interface{}{"type": "string", "description": "Field to parse (typically Body)."},
+			"pattern": map[string]interface{}{"type": "string", "description": "Regexp pattern with named capture groups (regexp parser only)."},
+			"labels":  map[string]interface{}{"type": "object", "description": "Field mappings for json/logfmt parsing."},
+		},
+		"additionalProperties": false,
+	}
+}
+
+func logAggregateStageSchema() map[string]interface{} {
+	aggregateFuncSchema := map[string]interface{}{
+		"type":        "object",
+		"description": "Aggregate entry. Use 'aggregates' (plural) and 'as'. Function MUST be an object like {\"$count\": []} — never a string.",
+		"required":    []string{"function", "as"},
+		"properties": map[string]interface{}{
+			"function": map[string]interface{}{
+				"type":        "object",
+				"description": "Aggregation function as an object. Examples: {\"$count\": []}, {\"$avg\": [\"field\"]}, {\"$max\": [\"field\"]}.",
+			},
+			"as": map[string]interface{}{
+				"type":        "string",
+				"description": "Output field name. Use 'as', NOT 'alias'.",
+			},
+		},
+		"additionalProperties": false,
+	}
+
+	return map[string]interface{}{
+		"type":        "object",
+		"description": "Aggregate stage. Use 'aggregates' (NOT 'aggregations') and 'groupby' (NOT 'group_by').",
+		"required":    []string{"type", "aggregates"},
+		"properties": map[string]interface{}{
+			"type": logStringEnum("aggregate"),
+			"aggregates": map[string]interface{}{
+				"type":  "array",
+				"items": aggregateFuncSchema,
+			},
+			"groupby": map[string]interface{}{
+				"type":        "object",
+				"description": "Group-by fields as {\"FieldName\": \"alias\"}.",
+			},
+		},
+		"additionalProperties": false,
+	}
+}
+
+func logWindowAggregateStageSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type":        "object",
+		"description": "Window aggregate stage: time-bucketed counts/trends. CRITICAL: use 'function'+'as'+'window' — NOT 'aggregates', NOT 'window_minutes', NOT 'TimeBucket'.",
+		"required":    []string{"type", "function", "as", "window"},
+		"properties": map[string]interface{}{
+			"type": logStringEnum("window_aggregate"),
+			"function": map[string]interface{}{
+				"type":        "object",
+				"description": "Aggregation function object. Example: {\"$count\": []}",
+			},
+			"as": map[string]interface{}{
+				"type":        "string",
+				"description": "Output field name for the window result.",
+			},
+			"window": map[string]interface{}{
+				"type":        "array",
+				"description": "Window duration as [\"duration\", \"unit\"]. Units: minutes, seconds, hours. Example: [\"1\", \"minutes\"]",
+			},
+			"groupby": map[string]interface{}{
+				"type":        "object",
+				"description": "Optional group-by fields as {\"FieldName\": \"alias\"}.",
+			},
+		},
+		"additionalProperties": false,
+	}
+}

--- a/internal/telemetry/logs/logs.go
+++ b/internal/telemetry/logs/logs.go
@@ -38,10 +38,10 @@ func NewGetLogsHandler(client *http.Client, cfg models.Config) func(context.Cont
 	return func(ctx context.Context, req *mcp.CallToolRequest, args GetLogsArgs) (*mcp.CallToolResult, any, error) {
 		// Check if logjson_query is provided
 		if len(args.LogjsonQuery) == 0 {
-			return nil, nil, fmt.Errorf("logjson_query parameter is required. Use the logjson_query_builder prompt to generate JSON pipeline queries from natural language")
+			return nil, nil, fmt.Errorf("logjson_query parameter is required. logjson_query is a JSON array of stages (filter/parse/aggregate/window_aggregate) — see last9://reference/logjson")
 		}
 
-		sanitizedQuery, err := sanitizeLogJSONQuery(args.LogjsonQuery)
+		sanitizedQuery, err := prepareLogJSONQuery(args.LogjsonQuery, "logjson_query")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/telemetry/logs/query_sanitize.go
+++ b/internal/telemetry/logs/query_sanitize.go
@@ -9,33 +9,33 @@ import (
 )
 
 var (
-	logAttributeFieldRefPattern  = regexp.MustCompile(`^attributes\['[^'\[\]]+'\]$`)
-	logResourceFieldRefPattern   = regexp.MustCompile(`^resources\['[^'\[\]]+'\]$`)
-	logKubernetesAliasPattern    = regexp.MustCompile(`^k8s(?:\.[A-Za-z0-9_/-]+)+$`)
-	logSimpleFieldRefPattern     = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+	logAttributeFieldRefPattern = regexp.MustCompile(`^attributes\['[^'\[\]]+'\]$`)
+	logResourceFieldRefPattern  = regexp.MustCompile(`^resources\['[^'\[\]]+'\]$`)
+	logKubernetesAliasPattern   = regexp.MustCompile(`^k8s(?:\.[A-Za-z0-9_/-]+)+$`)
+	logSimpleFieldRefPattern    = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 )
 
 var logFilterFieldOperators = map[string]int{
-	"$contains":        0,
-	"$containsWords":   0,
-	"$eq":              0,
-	"$gt":              0,
-	"$gte":             0,
-	"$icontains":       0,
-	"$icontainsWords":  0,
-	"$ieq":             0,
-	"$ineq":            0,
-	"$inotcontains":    0,
+	"$contains":          0,
+	"$containsWords":     0,
+	"$eq":                0,
+	"$gt":                0,
+	"$gte":               0,
+	"$icontains":         0,
+	"$icontainsWords":    0,
+	"$ieq":               0,
+	"$ineq":              0,
+	"$inotcontains":      0,
 	"$inotcontainsWords": 0,
-	"$inotregex":       0,
-	"$iregex":          0,
-	"$lt":              0,
-	"$lte":             0,
-	"$neq":             0,
-	"$notcontains":     0,
-	"$notcontainsWords": 0,
-	"$notregex":        0,
-	"$regex":           0,
+	"$inotregex":         0,
+	"$iregex":            0,
+	"$lt":                0,
+	"$lte":               0,
+	"$neq":               0,
+	"$notcontains":       0,
+	"$notcontainsWords":  0,
+	"$notregex":          0,
+	"$regex":             0,
 }
 
 var logFilterLogicalOperators = map[string]struct{}{
@@ -123,11 +123,14 @@ func sanitizeLogCondition(value interface{}, path string) (interface{}, error) {
 			}
 
 			if _, isLogicalOperator := logFilterLogicalOperators[key]; !isLogicalOperator {
-				return nil, fmt.Errorf(
-					"invalid filter condition key %q at %s: keys must be operators ($eq, $neq, $ieq, $ineq, $gt, $gte, $lt, $lte, $contains, $notcontains, $icontains, $inotcontains, $containsWords, $notcontainsWords, $icontainsWords, $inotcontainsWords, $regex, $notregex, $iregex, $inotregex) or logical operators ($and, $or, $not); use the form {%q: [field, value]} — for example {\"$eq\": [\"ServiceName\", \"checkout\"]} — and call get_log_attributes if you need the exact field name",
-					key,
+				return nil, newLogValidationError(
+					LogValidationInvalidField,
 					path,
-					"$eq",
+					fmt.Sprintf(
+						"invalid filter condition key %q at %s: keys must be operators ($eq, $neq, $ieq, $ineq, $gt, $gte, $lt, $lte, $contains, $notcontains, $icontains, $inotcontains, $containsWords, $notcontainsWords, $icontainsWords, $inotcontainsWords, $regex, $notregex, $iregex, $inotregex) or logical operators ($and, $or, $not); use the form {\"$eq\": [field, value]} — for example {\"$eq\": [\"ServiceName\", \"checkout\"]} — and call get_log_attributes if you need the exact field name",
+						key,
+						path,
+					),
 				)
 			}
 
@@ -146,10 +149,14 @@ func sanitizeLogCondition(value interface{}, path string) (interface{}, error) {
 func sanitizeLogFieldOperatorArgs(value interface{}, fieldArgIndex int, path string) (interface{}, error) {
 	args, ok := value.([]interface{})
 	if !ok {
-		return nil, fmt.Errorf(
-			"invalid arguments for field operator at %s: expected an array like [field, value], got %T — use the form {\"$eq\": [\"ServiceName\", \"checkout\"]}",
+		return nil, newLogValidationError(
+			LogValidationInvalidField,
 			path,
-			value,
+			fmt.Sprintf(
+				"invalid arguments for field operator at %s: expected an array like [field, value], got %T — use the form {\"$eq\": [\"ServiceName\", \"checkout\"]}",
+				path,
+				value,
+			),
 		)
 	}
 
@@ -211,9 +218,13 @@ func coerceLogFilterValueToString(value interface{}, path string) (string, error
 	case nil:
 		return "", nil
 	default:
-		return "", fmt.Errorf(
-			"invalid filter value at %s: expected a string (got %T %#v) — use {\"$eq\":[\"attributes['status_code']\",\"500\"]} with a string value",
-			path, value, value,
+		return "", newLogValidationError(
+			LogValidationInvalidField,
+			path,
+			fmt.Sprintf(
+				"invalid filter value at %s: expected a string (got %T %#v) — use {\"$eq\":[\"attributes['status_code']\",\"500\"]} with a string value",
+				path, value, value,
+			),
 		)
 	}
 }
@@ -303,12 +314,16 @@ func sanitizeLogGroupBy(value interface{}, path string) (interface{}, error) {
 		}
 
 		if previous, exists := originalBySanitized[next]; exists {
-			return nil, fmt.Errorf(
-				"groupby collision at %s: %q and %q both normalize to %q",
+			return nil, newLogValidationError(
+				LogValidationInvalidField,
 				path,
-				previous,
-				fieldRef,
-				next,
+				fmt.Sprintf(
+					"groupby collision at %s: %q and %q both normalize to %q",
+					path,
+					previous,
+					fieldRef,
+					next,
+				),
 			)
 		}
 
@@ -330,45 +345,66 @@ func sanitizeLogFieldRef(fieldRef, path string) (string, error) {
 		return "ServiceName", nil
 	case strings.HasPrefix(trimmed, `attributes["`) || strings.HasPrefix(trimmed, `resources["`):
 		corrected := strings.ReplaceAll(trimmed, `"`, "'")
-		return "", fmt.Errorf(
-			"invalid log field reference %q at %s: use single quotes — %q; call get_log_attributes if you need the exact field name",
-			trimmed, path, corrected,
+		return "", newLogValidationError(
+			LogValidationInvalidField,
+			path,
+			fmt.Sprintf(
+				"invalid log field reference %q at %s: use single quotes — %q; call get_log_attributes if you need the exact field name",
+				trimmed, path, corrected,
+			),
 		)
 	case logKubernetesAliasPattern.MatchString(trimmed):
 		return fmt.Sprintf("resources['%s']", trimmed), nil
 	case isCanonicalLogFieldRef(trimmed):
 		return trimmed, nil
 	case isTraceOnlyLogField(trimmed):
-		return "", fmt.Errorf(
-			"invalid log field reference %q at %s: %q is a trace-only field and is not valid in logs — use ServiceName, SeverityText, Body, attributes['…'], or resources['…']; call get_log_attributes if you need the exact field name",
-			trimmed, path, trimmed,
+		return "", newLogValidationError(
+			LogValidationWrongDomainField,
+			path,
+			fmt.Sprintf(
+				"invalid log field reference %q at %s: %q is a trace-only field and is not valid in logs — use ServiceName, SeverityText, Body, attributes['…'], or resources['…']; call get_log_attributes if you need the exact field name",
+				trimmed, path, trimmed,
+			),
 		)
 	case strings.HasPrefix(trimmed, "resource_"):
 		stripped := trimmed[len("resource_"):]
-		return "", fmt.Errorf(
-			"invalid log field reference %q at %s: use resources['%s'] instead of the flat resource_ prefix; call get_log_attributes if you need the exact field name",
-			trimmed, path, stripped,
+		return "", newLogValidationError(
+			LogValidationInvalidField,
+			path,
+			fmt.Sprintf(
+				"invalid log field reference %q at %s: use resources['%s'] instead of the flat resource_ prefix; call get_log_attributes if you need the exact field name",
+				trimmed, path, stripped,
+			),
 		)
 	case logSimpleFieldRefPattern.MatchString(trimmed):
 		// Bare single-token names (e.g. community_member_id) look plausible but
 		// are invalid unless they are a known top-level log field. Fail closed with
 		// the attributes['…'] form so models can self-correct (ENG-1410).
-		return "", fmt.Errorf(
-			"invalid log field reference %q at %s: never emit bare field names (dotted or single-token) — use attributes['%s'] or resources['%s']; only ServiceName, Body, SeverityText, Timestamp may be bare; call get_log_attributes if you need the exact field name",
-			trimmed, path, trimmed, trimmed,
+		return "", newLogValidationError(
+			LogValidationInvalidField,
+			path,
+			fmt.Sprintf(
+				"invalid log field reference %q at %s: never emit bare field names (dotted or single-token) — use attributes['%s'] or resources['%s']; only ServiceName, Body, SeverityText, Timestamp may be bare; call get_log_attributes if you need the exact field name",
+				trimmed, path, trimmed, trimmed,
+			),
 		)
 	default:
-		return "", fmt.Errorf(
-			"invalid log field reference %q at %s: use ServiceName, attributes['field'], or resources['field']; call get_log_attributes if you need the exact field name",
-			trimmed,
+		return "", newLogValidationError(
+			LogValidationInvalidField,
 			path,
+			fmt.Sprintf(
+				"invalid log field reference %q at %s: use ServiceName, attributes['field'], or resources['field']; call get_log_attributes if you need the exact field name",
+				trimmed,
+				path,
+			),
 		)
 	}
 }
 
 func isCanonicalLogFieldRef(fieldRef string) bool {
 	switch fieldRef {
-	case "Body", "ServiceName", "SeverityText", "Timestamp":
+	case "Body", "ServiceName", "SeverityText", "Timestamp",
+		"TraceId", "SpanId", "ParentSpanId":
 		return true
 	}
 

--- a/internal/telemetry/logs/query_sanitize.go
+++ b/internal/telemetry/logs/query_sanitize.go
@@ -51,11 +51,18 @@ var logAggregateFieldArgIndexes = map[string][]int{
 }
 
 func sanitizeLogJSONQuery(stages []map[string]interface{}) ([]map[string]interface{}, error) {
+	return sanitizeLogJSONQueryPrefixed(stages, "logjson_query")
+}
+
+func sanitizeLogJSONQueryPrefixed(stages []map[string]interface{}, pathPrefix string) ([]map[string]interface{}, error) {
+	if pathPrefix == "" {
+		pathPrefix = "logjson_query"
+	}
 	sanitized := make([]map[string]interface{}, 0, len(stages))
 
 	for stageIndex, stage := range stages {
 		sanitizedStage := make(map[string]interface{}, len(stage))
-		stagePath := fmt.Sprintf("logjson_query[%d]", stageIndex)
+		stagePath := fmt.Sprintf("%s[%d]", pathPrefix, stageIndex)
 
 		for key, value := range stage {
 			var (
@@ -289,7 +296,13 @@ func sanitizeLogFieldRef(fieldRef, path string) (string, error) {
 			trimmed, path, stripped,
 		)
 	case logSimpleFieldRefPattern.MatchString(trimmed):
-		return trimmed, nil
+		// Bare single-token names (e.g. community_member_id) look plausible but
+		// are invalid unless they are a known top-level log field. Fail closed with
+		// the attributes['…'] form so models can self-correct (ENG-1410).
+		return "", fmt.Errorf(
+			"invalid log field reference %q at %s: never emit bare field names (dotted or single-token) — use attributes['%s'] or resources['%s']; only ServiceName, Body, SeverityText, Timestamp may be bare; call get_log_attributes if you need the exact field name",
+			trimmed, path, trimmed, trimmed,
+		)
 	default:
 		return "", fmt.Errorf(
 			"invalid log field reference %q at %s: use ServiceName, attributes['field'], or resources['field']; call get_log_attributes if you need the exact field name",

--- a/internal/telemetry/logs/query_sanitize.go
+++ b/internal/telemetry/logs/query_sanitize.go
@@ -91,6 +91,14 @@ func sanitizeLogJSONQueryPrefixed(stages []map[string]interface{}, pathPrefix st
 			sanitizedStage[key] = sanitizedValue
 		}
 
+		// Default missing or blank parse "field" to "Body" on the rebuilt copy so
+		// the API always receives a value without mutating the caller's original map.
+		if stageType, _ := sanitizedStage["type"].(string); stageType == "parse" {
+			if field, _ := sanitizedStage["field"].(string); strings.TrimSpace(field) == "" {
+				sanitizedStage["field"] = "Body"
+			}
+		}
+
 		sanitized = append(sanitized, sanitizedStage)
 	}
 

--- a/internal/telemetry/logs/query_sanitize.go
+++ b/internal/telemetry/logs/query_sanitize.go
@@ -1,8 +1,10 @@
 package logs
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -166,7 +168,54 @@ func sanitizeLogFieldOperatorArgs(value interface{}, fieldArgIndex int, path str
 		return nil, err
 	}
 	sanitized[fieldArgIndex] = next
+
+	// last9/api logjson requires comparison values as strings. JSON numbers/bools
+	// from model tool calls (e.g. 500 instead of "500") produce opaque
+	// "invalid JSON pipeline" 400s — coerce in place.
+	valueIndex := fieldArgIndex + 1
+	if valueIndex < len(sanitized) {
+		coerced, err := coerceLogFilterValueToString(sanitized[valueIndex], fmt.Sprintf("%s[%d]", path, valueIndex))
+		if err != nil {
+			return nil, err
+		}
+		sanitized[valueIndex] = coerced
+	}
 	return sanitized, nil
+}
+
+func coerceLogFilterValueToString(value interface{}, path string) (string, error) {
+	switch typed := value.(type) {
+	case string:
+		return typed, nil
+	case float64:
+		if typed == float64(int64(typed)) {
+			return strconv.FormatInt(int64(typed), 10), nil
+		}
+		return strconv.FormatFloat(typed, 'g', -1, 64), nil
+	case float32:
+		f := float64(typed)
+		if f == float64(int64(f)) {
+			return strconv.FormatInt(int64(f), 10), nil
+		}
+		return strconv.FormatFloat(f, 'g', -1, 32), nil
+	case int:
+		return strconv.Itoa(typed), nil
+	case int64:
+		return strconv.FormatInt(typed, 10), nil
+	case int32:
+		return strconv.FormatInt(int64(typed), 10), nil
+	case json.Number:
+		return typed.String(), nil
+	case bool:
+		return strconv.FormatBool(typed), nil
+	case nil:
+		return "", nil
+	default:
+		return "", fmt.Errorf(
+			"invalid filter value at %s: expected a string (got %T %#v) — use {\"$eq\":[\"attributes['status_code']\",\"500\"]} with a string value",
+			path, value, value,
+		)
+	}
 }
 
 func sanitizeLogAggregates(value interface{}, path string) (interface{}, error) {
@@ -289,6 +338,11 @@ func sanitizeLogFieldRef(fieldRef, path string) (string, error) {
 		return fmt.Sprintf("resources['%s']", trimmed), nil
 	case isCanonicalLogFieldRef(trimmed):
 		return trimmed, nil
+	case isTraceOnlyLogField(trimmed):
+		return "", fmt.Errorf(
+			"invalid log field reference %q at %s: %q is a trace-only field and is not valid in logs — use ServiceName, SeverityText, Body, attributes['…'], or resources['…']; call get_log_attributes if you need the exact field name",
+			trimmed, path, trimmed,
+		)
 	case strings.HasPrefix(trimmed, "resource_"):
 		stripped := trimmed[len("resource_"):]
 		return "", fmt.Errorf(
@@ -320,4 +374,9 @@ func isCanonicalLogFieldRef(fieldRef string) bool {
 
 	return logAttributeFieldRefPattern.MatchString(fieldRef) ||
 		logResourceFieldRefPattern.MatchString(fieldRef)
+}
+
+func isTraceOnlyLogField(fieldRef string) bool {
+	_, ok := traceOnlyLogFields[fieldRef]
+	return ok
 }

--- a/internal/telemetry/logs/query_sanitize_test.go
+++ b/internal/telemetry/logs/query_sanitize_test.go
@@ -1037,6 +1037,142 @@ func TestPrepareLogJSONQueryRejectsBareSingleTokenField(t *testing.T) {
 	}
 }
 
+func TestPrepareLogJSONQueryRequiresParseField(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{"type": "parse", "parser": "json"},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected missing field rejection")
+	}
+	if !strings.Contains(err.Error(), "field") {
+		t.Errorf("error should mention field, got: %q", err.Error())
+	}
+}
+
+func TestPrepareLogJSONQueryRejectsBadRegexpNamedCapture(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type":    "parse",
+			"parser":  "regexp",
+			"field":   "Body",
+			"pattern": `merchant_name (?P<$merchant>\S+)`,
+			"labels":  map[string]interface{}{"merchant": "Body"},
+		},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected bad named capture rejection")
+	}
+	if !strings.Contains(err.Error(), "$merchant") && !strings.Contains(err.Error(), "named capture") {
+		t.Errorf("error should mention invalid named capture, got: %q", err.Error())
+	}
+}
+
+func TestPrepareLogJSONQueryRejectsDollarLabelKey(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type":   "parse",
+			"parser": "json",
+			"field":  "Body",
+			"labels": map[string]interface{}{"$merchant": "merchant"},
+		},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected invalid labels key rejection")
+	}
+	if !strings.Contains(err.Error(), "$merchant") {
+		t.Errorf("error should mention $merchant, got: %q", err.Error())
+	}
+}
+
+func TestPrepareLogJSONQueryRejectsSpanNameGroupBy(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type": "aggregate",
+			"aggregates": []interface{}{
+				map[string]interface{}{
+					"function": map[string]interface{}{"$count": []interface{}{}},
+					"as":       "error_count",
+				},
+			},
+			"groupby": map[string]interface{}{"SpanName": "span_name"},
+		},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected SpanName groupby rejection")
+	}
+	if !strings.Contains(err.Error(), "SpanName") {
+		t.Errorf("error should mention SpanName, got: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "trace-only") {
+		t.Errorf("error should say trace-only, got: %q", err.Error())
+	}
+}
+
+func TestPrepareLogJSONQueryCoercesNumericFilterValues(t *testing.T) {
+	result, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type": "filter",
+			"query": map[string]interface{}{
+				"$and": []interface{}{
+					map[string]interface{}{"$eq": []interface{}{"attributes['status_code']", float64(500)}},
+				},
+			},
+		},
+	}, "logjson_query")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	query := result[0]["query"].(map[string]interface{})
+	andConditions := query["$and"].([]interface{})
+	eqArgs := andConditions[0].(map[string]interface{})["$eq"].([]interface{})
+	if got, ok := eqArgs[1].(string); !ok || got != "500" {
+		t.Fatalf("expected numeric 500 coerced to string \"500\", got %#v", eqArgs[1])
+	}
+}
+
+func TestPrepareLogJSONQueryAcceptsCanonicalParseThenFilter(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type": "filter",
+			"query": map[string]interface{}{
+				"$and": []interface{}{
+					map[string]interface{}{"$eq": []interface{}{"ServiceName", "orders-api"}},
+				},
+			},
+		},
+		{
+			"type":   "parse",
+			"parser": "json",
+			"field":  "Body",
+			"labels": map[string]interface{}{
+				"status_code": "status_code",
+				"uri":         "uri",
+			},
+		},
+		{
+			"type": "filter",
+			"query": map[string]interface{}{
+				"$and": []interface{}{
+					map[string]interface{}{"$eq": []interface{}{"attributes['status_code']", float64(500)}},
+				},
+			},
+		},
+		{
+			"type": "aggregate",
+			"aggregates": []interface{}{
+				map[string]interface{}{
+					"function": map[string]interface{}{"$count": []interface{}{}},
+					"as":       "_count",
+				},
+			},
+			"groupby": map[string]interface{}{"attributes['uri']": "uri"},
+		},
+	}, "logjson_query")
+	if err != nil {
+		t.Fatalf("canonical parse+filter+aggregate pipeline should pass after coerce+field require, got: %v", err)
+	}
+}
+
 func TestPrepareLogJSONQueryTypedValidationError(t *testing.T) {
 	_, err := prepareLogJSONQuery([]map[string]interface{}{
 		{

--- a/internal/telemetry/logs/query_sanitize_test.go
+++ b/internal/telemetry/logs/query_sanitize_test.go
@@ -1037,15 +1037,15 @@ func TestPrepareLogJSONQueryRejectsBareSingleTokenField(t *testing.T) {
 	}
 }
 
-func TestPrepareLogJSONQueryRequiresParseField(t *testing.T) {
-	_, err := prepareLogJSONQuery([]map[string]interface{}{
+func TestPrepareLogJSONQueryDefaultsMissingParseField(t *testing.T) {
+	result, err := prepareLogJSONQuery([]map[string]interface{}{
 		{"type": "parse", "parser": "json"},
 	}, "logjson_query")
-	if err == nil {
-		t.Fatal("expected missing field rejection")
+	if err != nil {
+		t.Fatalf("missing parse field should default to Body, got error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "field") {
-		t.Errorf("error should mention field, got: %q", err.Error())
+	if result[0]["field"] != "Body" {
+		t.Errorf("expected field to default to Body, got %v", result[0]["field"])
 	}
 }
 
@@ -1220,5 +1220,78 @@ func TestPrepareLogJSONQueryTypedWrongDomainField(t *testing.T) {
 	}
 	if typed.Category != LogValidationWrongDomainField {
 		t.Errorf("category=%q, want %q", typed.Category, LogValidationWrongDomainField)
+	}
+}
+
+// TestPrepareLogJSONQueryAcceptsTraceIdFilter verifies that TraceId, SpanId, and
+// ParentSpanId are accepted as log field references for log↔trace correlation.
+func TestPrepareLogJSONQueryAcceptsTraceIdFilter(t *testing.T) {
+	for _, field := range []string{"TraceId", "SpanId", "ParentSpanId"} {
+		t.Run(field, func(t *testing.T) {
+			_, err := prepareLogJSONQuery([]map[string]interface{}{
+				{
+					"type": "filter",
+					"query": map[string]interface{}{
+						"$and": []interface{}{
+							map[string]interface{}{"$neq": []interface{}{field, ""}},
+						},
+					},
+				},
+				{
+					"type": "aggregate",
+					"aggregates": []interface{}{
+						map[string]interface{}{
+							"function": map[string]interface{}{"$count": []interface{}{}},
+							"as":       "log_count",
+						},
+					},
+				},
+			}, "logjson_query")
+			if err != nil {
+				t.Fatalf("%s filter should be accepted for log-trace correlation, got: %v", field, err)
+			}
+		})
+	}
+}
+
+// TestPrepareLogJSONQueryAcceptsDottedParseLabelKey verifies that dotted label
+// keys like http.status_code are accepted in parse stage labels (safeBodyKeyPattern).
+func TestPrepareLogJSONQueryAcceptsDottedParseLabelKey(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type":   "parse",
+			"parser": "json",
+			"field":  "Body",
+			"labels": map[string]interface{}{"http.status_code": "status_code"},
+		},
+	}, "logjson_query")
+	if err != nil {
+		t.Fatalf("dotted label key http.status_code should be accepted, got: %v", err)
+	}
+}
+
+// TestPrepareLogJSONQueryRoundTripBodyDerivedHint verifies that the two-stage
+// pipeline shape emitted by bodyDerivedHint (parse json + filter on derived attr)
+// passes prepareLogJSONQuery without error when a dotted key is used.
+func TestPrepareLogJSONQueryRoundTripBodyDerivedHint(t *testing.T) {
+	stages := []map[string]interface{}{
+		{
+			"type":   "parse",
+			"parser": "json",
+			"field":  "Body",
+			"labels": map[string]interface{}{"http.status_code": "http.status_code"},
+		},
+		{
+			"type": "filter",
+			"query": map[string]interface{}{
+				"$and": []interface{}{
+					map[string]interface{}{"$eq": []interface{}{"attributes['http.status_code']", "500"}},
+				},
+			},
+		},
+	}
+	_, err := prepareLogJSONQuery(stages, "logjson_query")
+	if err != nil {
+		t.Fatalf("body-derived hint round-trip should pass: %v", err)
 	}
 }

--- a/internal/telemetry/logs/query_sanitize_test.go
+++ b/internal/telemetry/logs/query_sanitize_test.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -756,5 +757,332 @@ func TestGetLogsHandlerRejectsUnsupportedDottedRefsBeforeAPICall(t *testing.T) {
 	}
 	if requestCount != 0 {
 		t.Fatalf("expected no API requests for invalid field refs, got %d", requestCount)
+	}
+}
+
+// TestPrepareLogJSONQueryValidation covers the fail-closed validation rules
+// introduced by prepareLogJSONQuery / validateLogJSONQuery.
+func TestPrepareLogJSONQueryValidation(t *testing.T) {
+	type tc struct {
+		name      string
+		stages    []map[string]interface{}
+		wantErr   bool
+		errSubstr string
+	}
+
+	cases := []tc{
+		{
+			name: "canonical window_aggregate accepted",
+			stages: []map[string]interface{}{
+				{
+					"type":  "filter",
+					"query": map[string]interface{}{"$and": []interface{}{map[string]interface{}{"$eq": []interface{}{"SeverityText", "ERROR"}}}},
+				},
+				{
+					"type":     "window_aggregate",
+					"function": map[string]interface{}{"$count": []interface{}{}},
+					"as":       "errors",
+					"window":   []interface{}{"1", "minutes"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "window_minutes on window_aggregate rejected",
+			stages: []map[string]interface{}{
+				{
+					"type":           "window_aggregate",
+					"function":       map[string]interface{}{"$count": []interface{}{}},
+					"as":             "errors",
+					"window_minutes": 1,
+				},
+			},
+			wantErr:   true,
+			errSubstr: "window_minutes",
+		},
+		{
+			name: "aggregates on window_aggregate rejected",
+			stages: []map[string]interface{}{
+				{
+					"type": "window_aggregate",
+					"aggregates": []interface{}{
+						map[string]interface{}{"function": map[string]interface{}{"$count": []interface{}{}}, "as": "c"},
+					},
+					"as":     "errors",
+					"window": []interface{}{"1", "minutes"},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "aggregates",
+		},
+		{
+			name: "format on parse stage rejected",
+			stages: []map[string]interface{}{
+				{
+					"type":   "parse",
+					"format": "json",
+					"field":  "Body",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "format",
+		},
+		{
+			name: "missing parser on parse stage rejected",
+			stages: []map[string]interface{}{
+				{
+					"type":  "parse",
+					"field": "Body",
+				},
+			},
+			wantErr:   true,
+			errSubstr: "parser",
+		},
+		{
+			name: "SpanKind filter rejected",
+			stages: []map[string]interface{}{
+				{
+					"type": "filter",
+					"query": map[string]interface{}{
+						"$and": []interface{}{
+							map[string]interface{}{"$eq": []interface{}{"SpanKind", "SPAN_KIND_SERVER"}},
+						},
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "SpanKind",
+		},
+		{
+			name: "StatusCode filter rejected",
+			stages: []map[string]interface{}{
+				{
+					"type": "filter",
+					"query": map[string]interface{}{
+						"$and": []interface{}{
+							map[string]interface{}{"$eq": []interface{}{"StatusCode", "STATUS_CODE_ERROR"}},
+						},
+					},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "StatusCode",
+		},
+		{
+			name: "valid parse with parser accepted",
+			stages: []map[string]interface{}{
+				{
+					"type":   "parse",
+					"parser": "json",
+					"field":  "Body",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "service.name alias still normalizes via prepare (sanitize runs after validate)",
+			stages: []map[string]interface{}{
+				{
+					"type": "filter",
+					"query": map[string]interface{}{
+						"$and": []interface{}{
+							map[string]interface{}{"$eq": []interface{}{"service.name", "api"}},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result, err := prepareLogJSONQuery(c.stages, "logjson_query")
+			if c.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if c.errSubstr != "" && !strings.Contains(err.Error(), c.errSubstr) {
+					t.Errorf("error %q missing expected substring %q", err.Error(), c.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+		})
+	}
+}
+
+// TestPrepareLogJSONQueryErrorsNoQueryBuilder asserts that the empty-query path
+// in NewGetLogsHandler no longer references the logjson_query_builder prompt.
+func TestPrepareLogJSONQueryErrorsNoQueryBuilder(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "should not be called", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	handler := NewGetLogsHandler(server.Client(), testLogsConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLogsArgs{})
+	if err == nil {
+		t.Fatal("expected error for empty logjson_query")
+	}
+	if strings.Contains(err.Error(), "query_builder") {
+		t.Errorf("empty logjson_query error must not reference 'query_builder', got: %q", err.Error())
+	}
+}
+
+func TestUnknownKeyTipsAreStageSpecific(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{"type": "parse", "format": "json", "field": "Body"},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected parse format rejection")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "window_aggregate uses") {
+		t.Errorf("parse unknown-key error must not include window_aggregate tip, got: %q", msg)
+	}
+	if !strings.Contains(msg, "never \"format\"") {
+		t.Errorf("parse format error should mention never format, got: %q", msg)
+	}
+
+	_, err = prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type":           "window_aggregate",
+			"function":       map[string]interface{}{"$count": []interface{}{}},
+			"as":             "errors",
+			"window_minutes": 1,
+		},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected window_minutes rejection")
+	}
+	msg = err.Error()
+	if !strings.Contains(msg, "window_aggregate uses") {
+		t.Errorf("window_aggregate unknown-key error should include WA tip, got: %q", msg)
+	}
+}
+
+func TestPrepareLogJSONQuerySanitizeUsesPathPrefix(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type": "filter",
+			"query": map[string]interface{}{
+				"$and": []interface{}{
+					map[string]interface{}{"$eq": []interface{}{`attributes["http.status_code"]`, "500"}},
+				},
+			},
+		},
+	}, "pipeline")
+	if err == nil {
+		t.Fatal("expected sanitize rejection for double-quoted attribute ref")
+	}
+	if !strings.Contains(err.Error(), "pipeline[0]") {
+		t.Errorf("sanitize failure for attrs tool must use pipeline path prefix, got: %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "logjson_query[0]") {
+		t.Errorf("sanitize failure must not hardcode logjson_query when prefix is pipeline, got: %q", err.Error())
+	}
+}
+
+func TestPrepareLogJSONQueryWrapsBareFilterInAnd(t *testing.T) {
+	result, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type": "filter",
+			"query": map[string]interface{}{
+				"$eq": []interface{}{"SeverityText", "ERROR"},
+			},
+		},
+	}, "logjson_query")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	query := result[0]["query"].(map[string]interface{})
+	andConditions, ok := query["$and"].([]interface{})
+	if !ok {
+		t.Fatalf("expected top-level $and wrap, got %#v", query)
+	}
+	if len(andConditions) != 1 {
+		t.Fatalf("expected 1 $and condition, got %#v", andConditions)
+	}
+	cond := andConditions[0].(map[string]interface{})
+	if _, ok := cond["$eq"]; !ok {
+		t.Fatalf("expected wrapped $eq condition, got %#v", cond)
+	}
+}
+
+func TestPrepareLogJSONQueryRejectsBareSingleTokenField(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type": "filter",
+			"query": map[string]interface{}{
+				"$and": []interface{}{
+					map[string]interface{}{"$eq": []interface{}{"community_member_id", "81453836"}},
+				},
+			},
+		},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected bare community_member_id to be rejected")
+	}
+	if !strings.Contains(err.Error(), "community_member_id") {
+		t.Errorf("error should mention field name, got: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "attributes['community_member_id']") {
+		t.Errorf("error should suggest attributes['…'] form, got: %q", err.Error())
+	}
+}
+
+func TestPrepareLogJSONQueryTypedValidationError(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type":           "window_aggregate",
+			"function":       map[string]interface{}{"$count": []interface{}{}},
+			"as":             "errors",
+			"window_minutes": 1,
+		},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var typed *LogPipelineValidationError
+	if !errors.As(err, &typed) {
+		t.Fatalf("expected *LogPipelineValidationError, got %T (%v)", err, err)
+	}
+	if typed.Category != LogValidationUnknownStageKey {
+		t.Errorf("category=%q, want %q", typed.Category, LogValidationUnknownStageKey)
+	}
+	if typed.Path == "" {
+		t.Error("typed error Path must be non-empty")
+	}
+	if !strings.Contains(typed.Message, "window_minutes") {
+		t.Errorf("message should mention window_minutes, got: %q", typed.Message)
+	}
+}
+
+func TestPrepareLogJSONQueryTypedWrongDomainField(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type": "filter",
+			"query": map[string]interface{}{
+				"$and": []interface{}{
+					map[string]interface{}{"$eq": []interface{}{"SpanKind", "SPAN_KIND_SERVER"}},
+				},
+			},
+		},
+	}, "pipeline")
+	if err == nil {
+		t.Fatal("expected SpanKind rejection")
+	}
+	var typed *LogPipelineValidationError
+	if !errors.As(err, &typed) {
+		t.Fatalf("expected *LogPipelineValidationError, got %T", err)
+	}
+	if typed.Category != LogValidationWrongDomainField {
+		t.Errorf("category=%q, want %q", typed.Category, LogValidationWrongDomainField)
 	}
 }

--- a/internal/telemetry/logs/query_sanitize_test.go
+++ b/internal/telemetry/logs/query_sanitize_test.go
@@ -1295,3 +1295,130 @@ func TestPrepareLogJSONQueryRoundTripBodyDerivedHint(t *testing.T) {
 		t.Fatalf("body-derived hint round-trip should pass: %v", err)
 	}
 }
+
+// TestPrepareLogJSONQueryFilterQueryRequired verifies that a filter stage missing
+// "query" is rejected with a tip mentioning "conditions".
+func TestPrepareLogJSONQueryFilterQueryRequired(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{"type": "filter"},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected error for filter stage missing query")
+	}
+	if !strings.Contains(err.Error(), "query") {
+		t.Errorf("error should mention \"query\", got: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "conditions") {
+		t.Errorf("error should tip \"conditions\", got: %q", err.Error())
+	}
+}
+
+// TestPrepareLogJSONQueryConditionsRejectsWithTip verifies that "conditions" (a
+// common wrong key) is rejected before validation with a clear tip.
+func TestPrepareLogJSONQueryConditionsRejectsWithTip(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type":       "filter",
+			"conditions": map[string]interface{}{"$and": []interface{}{}},
+		},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected error for filter with conditions instead of query")
+	}
+	if !strings.Contains(err.Error(), "conditions") {
+		t.Errorf("error should mention \"conditions\", got: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "query") {
+		t.Errorf("error should tip to use \"query\", got: %q", err.Error())
+	}
+}
+
+// TestPrepareLogJSONQueryAggregatesRequired verifies that an aggregate stage
+// missing "aggregates" is rejected with tips for "aggs"/"aggregations".
+func TestPrepareLogJSONQueryAggregatesRequired(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{"type": "aggregate"},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected error for aggregate stage missing aggregates")
+	}
+	if !strings.Contains(err.Error(), "aggregates") {
+		t.Errorf("error should mention \"aggregates\", got: %q", err.Error())
+	}
+}
+
+// TestPrepareLogJSONQueryAggsRejectsWithTip verifies that "aggs" is rejected
+// with a tip to use "aggregates".
+func TestPrepareLogJSONQueryAggsRejectsWithTip(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type": "aggregate",
+			"aggs": []interface{}{
+				map[string]interface{}{
+					"function": map[string]interface{}{"$count": []interface{}{}},
+					"as":       "c",
+				},
+			},
+		},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected error for aggregate with aggs instead of aggregates")
+	}
+	if !strings.Contains(err.Error(), "aggs") {
+		t.Errorf("error should mention \"aggs\", got: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "aggregates") {
+		t.Errorf("error should tip to use \"aggregates\", got: %q", err.Error())
+	}
+}
+
+// TestPrepareLogJSONQueryAliasRejectsWithTip verifies that "alias" in an
+// aggregates item is rejected with a tip to use "as".
+func TestPrepareLogJSONQueryAliasRejectsWithTip(t *testing.T) {
+	_, err := prepareLogJSONQuery([]map[string]interface{}{
+		{
+			"type": "aggregate",
+			"aggregates": []interface{}{
+				map[string]interface{}{
+					"function": map[string]interface{}{"$count": []interface{}{}},
+					"alias":    "count",
+				},
+			},
+		},
+	}, "logjson_query")
+	if err == nil {
+		t.Fatal("expected error for aggregate item with alias instead of as")
+	}
+	if !strings.Contains(err.Error(), "alias") {
+		t.Errorf("error should mention \"alias\", got: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "as") {
+		t.Errorf("error should tip to use \"as\", got: %q", err.Error())
+	}
+}
+
+// TestPrepareLogJSONQueryParseFieldNoCallerMutation verifies that the caller's
+// original stage map is NOT mutated when "field" is defaulted to "Body".
+func TestPrepareLogJSONQueryParseFieldNoCallerMutation(t *testing.T) {
+	original := map[string]interface{}{
+		"type":   "parse",
+		"parser": "json",
+		// no "field" key — should be defaulted in returned pipeline only
+	}
+	stages := []map[string]interface{}{original}
+
+	result, err := prepareLogJSONQuery(stages, "logjson_query")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Returned pipeline must have "field" defaulted to "Body".
+	if result[0]["field"] != "Body" {
+		t.Errorf("expected returned stage to have field=Body, got %v", result[0]["field"])
+	}
+
+	// Caller's original map must NOT have been mutated.
+	if _, mutated := original["field"]; mutated {
+		t.Errorf("caller's original map was mutated: got field=%v", original["field"])
+	}
+}

--- a/internal/telemetry/logs/query_sanitize_test.go
+++ b/internal/telemetry/logs/query_sanitize_test.go
@@ -1422,3 +1422,102 @@ func TestPrepareLogJSONQueryParseFieldNoCallerMutation(t *testing.T) {
 		t.Errorf("caller's original map was mutated: got field=%v", original["field"])
 	}
 }
+
+// TestPrepareLogJSONQueryCatchAllTips verifies that inputs which pass schema
+// validation via the catch-all anyOf branch are still rejected by
+// validateLogJSONQuery with actionable tips — and never produce "anonymous
+// schema" error messages that the model cannot act on.
+func TestPrepareLogJSONQueryCatchAllTips(t *testing.T) {
+	type tc struct {
+		name      string
+		stages    []map[string]interface{}
+		errSubstr string
+	}
+
+	cases := []tc{
+		{
+			name: "filter query as SQL string",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": "SELECT * FROM logs WHERE SeverityText = 'ERROR'"},
+			},
+			errSubstr: "NOT SQL",
+		},
+		{
+			name: "type sort (unknown stage type)",
+			stages: []map[string]interface{}{
+				{"type": "sort"},
+			},
+			errSubstr: "unknown stage type",
+		},
+		{
+			name: "stage with no type field",
+			stages: []map[string]interface{}{
+				{"stage": "filter", "query": map[string]interface{}{"$and": []interface{}{}}},
+			},
+			errSubstr: "missing or non-string",
+		},
+		{
+			name: "parser grok (invalid parser value)",
+			stages: []map[string]interface{}{
+				{"type": "parse", "parser": "grok"},
+			},
+			errSubstr: "grok",
+		},
+		{
+			name: "function as string on window_aggregate",
+			stages: []map[string]interface{}{
+				{"type": "window_aggregate", "function": "$count", "as": "errors", "window": []interface{}{"1", "minutes"}},
+			},
+			errSubstr: "function",
+		},
+		{
+			name: "window as string on window_aggregate",
+			stages: []map[string]interface{}{
+				{"type": "window_aggregate", "function": map[string]interface{}{"$count": []interface{}{}}, "as": "errors", "window": "1m"},
+			},
+			errSubstr: "window",
+		},
+		{
+			name: "groupby as array on aggregate",
+			stages: []map[string]interface{}{
+				{
+					"type": "aggregate",
+					"aggregates": []interface{}{
+						map[string]interface{}{"function": map[string]interface{}{"$count": []interface{}{}}, "as": "c"},
+					},
+					"groupby": []interface{}{"ServiceName"},
+				},
+			},
+			errSubstr: "groupby",
+		},
+		{
+			name: "groupby as string on window_aggregate",
+			stages: []map[string]interface{}{
+				{
+					"type":     "window_aggregate",
+					"function": map[string]interface{}{"$count": []interface{}{}},
+					"as":       "errors",
+					"window":   []interface{}{"1", "minutes"},
+					"groupby":  "ServiceName",
+				},
+			},
+			errSubstr: "groupby",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := prepareLogJSONQuery(c.stages, "logjson_query")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, c.errSubstr) {
+				t.Errorf("error %q missing expected substring %q", msg, c.errSubstr)
+			}
+			if strings.Contains(msg, "anonymous schema") {
+				t.Errorf("error must not contain 'anonymous schema' (opaque validator message leaking through): %q", msg)
+			}
+		})
+	}
+}

--- a/internal/telemetry/logs/query_validate.go
+++ b/internal/telemetry/logs/query_validate.go
@@ -105,19 +105,10 @@ func prepareLogJSONQuery(stages []map[string]interface{}, pathPrefix string) ([]
 		pathPrefix = "logjson_query"
 	}
 
-	// Validate first (fail-closed), then sanitize field refs, then $and-wrap.
+	// Validate first (fail-closed), then sanitize field refs (which also defaults
+	// missing parse "field" to "Body" on rebuilt copies), then $and-wrap.
 	if err := validateLogJSONQuery(stages, pathPrefix); err != nil {
 		return nil, err
-	}
-
-	// Default missing or blank parse field to "Body" after validation so the
-	// schema can leave "field" optional while the API always receives a value.
-	for _, stage := range stages {
-		if stageType, _ := stage["type"].(string); stageType == "parse" {
-			if field, _ := stage["field"].(string); strings.TrimSpace(field) == "" {
-				stage["field"] = "Body"
-			}
-		}
 	}
 
 	sanitized, err := sanitizeLogJSONQueryPrefixed(stages, pathPrefix)
@@ -204,6 +195,12 @@ func validateLogJSONQuery(stages []map[string]interface{}, pathPrefix string) er
 				if stageType == "parse" && key == "format" {
 					msg += `; use "parser": "json"|"logfmt"|"regexp" (never "format")`
 				}
+				if stageType == "filter" && key == "conditions" {
+					msg += `; use "query" not "conditions"`
+				}
+				if stageType == "aggregate" && key == "aggs" {
+					msg += `; use "aggregates" (plural), not "aggs" or "aggregations"`
+				}
 				return newLogValidationError(LogValidationUnknownStageKey, stagePath+"."+key, msg)
 			}
 		}
@@ -221,11 +218,11 @@ func validateLogJSONQuery(stages []map[string]interface{}, pathPrefix string) er
 				return err
 			}
 		case "aggregate":
-			if err := validateGroupByForTraceFields(stage, stagePath); err != nil {
+			if err := validateAggregateStage(stage, stagePath); err != nil {
 				return err
 			}
 		case "filter":
-			if err := validateFilterStageForTraceFields(stage, stagePath); err != nil {
+			if err := validateFilterStage(stage, stagePath); err != nil {
 				return err
 			}
 		}
@@ -432,6 +429,115 @@ func walkFilterForTraceFields(node interface{}, path string) error {
 		}
 	}
 	return nil
+}
+
+// validateFilterStage checks that a filter stage has a non-nil "query" key and
+// then delegates trace-field checks to validateFilterStageForTraceFields.
+func validateFilterStage(stage map[string]interface{}, stagePath string) error {
+	if stage["query"] == nil {
+		return newLogValidationError(
+			LogValidationMissingRequired,
+			stagePath+".query",
+			fmt.Sprintf(
+				"filter stage at %s missing required \"query\" key — use \"query\" not \"conditions\"",
+				stagePath,
+			),
+		)
+	}
+	return validateFilterStageForTraceFields(stage, stagePath)
+}
+
+// allowedAggregateItemKeys are the only keys permitted inside each aggregates[] item.
+var allowedAggregateItemKeys = map[string]struct{}{
+	"function": {},
+	"as":       {},
+}
+
+// validateAggregateStage checks that "aggregates" is a non-empty array of valid
+// items (each with "function" and "as"), then delegates groupby checks.
+func validateAggregateStage(stage map[string]interface{}, stagePath string) error {
+	rawAggs := stage["aggregates"]
+	if rawAggs == nil {
+		return newLogValidationError(
+			LogValidationMissingRequired,
+			stagePath+".aggregates",
+			fmt.Sprintf(
+				"aggregate stage at %s missing required \"aggregates\" key — use \"aggregates\" (plural), not \"aggs\" or \"aggregations\"",
+				stagePath,
+			),
+		)
+	}
+	aggs, ok := rawAggs.([]interface{})
+	if !ok || len(aggs) == 0 {
+		return newLogValidationError(
+			LogValidationMissingRequired,
+			stagePath+".aggregates",
+			fmt.Sprintf(
+				"aggregate stage at %s: \"aggregates\" must be a non-empty array — use \"aggregates\" (plural), not \"aggs\" or \"aggregations\"",
+				stagePath,
+			),
+		)
+	}
+
+	for i, rawItem := range aggs {
+		itemPath := fmt.Sprintf("%s.aggregates[%d]", stagePath, i)
+		itemMap, ok := rawItem.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Reject unknown keys in each item.
+		for key := range itemMap {
+			if _, ok := allowedAggregateItemKeys[key]; !ok {
+				msg := fmt.Sprintf(
+					"unknown key %q in aggregates item at %s — allowed keys are \"function\" and \"as\"",
+					key, itemPath,
+				)
+				if key == "alias" {
+					msg += `; use "as", not "alias"`
+				}
+				return newLogValidationError(LogValidationUnknownStageKey, itemPath+"."+key, msg)
+			}
+		}
+
+		// Require "function" as an object.
+		fn := itemMap["function"]
+		if fn == nil {
+			return newLogValidationError(
+				LogValidationMissingRequired,
+				itemPath+".function",
+				fmt.Sprintf(
+					"aggregates item at %s missing required \"function\" key — example: {\"function\":{\"$count\":[]},\"as\":\"count\"}",
+					itemPath,
+				),
+			)
+		}
+		if _, ok := fn.(map[string]interface{}); !ok {
+			return newLogValidationError(
+				LogValidationInvalidField,
+				itemPath+".function",
+				fmt.Sprintf(
+					"aggregates item at %s: \"function\" must be an object like {\"$count\":[]}, not a %T",
+					itemPath, fn,
+				),
+			)
+		}
+
+		// Require "as" as a non-empty string.
+		as, _ := itemMap["as"].(string)
+		if strings.TrimSpace(as) == "" {
+			return newLogValidationError(
+				LogValidationMissingRequired,
+				itemPath+".as",
+				fmt.Sprintf(
+					"aggregates item at %s missing required \"as\" key (output field name) — use \"as\", not \"alias\"",
+					itemPath,
+				),
+			)
+		}
+	}
+
+	return validateGroupByForTraceFields(stage, stagePath)
 }
 
 func stageKeyList(allowed map[string]struct{}) string {

--- a/internal/telemetry/logs/query_validate.go
+++ b/internal/telemetry/logs/query_validate.go
@@ -310,7 +310,14 @@ func validateGroupByForTraceFields(stage map[string]interface{}, stagePath strin
 	}
 	groupBy, ok := raw.(map[string]interface{})
 	if !ok {
-		return nil
+		return newLogValidationError(
+			LogValidationInvalidField,
+			stagePath+".groupby",
+			fmt.Sprintf(
+				"groupby at %s must be an object like {\"ServiceName\":\"service\"}, not %T",
+				stagePath+".groupby", raw,
+			),
+		)
 	}
 	for fieldRef := range groupBy {
 		if _, isTraceOnly := traceOnlyLogFields[fieldRef]; isTraceOnly {
@@ -431,8 +438,8 @@ func walkFilterForTraceFields(node interface{}, path string) error {
 	return nil
 }
 
-// validateFilterStage checks that a filter stage has a non-nil "query" key and
-// then delegates trace-field checks to validateFilterStageForTraceFields.
+// validateFilterStage checks that a filter stage has a non-nil "query" key
+// that is a condition object (map), then delegates trace-field checks.
 func validateFilterStage(stage map[string]interface{}, stagePath string) error {
 	if stage["query"] == nil {
 		return newLogValidationError(
@@ -440,6 +447,16 @@ func validateFilterStage(stage map[string]interface{}, stagePath string) error {
 			stagePath+".query",
 			fmt.Sprintf(
 				"filter stage at %s missing required \"query\" key — use \"query\" not \"conditions\"",
+				stagePath,
+			),
+		)
+	}
+	if _, ok := stage["query"].(map[string]interface{}); !ok {
+		return newLogValidationError(
+			LogValidationInvalidField,
+			stagePath+".query",
+			fmt.Sprintf(
+				"filter stage at %s: \"query\" must be a condition object (NOT SQL / not a string) — example: {\"query\":{\"$and\":[{\"$eq\":[\"SeverityText\",\"ERROR\"]}]}}",
 				stagePath,
 			),
 		)

--- a/internal/telemetry/logs/query_validate.go
+++ b/internal/telemetry/logs/query_validate.go
@@ -2,9 +2,16 @@ package logs
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 )
+
+// namedCapturePattern extracts (?P<name>…) groups from a regexp parse pattern.
+var namedCapturePattern = regexp.MustCompile(`\(\?P<([^>]+)>`)
+
+// validNamedCaptureName is the Go regexp named-group alphabet (no `$`, hyphens, etc.).
+var validNamedCaptureName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // Validation error categories for fail-closed log pipeline checks.
 // Stable strings — safe for metrics labels; never include customer payloads.
@@ -199,6 +206,13 @@ func validateLogJSONQuery(stages []map[string]interface{}, pathPrefix string) er
 			if err := validateWindowAggregateStage(stage, stagePath); err != nil {
 				return err
 			}
+			if err := validateGroupByForTraceFields(stage, stagePath); err != nil {
+				return err
+			}
+		case "aggregate":
+			if err := validateGroupByForTraceFields(stage, stagePath); err != nil {
+				return err
+			}
 		case "filter":
 			if err := validateFilterStageForTraceFields(stage, stagePath); err != nil {
 				return err
@@ -223,6 +237,93 @@ func validateParseStage(stage map[string]interface{}, stagePath string) error {
 			stagePath+".parser",
 			fmt.Sprintf("invalid parser %q at %s — must be one of: json, logfmt, regexp (never \"format\")", parser, stagePath),
 		)
+	}
+
+	field, _ := stage["field"].(string)
+	if strings.TrimSpace(field) == "" {
+		return newLogValidationError(
+			LogValidationMissingRequired,
+			stagePath+".field",
+			fmt.Sprintf("parse stage at %s missing required \"field\" key — usually \"field\":\"Body\"", stagePath),
+		)
+	}
+
+	if labels, ok := stage["labels"].(map[string]interface{}); ok {
+		for labelKey := range labels {
+			if !validNamedCaptureName.MatchString(labelKey) {
+				return newLogValidationError(
+					LogValidationInvalidField,
+					stagePath+".labels."+labelKey,
+					fmt.Sprintf(
+						"parse labels key %q at %s is invalid — use a plain identifier like merchant (letters/digits/underscore); never \"$merchant\" or dotted names",
+						labelKey, stagePath+".labels",
+					),
+				)
+			}
+		}
+	}
+
+	if parser == "regexp" {
+		pattern, _ := stage["pattern"].(string)
+		if strings.TrimSpace(pattern) == "" {
+			return newLogValidationError(
+				LogValidationMissingRequired,
+				stagePath+".pattern",
+				fmt.Sprintf("regexp parse stage at %s missing required \"pattern\" with named captures like (?P<level>ERROR|WARN)", stagePath),
+			)
+		}
+		if err := validateRegexpNamedCaptures(pattern, stagePath+".pattern"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRegexpNamedCaptures(pattern, path string) error {
+	matches := namedCapturePattern.FindAllStringSubmatch(pattern, -1)
+	if len(matches) == 0 {
+		return newLogValidationError(
+			LogValidationInvalidField,
+			path,
+			fmt.Sprintf("regexp pattern at %s has no named captures — use (?P<name>…) groups (name must match [A-Za-z_][A-Za-z0-9_]*)", path),
+		)
+	}
+	for _, m := range matches {
+		name := m[1]
+		if !validNamedCaptureName.MatchString(name) {
+			return newLogValidationError(
+				LogValidationInvalidField,
+				path,
+				fmt.Sprintf(
+					"invalid regexp named capture %q at %s — Go named groups must match [A-Za-z_][A-Za-z0-9_]* (got (?P<%s>…); never include \"$\"). Example: (?P<merchant>\\\\S+)",
+					name, path, name,
+				),
+			)
+		}
+	}
+	return nil
+}
+
+func validateGroupByForTraceFields(stage map[string]interface{}, stagePath string) error {
+	raw, ok := stage["groupby"]
+	if !ok || raw == nil {
+		return nil
+	}
+	groupBy, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	for fieldRef := range groupBy {
+		if _, isTraceOnly := traceOnlyLogFields[fieldRef]; isTraceOnly {
+			return newLogValidationError(
+				LogValidationWrongDomainField,
+				stagePath+".groupby."+fieldRef,
+				fmt.Sprintf(
+					"groupby at %s uses trace-only field %q — not valid in logs; use ServiceName, SeverityText, attributes['…'], or resources['…']",
+					stagePath+".groupby", fieldRef,
+				),
+			)
+		}
 	}
 	return nil
 }

--- a/internal/telemetry/logs/query_validate.go
+++ b/internal/telemetry/logs/query_validate.go
@@ -1,0 +1,344 @@
+package logs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Validation error categories for fail-closed log pipeline checks.
+// Stable strings — safe for metrics labels; never include customer payloads.
+const (
+	LogValidationUnknownStageType = "unknown_stage_type"
+	LogValidationUnknownStageKey  = "unknown_stage_key"
+	LogValidationMissingRequired     = "missing_required"
+	LogValidationInvalidField        = "invalid_field"
+	LogValidationWrongDomainField    = "wrong_domain_field"
+)
+
+// LogPipelineValidationError is a fail-closed validation failure with a stable
+// category + JSON path for metrics and model self-correction.
+type LogPipelineValidationError struct {
+	Category string
+	Path     string
+	Message  string
+}
+
+func (e *LogPipelineValidationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+func newLogValidationError(category, path, message string) error {
+	return &LogPipelineValidationError{
+		Category: category,
+		Path:     path,
+		Message:  message,
+	}
+}
+
+// traceOnlyLogFields are span/trace fields that have no meaning as top-level
+// log filters. Accepting them silently produces zero results; rejecting them
+// surfaces the model error before the API call.
+var traceOnlyLogFields = map[string]struct{}{
+	"SpanKind":     {},
+	"StatusCode":   {},
+	"Duration":     {},
+	"SpanName":     {},
+	"TraceId":      {},
+	"SpanId":       {},
+	"ParentSpanId": {},
+}
+
+// validParserValues are the accepted values for the parse stage "parser" key.
+var validParserValues = map[string]struct{}{
+	"json":   {},
+	"logfmt": {},
+	"regexp": {},
+}
+
+// allowedStageKeys lists the permitted top-level keys for each stage type.
+// Any key not in the set is rejected so wrong-name mistakes are caught
+// (e.g. window_minutes on window_aggregate, or format on parse).
+var allowedStageKeys = map[string]map[string]struct{}{
+	"filter": {
+		"type":  {},
+		"query": {},
+	},
+	"parse": {
+		"type":    {},
+		"parser":  {},
+		"field":   {},
+		"pattern": {},
+		"labels":  {},
+	},
+	"aggregate": {
+		"type":       {},
+		"aggregates": {},
+		"groupby":    {},
+	},
+	"window_aggregate": {
+		"type":     {},
+		"function": {},
+		"as":       {},
+		"window":   {},
+		"groupby":  {},
+	},
+}
+
+// prepareLogJSONQuery validates then sanitizes a logjson pipeline, then
+// normalizes bare top-level filter queries into $and (traces parity).
+// It is the single entry point for both get_logs and
+// get_log_attributes_for_pipeline before any HTTP call is made.
+// pathPrefix is used in error messages — "logjson_query" for get_logs,
+// "pipeline" for get_log_attributes_for_pipeline — including sanitize failures.
+func prepareLogJSONQuery(stages []map[string]interface{}, pathPrefix string) ([]map[string]interface{}, error) {
+	if pathPrefix == "" {
+		pathPrefix = "logjson_query"
+	}
+
+	// Validate first (fail-closed), then sanitize field refs, then $and-wrap.
+	if err := validateLogJSONQuery(stages, pathPrefix); err != nil {
+		return nil, err
+	}
+
+	sanitized, err := sanitizeLogJSONQueryPrefixed(stages, pathPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, stage := range sanitized {
+		if stageType, _ := stage["type"].(string); stageType == "filter" {
+			if query, ok := stage["query"]; ok {
+				stage["query"] = wrapTopLevelLogFilterQuery(query)
+			}
+		}
+	}
+
+	return sanitized, nil
+}
+
+// wrapTopLevelLogFilterQuery ensures the top-level filter query is wrapped in a
+// logical operator. Already-$and/$or/$not queries pass through; bare field
+// operators are wrapped in $and (deterministic key order).
+func wrapTopLevelLogFilterQuery(query interface{}) interface{} {
+	queryMap, ok := query.(map[string]interface{})
+	if !ok || len(queryMap) == 0 {
+		return query
+	}
+
+	if len(queryMap) == 1 {
+		for key := range queryMap {
+			if _, isLogical := logFilterLogicalOperators[key]; isLogical {
+				return queryMap
+			}
+		}
+	}
+
+	keys := make([]string, 0, len(queryMap))
+	for key := range queryMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	conditions := make([]interface{}, 0, len(keys))
+	for _, key := range keys {
+		conditions = append(conditions, map[string]interface{}{key: queryMap[key]})
+	}
+	return map[string]interface{}{"$and": conditions}
+}
+
+// validateLogJSONQuery performs structural validation before the HTTP fan-out.
+func validateLogJSONQuery(stages []map[string]interface{}, pathPrefix string) error {
+	for i, stage := range stages {
+		stagePath := fmt.Sprintf("%s[%d]", pathPrefix, i)
+
+		stageType, _ := stage["type"].(string)
+		if stageType == "" {
+			return newLogValidationError(
+				LogValidationMissingRequired,
+				stagePath,
+				fmt.Sprintf("missing or non-string \"type\" at %s — each stage must set type to filter|parse|aggregate|window_aggregate", stagePath),
+			)
+		}
+
+		allowed, ok := allowedStageKeys[stageType]
+		if !ok {
+			return newLogValidationError(
+				LogValidationUnknownStageType,
+				stagePath,
+				fmt.Sprintf("unknown stage type %q at %s — valid types are filter, parse, aggregate, window_aggregate", stageType, stagePath),
+			)
+		}
+
+		// Reject any key not in the allowlist for this stage type.
+		for key := range stage {
+			if _, ok := allowed[key]; !ok {
+				msg := fmt.Sprintf(
+					"unknown key %q on %s stage at %s — allowed keys: %s",
+					key, stageType, stagePath, stageKeyList(allowed),
+				)
+				if stageType == "window_aggregate" {
+					msg += `; common mistake: window_aggregate uses "function"+"as"+"window" not "aggregates" or "window_minutes"`
+				}
+				if stageType == "parse" && key == "format" {
+					msg += `; use "parser": "json"|"logfmt"|"regexp" (never "format")`
+				}
+				return newLogValidationError(LogValidationUnknownStageKey, stagePath+"."+key, msg)
+			}
+		}
+
+		switch stageType {
+		case "parse":
+			if err := validateParseStage(stage, stagePath); err != nil {
+				return err
+			}
+		case "window_aggregate":
+			if err := validateWindowAggregateStage(stage, stagePath); err != nil {
+				return err
+			}
+		case "filter":
+			if err := validateFilterStageForTraceFields(stage, stagePath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateParseStage(stage map[string]interface{}, stagePath string) error {
+	parser, _ := stage["parser"].(string)
+	if parser == "" {
+		return newLogValidationError(
+			LogValidationMissingRequired,
+			stagePath+".parser",
+			fmt.Sprintf("parse stage at %s missing required \"parser\" key — use \"parser\": \"json\"|\"logfmt\"|\"regexp\" (never \"format\")", stagePath),
+		)
+	}
+	if _, ok := validParserValues[parser]; !ok {
+		return newLogValidationError(
+			LogValidationInvalidField,
+			stagePath+".parser",
+			fmt.Sprintf("invalid parser %q at %s — must be one of: json, logfmt, regexp (never \"format\")", parser, stagePath),
+		)
+	}
+	return nil
+}
+
+func validateWindowAggregateStage(stage map[string]interface{}, stagePath string) error {
+	fn := stage["function"]
+	if fn == nil {
+		return newLogValidationError(
+			LogValidationMissingRequired,
+			stagePath+".function",
+			fmt.Sprintf("window_aggregate at %s missing required \"function\" key — example: {\"function\":{\"$count\":[]},\"as\":\"errors\",\"window\":[\"1\",\"minutes\"]}", stagePath),
+		)
+	}
+	if _, ok := fn.(map[string]interface{}); !ok {
+		return newLogValidationError(
+			LogValidationInvalidField,
+			stagePath+".function",
+			fmt.Sprintf("window_aggregate at %s: \"function\" must be an object like {\"$count\":[]}, not a string — got %T", stagePath, fn),
+		)
+	}
+
+	as, _ := stage["as"].(string)
+	if as == "" {
+		return newLogValidationError(
+			LogValidationMissingRequired,
+			stagePath+".as",
+			fmt.Sprintf("window_aggregate at %s missing required \"as\" key (output field name) — example: \"as\":\"errors\"", stagePath),
+		)
+	}
+
+	rawWindow := stage["window"]
+	if rawWindow == nil {
+		return newLogValidationError(
+			LogValidationMissingRequired,
+			stagePath+".window",
+			fmt.Sprintf("window_aggregate at %s missing required \"window\" key — example: \"window\":[\"1\",\"minutes\"]", stagePath),
+		)
+	}
+	window, ok := rawWindow.([]interface{})
+	if !ok || len(window) != 2 {
+		return newLogValidationError(
+			LogValidationInvalidField,
+			stagePath+".window",
+			fmt.Sprintf("window_aggregate at %s: \"window\" must be an array of exactly 2 elements [duration, unit] — example: [\"1\",\"minutes\"]; got %T len=%d", stagePath, rawWindow, windowLen(rawWindow)),
+		)
+	}
+	return nil
+}
+
+// validateFilterStageForTraceFields rejects top-level log filter conditions
+// that reference trace-only fields (SpanKind, StatusCode, etc.) that are
+// meaningless in the log context and always produce zero results.
+func validateFilterStageForTraceFields(stage map[string]interface{}, stagePath string) error {
+	query, ok := stage["query"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return walkFilterForTraceFields(query, stagePath+".query")
+}
+
+func walkFilterForTraceFields(node interface{}, path string) error {
+	switch typed := node.(type) {
+	case map[string]interface{}:
+		for key, val := range typed {
+			switch key {
+			case "$and", "$or", "$not":
+				if err := walkFilterForTraceFields(val, path+"."+key); err != nil {
+					return err
+				}
+			default:
+				args, ok := val.([]interface{})
+				if !ok || len(args) == 0 {
+					continue
+				}
+				fieldRef, _ := args[0].(string)
+				if fieldRef == "" {
+					continue
+				}
+				if strings.Contains(fieldRef, "'") || strings.Contains(fieldRef, "[") {
+					continue
+				}
+				if _, isTraceOnly := traceOnlyLogFields[fieldRef]; isTraceOnly {
+					return newLogValidationError(
+						LogValidationWrongDomainField,
+						path+"."+key,
+						fmt.Sprintf(
+							"log filter at %s references trace-only field %q — this field does not exist in logs and will match nothing; "+
+								"use SeverityText for severity, Body for message content, or call get_log_attributes to discover the correct log field",
+							path+"."+key, fieldRef,
+						),
+					)
+				}
+			}
+		}
+	case []interface{}:
+		for i, item := range typed {
+			if err := walkFilterForTraceFields(item, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func stageKeyList(allowed map[string]struct{}) string {
+	keys := make([]string, 0, len(allowed))
+	for k := range allowed {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}
+
+func windowLen(v interface{}) int {
+	if arr, ok := v.([]interface{}); ok {
+		return len(arr)
+	}
+	return 0
+}

--- a/internal/telemetry/logs/query_validate.go
+++ b/internal/telemetry/logs/query_validate.go
@@ -18,9 +18,9 @@ var validNamedCaptureName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 const (
 	LogValidationUnknownStageType = "unknown_stage_type"
 	LogValidationUnknownStageKey  = "unknown_stage_key"
-	LogValidationMissingRequired     = "missing_required"
-	LogValidationInvalidField        = "invalid_field"
-	LogValidationWrongDomainField    = "wrong_domain_field"
+	LogValidationMissingRequired  = "missing_required"
+	LogValidationInvalidField     = "invalid_field"
+	LogValidationWrongDomainField = "wrong_domain_field"
 )
 
 // LogPipelineValidationError is a fail-closed validation failure with a stable
@@ -49,14 +49,13 @@ func newLogValidationError(category, path, message string) error {
 // traceOnlyLogFields are span/trace fields that have no meaning as top-level
 // log filters. Accepting them silently produces zero results; rejecting them
 // surfaces the model error before the API call.
+// TraceId, SpanId, ParentSpanId are intentionally excluded — they are valid
+// log fields used for log↔trace correlation queries.
 var traceOnlyLogFields = map[string]struct{}{
-	"SpanKind":     {},
-	"StatusCode":   {},
-	"Duration":     {},
-	"SpanName":     {},
-	"TraceId":      {},
-	"SpanId":       {},
-	"ParentSpanId": {},
+	"SpanKind":   {},
+	"StatusCode": {},
+	"Duration":   {},
+	"SpanName":   {},
 }
 
 // validParserValues are the accepted values for the parse stage "parser" key.
@@ -111,6 +110,16 @@ func prepareLogJSONQuery(stages []map[string]interface{}, pathPrefix string) ([]
 		return nil, err
 	}
 
+	// Default missing or blank parse field to "Body" after validation so the
+	// schema can leave "field" optional while the API always receives a value.
+	for _, stage := range stages {
+		if stageType, _ := stage["type"].(string); stageType == "parse" {
+			if field, _ := stage["field"].(string); strings.TrimSpace(field) == "" {
+				stage["field"] = "Body"
+			}
+		}
+	}
+
 	sanitized, err := sanitizeLogJSONQueryPrefixed(stages, pathPrefix)
 	if err != nil {
 		return nil, err
@@ -158,6 +167,8 @@ func wrapTopLevelLogFilterQuery(query interface{}) interface{} {
 }
 
 // validateLogJSONQuery performs structural validation before the HTTP fan-out.
+// Stage ordering (filter → parse → aggregate/window_aggregate) is documented in
+// the whale description and logjson reference but is not enforced here (MVP).
 func validateLogJSONQuery(stages []map[string]interface{}, pathPrefix string) error {
 	for i, stage := range stages {
 		stagePath := fmt.Sprintf("%s[%d]", pathPrefix, i)
@@ -239,23 +250,14 @@ func validateParseStage(stage map[string]interface{}, stagePath string) error {
 		)
 	}
 
-	field, _ := stage["field"].(string)
-	if strings.TrimSpace(field) == "" {
-		return newLogValidationError(
-			LogValidationMissingRequired,
-			stagePath+".field",
-			fmt.Sprintf("parse stage at %s missing required \"field\" key — usually \"field\":\"Body\"", stagePath),
-		)
-	}
-
 	if labels, ok := stage["labels"].(map[string]interface{}); ok {
 		for labelKey := range labels {
-			if !validNamedCaptureName.MatchString(labelKey) {
+			if !safeBodyKeyPattern.MatchString(labelKey) {
 				return newLogValidationError(
 					LogValidationInvalidField,
 					stagePath+".labels."+labelKey,
 					fmt.Sprintf(
-						"parse labels key %q at %s is invalid — use a plain identifier like merchant (letters/digits/underscore); never \"$merchant\" or dotted names",
+						"parse labels key %q at %s is invalid — use a safe key (letters/digits/underscore/dot/@/-); never \"$merchant\" or keys with spaces, quotes, or backslashes",
 						labelKey, stagePath+".labels",
 					),
 				)
@@ -363,11 +365,15 @@ func validateWindowAggregateStage(stage map[string]interface{}, stagePath string
 		)
 	}
 	window, ok := rawWindow.([]interface{})
-	if !ok || len(window) != 2 {
+	gotLen := 0
+	if ok {
+		gotLen = len(window)
+	}
+	if !ok || gotLen != 2 {
 		return newLogValidationError(
 			LogValidationInvalidField,
 			stagePath+".window",
-			fmt.Sprintf("window_aggregate at %s: \"window\" must be an array of exactly 2 elements [duration, unit] — example: [\"1\",\"minutes\"]; got %T len=%d", stagePath, rawWindow, windowLen(rawWindow)),
+			fmt.Sprintf("window_aggregate at %s: \"window\" must be an array of exactly 2 elements [duration, unit] — example: [\"1\",\"minutes\"]; got %T len=%d", stagePath, rawWindow, gotLen),
 		)
 	}
 	return nil
@@ -435,11 +441,4 @@ func stageKeyList(allowed map[string]struct{}) string {
 	}
 	sort.Strings(keys)
 	return strings.Join(keys, ", ")
-}
-
-func windowLen(v interface{}) int {
-	if arr, ok := v.([]interface{}); ok {
-		return len(arr)
-	}
-	return 0
 }

--- a/internal/telemetry/logs/schema_test.go
+++ b/internal/telemetry/logs/schema_test.go
@@ -146,3 +146,129 @@ func TestGetLogsArgs_LookbackDescriptionMatchesPromptDefault(t *testing.T) {
 		t.Fatalf("lookback_minutes.description should not advertise default: 60, got %q", description)
 	}
 }
+
+// TestGetLogsInputSchema_Structure verifies the hand-crafted GetLogsInputSchema
+// conforms to the expected shape: logjson_query required, oneOf stages,
+// window_aggregate has additionalProperties:false.
+func TestGetLogsInputSchema_Structure(t *testing.T) {
+	schema := GetLogsInputSchema()
+
+	// logjson_query must be in required.
+	required, ok := schema["required"].([]string)
+	if !ok {
+		t.Fatal("schema required is not []string")
+	}
+	foundRequired := false
+	for _, r := range required {
+		if r == "logjson_query" {
+			foundRequired = true
+			break
+		}
+	}
+	if !foundRequired {
+		t.Error("logjson_query must be in required")
+	}
+
+	// logjson_query must have items.oneOf with at least 4 stage schemas.
+	props, ok := schema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("schema properties is not a map")
+	}
+	lq, ok := props["logjson_query"].(map[string]interface{})
+	if !ok {
+		t.Fatal("logjson_query property missing")
+	}
+	items, ok := lq["items"].(map[string]interface{})
+	if !ok {
+		t.Fatal("logjson_query items not an object")
+	}
+	oneOf, ok := items["oneOf"].([]interface{})
+	if !ok {
+		t.Fatal("logjson_query items.oneOf missing or not a slice")
+	}
+	if len(oneOf) < 4 {
+		t.Errorf("expected at least 4 stage schemas in oneOf, got %d", len(oneOf))
+	}
+
+	// Find window_aggregate stage schema and verify additionalProperties: false.
+	found := false
+	for _, stageRaw := range oneOf {
+		stageMap, ok := stageRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		stageProps, ok := stageMap["properties"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		typeField, ok := stageProps["type"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		enum, ok := typeField["enum"].([]string)
+		if !ok {
+			continue
+		}
+		for _, e := range enum {
+			if e == "window_aggregate" {
+				found = true
+				if stageMap["additionalProperties"] != false {
+					t.Error("window_aggregate stage schema must have additionalProperties: false")
+				}
+				// verify required fields
+				waRequired, ok := stageMap["required"].([]string)
+				if !ok {
+					t.Error("window_aggregate required is not []string")
+					break
+				}
+				requiredSet := map[string]bool{}
+				for _, r := range waRequired {
+					requiredSet[r] = true
+				}
+				for _, field := range []string{"type", "function", "as", "window"} {
+					if !requiredSet[field] {
+						t.Errorf("window_aggregate required must include %q", field)
+					}
+				}
+				break
+			}
+		}
+	}
+	if !found {
+		t.Error("window_aggregate stage schema not found in oneOf")
+	}
+
+	if schema["additionalProperties"] != false {
+		t.Error("root GetLogsInputSchema must set additionalProperties: false")
+	}
+}
+
+func TestGetLogsInputSchema_RejectsUnknownTopLevelKeys(t *testing.T) {
+	raw, err := json.Marshal(GetLogsInputSchema())
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	var parsed jsonschema.Schema
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	resolved, err := parsed.Resolve(nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	validPipeline := []interface{}{
+		map[string]interface{}{
+			"type":  "filter",
+			"query": map[string]interface{}{"$and": []interface{}{map[string]interface{}{"$eq": []interface{}{"SeverityText", "ERROR"}}}},
+		},
+	}
+
+	err = resolved.Validate(map[string]interface{}{
+		"logjson_query":  validPipeline,
+		"window_minutes": 5,
+	})
+	if err == nil {
+		t.Fatal("expected top-level window_minutes to be rejected by additionalProperties:false")
+	}
+}

--- a/internal/telemetry/logs/schema_test.go
+++ b/internal/telemetry/logs/schema_test.go
@@ -363,6 +363,34 @@ func TestGetLogsInputSchema_RejectsUnknownTopLevelKeys(t *testing.T) {
 				"window": []interface{}{"1", "minutes"},
 			},
 		},
+		{
+			name: "conditions instead of query on filter",
+			stage: map[string]interface{}{
+				"type":       "filter",
+				"conditions": map[string]interface{}{"$and": []interface{}{}},
+			},
+		},
+		{
+			name: "aggs instead of aggregates on aggregate",
+			stage: map[string]interface{}{
+				"type": "aggregate",
+				"aggs": []interface{}{
+					map[string]interface{}{"function": map[string]interface{}{"$count": []interface{}{}}, "as": "c"},
+				},
+			},
+		},
+		{
+			name: "alias instead of as in aggregate item",
+			stage: map[string]interface{}{
+				"type": "aggregate",
+				"aggregates": []interface{}{
+					map[string]interface{}{
+						"function": map[string]interface{}{"$count": []interface{}{}},
+						"alias":    "count",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tipReachable {
 		t.Run(tt.name+" passes schema", func(t *testing.T) {

--- a/internal/telemetry/logs/schema_test.go
+++ b/internal/telemetry/logs/schema_test.go
@@ -169,7 +169,8 @@ func TestGetLogsInputSchema_Structure(t *testing.T) {
 		t.Error("logjson_query must be in required")
 	}
 
-	// logjson_query must have items.anyOf with at least 4 stage schemas.
+	// logjson_query must have items.anyOf with at least 5 schemas:
+	// the 4 stage schemas + the permissive catch-all {"type":"object"}.
 	props, ok := schema["properties"].(map[string]interface{})
 	if !ok {
 		t.Fatal("schema properties is not a map")
@@ -186,8 +187,8 @@ func TestGetLogsInputSchema_Structure(t *testing.T) {
 	if !ok {
 		t.Fatal("logjson_query items.anyOf missing or not a slice")
 	}
-	if len(anyOf) < 4 {
-		t.Errorf("expected at least 4 stage schemas in anyOf, got %d", len(anyOf))
+	if len(anyOf) < 5 {
+		t.Errorf("expected at least 5 schemas in anyOf (4 stage schemas + catch-all), got %d", len(anyOf))
 	}
 
 	// Find window_aggregate stage schema and verify its required fields.
@@ -389,6 +390,54 @@ func TestGetLogsInputSchema_RejectsUnknownTopLevelKeys(t *testing.T) {
 						"alias":    "count",
 					},
 				},
+			},
+		},
+		// New catch-all cases: wrong query type, unknown stage type, missing type,
+		// invalid parser, function as string, window as string — all must pass
+		// schema so validateLogJSONQuery can return actionable tips.
+		{
+			name: "filter query as SQL string passes schema (validate owns NOT SQL tip)",
+			stage: map[string]interface{}{
+				"type":  "filter",
+				"query": "SELECT * FROM logs WHERE SeverityText = 'ERROR'",
+			},
+		},
+		{
+			name: "type sort passes schema (validate owns unknown stage type tip)",
+			stage: map[string]interface{}{
+				"type": "sort",
+			},
+		},
+		{
+			name: "stage with no type passes schema (validate owns missing type tip)",
+			stage: map[string]interface{}{
+				"stage": "filter",
+				"query": map[string]interface{}{"$and": []interface{}{}},
+			},
+		},
+		{
+			name: "parser grok passes schema (validate owns invalid parser tip)",
+			stage: map[string]interface{}{
+				"type":   "parse",
+				"parser": "grok",
+			},
+		},
+		{
+			name: "function as string passes schema (validate owns function-must-be-object tip)",
+			stage: map[string]interface{}{
+				"type":     "window_aggregate",
+				"function": "$count",
+				"as":       "errors",
+				"window":   []interface{}{"1", "minutes"},
+			},
+		},
+		{
+			name: "window as string passes schema (validate owns window-must-be-array tip)",
+			stage: map[string]interface{}{
+				"type":     "window_aggregate",
+				"function": map[string]interface{}{"$count": []interface{}{}},
+				"as":       "errors",
+				"window":   "1m",
 			},
 		},
 	}

--- a/internal/telemetry/logs/schema_test.go
+++ b/internal/telemetry/logs/schema_test.go
@@ -148,8 +148,8 @@ func TestGetLogsArgs_LookbackDescriptionMatchesPromptDefault(t *testing.T) {
 }
 
 // TestGetLogsInputSchema_Structure verifies the hand-crafted GetLogsInputSchema
-// conforms to the expected shape: logjson_query required, oneOf stages,
-// window_aggregate has additionalProperties:false.
+// conforms to the expected shape: logjson_query required, anyOf stages,
+// root has additionalProperties:false (stage level does not).
 func TestGetLogsInputSchema_Structure(t *testing.T) {
 	schema := GetLogsInputSchema()
 
@@ -169,7 +169,7 @@ func TestGetLogsInputSchema_Structure(t *testing.T) {
 		t.Error("logjson_query must be in required")
 	}
 
-	// logjson_query must have items.oneOf with at least 4 stage schemas.
+	// logjson_query must have items.anyOf with at least 4 stage schemas.
 	props, ok := schema["properties"].(map[string]interface{})
 	if !ok {
 		t.Fatal("schema properties is not a map")
@@ -182,17 +182,19 @@ func TestGetLogsInputSchema_Structure(t *testing.T) {
 	if !ok {
 		t.Fatal("logjson_query items not an object")
 	}
-	oneOf, ok := items["oneOf"].([]interface{})
+	anyOf, ok := items["anyOf"].([]interface{})
 	if !ok {
-		t.Fatal("logjson_query items.oneOf missing or not a slice")
+		t.Fatal("logjson_query items.anyOf missing or not a slice")
 	}
-	if len(oneOf) < 4 {
-		t.Errorf("expected at least 4 stage schemas in oneOf, got %d", len(oneOf))
+	if len(anyOf) < 4 {
+		t.Errorf("expected at least 4 stage schemas in anyOf, got %d", len(anyOf))
 	}
 
-	// Find window_aggregate stage schema and verify additionalProperties: false.
+	// Find window_aggregate stage schema and verify its required fields.
+	// Stage-level additionalProperties: false is intentionally absent so handler
+	// tips (e.g. for window_minutes misuse) are reachable after schema validation.
 	found := false
-	for _, stageRaw := range oneOf {
+	for _, stageRaw := range anyOf {
 		stageMap, ok := stageRaw.(map[string]interface{})
 		if !ok {
 			continue
@@ -212,10 +214,11 @@ func TestGetLogsInputSchema_Structure(t *testing.T) {
 		for _, e := range enum {
 			if e == "window_aggregate" {
 				found = true
-				if stageMap["additionalProperties"] != false {
-					t.Error("window_aggregate stage schema must have additionalProperties: false")
+				// Stage-level additionalProperties: false is intentionally removed.
+				if stageMap["additionalProperties"] == false {
+					t.Error("window_aggregate stage schema must NOT have additionalProperties: false at stage level (handler tips must be reachable)")
 				}
-				// verify required fields
+				// Schema only requires "type"; validate owns function/as/window tips.
 				waRequired, ok := stageMap["required"].([]string)
 				if !ok {
 					t.Error("window_aggregate required is not []string")
@@ -225,9 +228,12 @@ func TestGetLogsInputSchema_Structure(t *testing.T) {
 				for _, r := range waRequired {
 					requiredSet[r] = true
 				}
-				for _, field := range []string{"type", "function", "as", "window"} {
-					if !requiredSet[field] {
-						t.Errorf("window_aggregate required must include %q", field)
+				if !requiredSet["type"] {
+					t.Error("window_aggregate required must include \"type\"")
+				}
+				for _, field := range []string{"function", "as", "window"} {
+					if requiredSet[field] {
+						t.Errorf("window_aggregate schema must not require %q (validate owns tips)", field)
 					}
 				}
 				break
@@ -235,7 +241,7 @@ func TestGetLogsInputSchema_Structure(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Error("window_aggregate stage schema not found in oneOf")
+		t.Error("window_aggregate stage schema not found in anyOf")
 	}
 
 	if schema["additionalProperties"] != false {
@@ -270,5 +276,102 @@ func TestGetLogsInputSchema_RejectsUnknownTopLevelKeys(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected top-level window_minutes to be rejected by additionalProperties:false")
+	}
+
+	// One valid document per stage type must pass schema validation.
+	validStages := []struct {
+		name  string
+		stage map[string]interface{}
+	}{
+		{
+			name: "filter",
+			stage: map[string]interface{}{
+				"type":  "filter",
+				"query": map[string]interface{}{"$and": []interface{}{map[string]interface{}{"$eq": []interface{}{"SeverityText", "ERROR"}}}},
+			},
+		},
+		{
+			name: "parse without field",
+			stage: map[string]interface{}{
+				"type":   "parse",
+				"parser": "json",
+			},
+		},
+		{
+			name: "aggregate",
+			stage: map[string]interface{}{
+				"type": "aggregate",
+				"aggregates": []interface{}{
+					map[string]interface{}{
+						"function": map[string]interface{}{"$count": []interface{}{}},
+						"as":       "log_count",
+					},
+				},
+			},
+		},
+		{
+			name: "window_aggregate",
+			stage: map[string]interface{}{
+				"type":     "window_aggregate",
+				"function": map[string]interface{}{"$count": []interface{}{}},
+				"as":       "errors",
+				"window":   []interface{}{"1", "minutes"},
+			},
+		},
+	}
+	for _, tt := range validStages {
+		t.Run(tt.name+" valid document passes", func(t *testing.T) {
+			err := resolved.Validate(map[string]interface{}{
+				"logjson_query": []interface{}{tt.stage},
+			})
+			if err != nil {
+				t.Errorf("valid %s stage document should pass schema validation: %v", tt.name, err)
+			}
+		})
+	}
+
+	// Flagship wrong-key mistakes must pass schema so handler tips are reachable.
+	tipReachable := []struct {
+		name  string
+		stage map[string]interface{}
+	}{
+		{
+			name: "window_minutes instead of window",
+			stage: map[string]interface{}{
+				"type":           "window_aggregate",
+				"function":       map[string]interface{}{"$count": []interface{}{}},
+				"as":             "errors",
+				"window_minutes": 1,
+			},
+		},
+		{
+			name: "format instead of parser",
+			stage: map[string]interface{}{
+				"type":   "parse",
+				"format": "json",
+				"field":  "Body",
+			},
+		},
+		{
+			name: "aggregates on window_aggregate",
+			stage: map[string]interface{}{
+				"type": "window_aggregate",
+				"aggregates": []interface{}{
+					map[string]interface{}{"function": map[string]interface{}{"$count": []interface{}{}}, "as": "c"},
+				},
+				"as":     "errors",
+				"window": []interface{}{"1", "minutes"},
+			},
+		},
+	}
+	for _, tt := range tipReachable {
+		t.Run(tt.name+" passes schema", func(t *testing.T) {
+			err := resolved.Validate(map[string]interface{}{
+				"logjson_query": []interface{}{tt.stage},
+			})
+			if err != nil {
+				t.Errorf("%s should pass schema so validate tips are reachable: %v", tt.name, err)
+			}
+		})
 	}
 }

--- a/internal/telemetry/logs/service_logs.go
+++ b/internal/telemetry/logs/service_logs.go
@@ -18,7 +18,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-
 // ServiceLogsResponse represents the response structure for service logs
 type ServiceLogsResponse struct {
 	Service       string     `json:"service"`

--- a/internal/telemetry/traces/traces.go
+++ b/internal/telemetry/traces/traces.go
@@ -35,7 +35,7 @@ func NewGetTracesHandler(client *http.Client, cfg models.Config) func(context.Co
 	return func(ctx context.Context, req *mcp.CallToolRequest, args GetTracesArgs) (*mcp.CallToolResult, any, error) {
 		// Check if tracejson_query is provided
 		if len(args.TracejsonQuery) == 0 {
-			return nil, nil, fmt.Errorf("tracejson_query parameter is required. Use the tracejson_query_builder prompt to generate JSON pipeline queries from natural language")
+			return nil, nil, fmt.Errorf("tracejson_query parameter is required. tracejson_query is a JSON array of stages (filter/parse/aggregate/window_aggregate) — see last9://reference/tracejson")
 		}
 
 		// Validate the pipeline before forwarding to the API

--- a/tools.go
+++ b/tools.go
@@ -134,6 +134,7 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config) error 
 	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
 		Name:        "get_logs",
 		Description: getLogsDesc,
+		InputSchema: logs.GetLogsInputSchema(),
 	}, logs.NewGetLogsHandler(client, cfg)))
 
 	// Register service logs tool


### PR DESCRIPTION
## Summary
- Align `get_logs` whale `window_aggregate` with last9/api (`function`/`as`/`window`) and add NOT-SQL / bare-field / order rules (ENG-1730, surgical ENG-1452/1410).
- Fail-closed pipeline validation before upstream or attrs fan-out; typed `LogPipelineValidationError`; `$and` wrap; thin `get_logs` InputSchema (ENG-1729 MVP + thin ENG-953).
- Fix traces lookback docs 5→60 (and matching `tracejson.md`); delete unused description stubs; point empty-query errors at `last9://reference/*`.

## Test plan
- [x] `go test ./internal/prompts/ ./internal/telemetry/logs/ ./ -count=1`
- [x] `dump-tools` vs main: candidate has no `window_minutes`, has NOT SQL + InputSchema oneOf
- [x] Live MCP: canonical WA succeeds; `window_minutes` / SpanKind / bad parse reject locally
- [x] Companion evals: https://github.com/last9/last9-mcp-evals/pull/49 — 50/50 on candidate; WA cases fail on main

Linear: ENG-1730, ENG-1729 (MVP), ENG-1452 (surgical), ENG-953 (thin get_logs), ENG-1410


Made with [Cursor](https://cursor.com)

**Deferred:** stage ordering (filter→parse→aggregate) is documented in the whale/`logjson` manual but not enforced by `validateLogJSONQuery` (MVP).

**Review follow-up (`8d53762`):** tip-reachable schema (`anyOf`, no stage `additionalProperties:false`, loose parse/WA `required`), allow TraceId/SpanId/ParentSpanId, default parse `field`→Body, dotted labels via `safeBodyKeyPattern`, typed sanitize errors, CHANGELOG + whale budget tighten.
