### PR TITLE
fix(mcp): compile last9/api fetches and structured log search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `get_logs` fail-closed logjson validation with self-correcting tips (wrong keys/types, bare fields, NOT-SQL, bad parse/`window_aggregate` shapes); whale description aligned with API `window_aggregate`; missing parse `field` defaults to `Body`; `TraceId`/`SpanId`/`ParentSpanId` allowed for log↔trace correlation; dotted parse labels accepted; `tracejson.md` lookback default corrected to 60 (#212).
 - Log-query `400`/`422` responses now use the shared upstream sanitizer (URL/credential redaction, 512-byte truncation with `… (truncated)`) instead of echoing the raw body. `get_logs` / `get_service_logs` also append the pipeline schema hint pointing at `get_log_attributes_for_pipeline` (#213).
+- `get_logs` fail-closed logjson validation with self-correcting tips (wrong keys/types, bare fields, NOT-SQL, bad parse/`window_aggregate` shapes); whale description aligned with API `window_aggregate`; missing parse `field` defaults to `Body`; `TraceId`/`SpanId`/`ParentSpanId` allowed for log↔trace correlation; dotted parse labels accepted; `tracejson.md` lookback default corrected to 60 (#212).
 
 ### Changed
 
+- **Breaking:** a failed later time-chunk on `get_logs`, `get_service_logs`, or `get_traces` is a tool error. The previous `partial_result` / `_last9_mcp` merge-and-continue envelope is gone; clients that treated a truncated merge as success must handle the error. Declared truncation (`get_trace_waterfall` evidence, `get_apm_service_deviations` `partial_errors`) is unchanged (#213).
+- `get_service_logs` accepts `http_status_class`, `http_status_code`, optional `http_status_field`, and `attribute_filters`, and echoes the resolved status field as `http_status_field`. Known-service HTTP status search should use this tool, not `get_logs` (#213).
+- `get_service_performance_details` now records per-section PromQL HTTP failures in a new `partial_errors` field and still returns surviving metrics. Transport errors still fail the whole tool (#213).
 - `get_logs` InputSchema uses a permissive stage `anyOf` (plus catch-all) so handler validation tips reach the model instead of opaque SDK `anyOf` errors (#212).
 - **Breaking:** `get_service_summary` response shape is now a ranked `{rows: [...]}` envelope with snake_case fields (`request_count`, `throughput_rpm`, `http_4xx_count`, `http_5xx_count`, `grpc_error_count`) instead of a `map[string]ServiceSummary` with PascalCase keys (`ErrorRate`, etc.). Rows are `(service, env)` pairs sorted and limited server-side; clients that unmarshal the old map shape will fail and should be updated (#210).
-- **Breaking:** a failed later time-chunk on `get_logs`, `get_service_logs`, or `get_traces` is a tool error. The previous `partial_result` / `_last9_mcp` merge-and-continue envelope is gone; clients that treated a truncated merge as success must handle the error. Declared truncation (`get_trace_waterfall` evidence, `get_apm_service_deviations` / `get_service_performance_details` `partial_errors`) is unchanged (#213).
-- `get_service_logs` accepts `http_status_class`, `http_status_code`, optional `http_status_field`, and `attribute_filters`, and echoes the resolved status field as `http_status_field`. Known-service HTTP status search should use this tool, not `get_logs` (#213).
-- `get_service_performance_details` records per-section PromQL HTTP failures in `partial_errors` and still returns surviving metrics. Transport errors still fail the whole tool (#213).
 
 ## [0.15.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `get_logs` fail-closed logjson validation with self-correcting tips (wrong keys/types, bare fields, NOT-SQL, bad parse/`window_aggregate` shapes); whale description aligned with API `window_aggregate`; missing parse `field` defaults to `Body`; `TraceId`/`SpanId`/`ParentSpanId` allowed for log↔trace correlation; dotted parse labels accepted; `tracejson.md` lookback default corrected to 60 (#212).
+- Log-query `400`/`422` responses now use the shared upstream sanitizer (URL/credential redaction, 512-byte truncation with `… (truncated)`) instead of echoing the raw body. `get_logs` / `get_service_logs` also append the pipeline schema hint pointing at `get_log_attributes_for_pipeline` (#213).
 
 ### Changed
 
 - `get_logs` InputSchema uses a permissive stage `anyOf` (plus catch-all) so handler validation tips reach the model instead of opaque SDK `anyOf` errors (#212).
 - **Breaking:** `get_service_summary` response shape is now a ranked `{rows: [...]}` envelope with snake_case fields (`request_count`, `throughput_rpm`, `http_4xx_count`, `http_5xx_count`, `grpc_error_count`) instead of a `map[string]ServiceSummary` with PascalCase keys (`ErrorRate`, etc.). Rows are `(service, env)` pairs sorted and limited server-side; clients that unmarshal the old map shape will fail and should be updated (#210).
+- **Breaking:** a failed later time-chunk on `get_logs`, `get_service_logs`, or `get_traces` is a tool error. The previous `partial_result` / `_last9_mcp` merge-and-continue envelope is gone; clients that treated a truncated merge as success must handle the error. Declared truncation (`get_trace_waterfall` evidence, `get_apm_service_deviations` / `get_service_performance_details` `partial_errors`) is unchanged (#213).
+- `get_service_logs` accepts `http_status_class`, `http_status_code`, optional `http_status_field`, and `attribute_filters`, and echoes the resolved status field as `http_status_field`. Known-service HTTP status search should use this tool, not `get_logs` (#213).
+- `get_service_performance_details` records per-section PromQL HTTP failures in `partial_errors` and still returns surviving metrics. Transport errors still fail the whole tool (#213).
 
 ## [0.15.0] - 2026-08-10
 

--- a/dump_test.go
+++ b/dump_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"last9-mcp/internal/apm"
+	"last9-mcp/internal/prompts"
 	"last9-mcp/internal/toolsets"
 )
 
@@ -161,6 +162,22 @@ func TestDumpTools(t *testing.T) {
 		t.Fatal("get_service_logs description must document HTTP status filters")
 	}
 
+	excIdx, ok := byName["get_exceptions"]
+	if !ok {
+		t.Fatal("tool \"get_exceptions\" missing from dump")
+	}
+	excDesc := out.Tools[excIdx].Description
+	if !strings.Contains(excDesc, "get_service_logs") || !strings.Contains(excDesc, "http_status") {
+		t.Fatal("get_exceptions must route HTTP-status log search to get_service_logs")
+	}
+	if strings.Contains(excDesc, "write a `get_logs` pipeline") && !strings.Contains(excDesc, "Do not write a `get_logs` pipeline") {
+		t.Fatal("get_exceptions must not send HTTP-status log search to get_logs")
+	}
+
+	if !strings.Contains(logsDesc, "get_service_logs") {
+		t.Fatal("get_logs whale must name get_service_logs as the structured HTTP-status alternative")
+	}
+
 	tracesDesc := out.Tools[byName["get_traces"]].Description
 	if strings.Contains(tracesDesc, "default **5**") {
 		t.Fatal("get_traces lookback default must match GetTracesArgs (60), not 5")
@@ -285,5 +302,18 @@ func TestDumpToolsInvestigate(t *testing.T) {
 	}
 	if len(out.Tools) >= 38 {
 		t.Fatalf("investigate should expose fewer than full surface; got %d", len(out.Tools))
+	}
+}
+
+func TestOnCallRunbookRoutesHTTPStatusToServiceLogs(t *testing.T) {
+	runbook := prompts.OnCallRunbookWorkflow
+	if !strings.Contains(runbook, "get_service_logs") {
+		t.Fatal("on_call_runbook must name get_service_logs for status-class log search")
+	}
+	if !strings.Contains(runbook, "http_status_class") {
+		t.Fatal("on_call_runbook must send HTTP-status log search to get_service_logs, not logjson")
+	}
+	if strings.Contains(runbook, "write logjson") && !strings.Contains(runbook, "do not write logjson") {
+		t.Fatal("on_call_runbook must not tell the agent to write logjson for service 5xx")
 	}
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -151,6 +151,22 @@ func TestDumpTools(t *testing.T) {
 		}
 	}
 
+	tracesDesc := out.Tools[byName["get_traces"]].Description
+	if strings.Contains(tracesDesc, "window_minutes") {
+		t.Fatal("get_traces description must not teach window_minutes; window_aggregate uses function/as/window")
+	}
+	for _, needle := range []string{`"function"`, `"as"`, `"window"`} {
+		if !strings.Contains(tracesDesc, needle) {
+			t.Fatalf("get_traces description missing last9/api window_aggregate key %s", needle)
+		}
+	}
+	if strings.Contains(tracesDesc, "default **5**") {
+		t.Fatal("get_traces lookback default must match GetTracesArgs (60), not 5")
+	}
+	if !strings.Contains(tracesDesc, "default **60**") {
+		t.Fatal("get_traces description missing lookback default 60")
+	}
+
 	svcLogsDesc := out.Tools[byName["get_service_logs"]].Description
 	if strings.Contains(svcLogsDesc, "Prefer `get_logs` instead when") {
 		t.Fatal("get_service_logs must not tell agents to prefer get_logs for HTTP status")
@@ -176,14 +192,6 @@ func TestDumpTools(t *testing.T) {
 
 	if !strings.Contains(logsDesc, "get_service_logs") {
 		t.Fatal("get_logs whale must name get_service_logs as the structured HTTP-status alternative")
-	}
-
-	tracesDesc := out.Tools[byName["get_traces"]].Description
-	if strings.Contains(tracesDesc, "default **5**") {
-		t.Fatal("get_traces lookback default must match GetTracesArgs (60), not 5")
-	}
-	if !strings.Contains(tracesDesc, "default **60**") {
-		t.Fatal("get_traces description missing lookback default 60")
 	}
 
 	perfIdx, ok := byName["get_service_performance_details"]

--- a/dump_test.go
+++ b/dump_test.go
@@ -140,6 +140,36 @@ func TestDumpTools(t *testing.T) {
 		t.Fatal("prometheus_range_query description missing metrics resource URI pointer")
 	}
 
+	logsDesc := out.Tools[byName["get_logs"]].Description
+	if strings.Contains(logsDesc, "window_minutes") {
+		t.Fatal("get_logs description must not teach window_minutes; window_aggregate uses function/as/window")
+	}
+	for _, needle := range []string{`"function"`, `"as"`, `"window"`} {
+		if !strings.Contains(logsDesc, needle) {
+			t.Fatalf("get_logs description missing last9/api window_aggregate key %s", needle)
+		}
+	}
+
+	tracesDesc := out.Tools[byName["get_traces"]].Description
+	if strings.Contains(tracesDesc, "default **5**") {
+		t.Fatal("get_traces lookback default must match GetTracesArgs (60), not 5")
+	}
+	if !strings.Contains(tracesDesc, "default **60**") {
+		t.Fatal("get_traces description missing lookback default 60")
+	}
+
+	perfIdx, ok := byName["get_service_performance_details"]
+	if !ok {
+		t.Fatal("tool \"get_service_performance_details\" missing from dump")
+	}
+	perfDesc := out.Tools[perfIdx].Description
+	if strings.Contains(perfDesc, "get_service_operation_details") {
+		t.Fatal("get_service_performance_details names nonexistent get_service_operation_details")
+	}
+	if !strings.Contains(perfDesc, "get_service_operations_summary") {
+		t.Fatal("get_service_performance_details must point at get_service_operations_summary")
+	}
+
 	deviationsIndex, ok := byName["get_apm_service_deviations"]
 	if !ok {
 		t.Fatal("tool \"get_apm_service_deviations\" missing from dump")

--- a/dump_test.go
+++ b/dump_test.go
@@ -150,6 +150,17 @@ func TestDumpTools(t *testing.T) {
 		}
 	}
 
+	svcLogsDesc := out.Tools[byName["get_service_logs"]].Description
+	if strings.Contains(svcLogsDesc, "Prefer `get_logs` instead when") {
+		t.Fatal("get_service_logs must not tell agents to prefer get_logs for HTTP status")
+	}
+	if strings.Contains(strings.ToLower(svcLogsDesc), "use `get_logs` + discovered status") {
+		t.Fatal("get_service_logs must not send HTTP-status search to get_logs")
+	}
+	if !strings.Contains(svcLogsDesc, "http_status") {
+		t.Fatal("get_service_logs description must document HTTP status filters")
+	}
+
 	tracesDesc := out.Tools[byName["get_traces"]].Description
 	if strings.Contains(tracesDesc, "default **5**") {
 		t.Fatal("get_traces lookback default must match GetTracesArgs (60), not 5")

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -274,7 +274,10 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		}
 		defer httpResp.Body.Close()
 
-		if httpResp.StatusCode == http.StatusOK {
+		if httpResp.StatusCode != http.StatusOK {
+			return nil, nil, promErr(httpResp, "service performance details")
+		}
+		{
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
@@ -297,7 +300,10 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		}
 		defer httpResp.Body.Close()
 
-		if httpResp.StatusCode == http.StatusOK {
+		if httpResp.StatusCode != http.StatusOK {
+			return nil, nil, promErr(httpResp, "service performance details")
+		}
+		{
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
@@ -320,7 +326,10 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		}
 		defer httpResp.Body.Close()
 
-		if httpResp.StatusCode == http.StatusOK {
+		if httpResp.StatusCode != http.StatusOK {
+			return nil, nil, promErr(httpResp, "service performance details")
+		}
+		{
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
@@ -343,7 +352,10 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		}
 		defer httpResp.Body.Close()
 
-		if httpResp.StatusCode == http.StatusOK {
+		if httpResp.StatusCode != http.StatusOK {
+			return nil, nil, promErr(httpResp, "service performance details")
+		}
+		{
 			// read response body to byte array
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
@@ -367,7 +379,10 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		}
 		defer httpResp.Body.Close()
 
-		if httpResp.StatusCode == http.StatusOK {
+		if httpResp.StatusCode != http.StatusOK {
+			return nil, nil, promErr(httpResp, "service performance details")
+		}
+		{
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
@@ -389,7 +404,10 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		}
 		defer httpResp.Body.Close()
 
-		if httpResp.StatusCode == http.StatusOK {
+		if httpResp.StatusCode != http.StatusOK {
+			return nil, nil, promErr(httpResp, "service performance details")
+		}
+		{
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
@@ -411,7 +429,10 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		}
 		defer httpResp.Body.Close()
 
-		if httpResp.StatusCode == http.StatusOK {
+		if httpResp.StatusCode != http.StatusOK {
+			return nil, nil, promErr(httpResp, "service performance details")
+		}
+		{
 			var topErrResp apiPromInstantResp
 			if err := json.NewDecoder(httpResp.Body).Decode(&topErrResp); err == nil {
 				details.TopOperations.ByResponseTime = make([]map[string]float64, 0)
@@ -450,7 +471,10 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		}
 		defer httpResp.Body.Close()
 
-		if httpResp.StatusCode == http.StatusOK {
+		if httpResp.StatusCode != http.StatusOK {
+			return nil, nil, promErr(httpResp, "service performance details")
+		}
+		{
 			var topErrResp apiPromInstantResp
 			if err := json.NewDecoder(httpResp.Body).Decode(&topErrResp); err == nil {
 				details.TopOperations.ByErrorRate = make([]map[string]int64, 0)
@@ -488,7 +512,10 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 			return nil, nil, err
 		}
 		defer httpResp.Body.Close()
-		if httpResp.StatusCode == http.StatusOK {
+		if httpResp.StatusCode != http.StatusOK {
+			return nil, nil, promErr(httpResp, "service performance details")
+		}
+		{
 			var topErrResp apiPromInstantResp
 			if err := json.NewDecoder(httpResp.Body).Decode(&topErrResp); err == nil {
 				details.TopErrors = make([]map[string]int64, 0)
@@ -561,7 +588,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var promResp apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&promResp); err != nil {
@@ -579,7 +606,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var respTimeRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&respTimeRaw); err != nil {
@@ -598,7 +625,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var errorRateRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&errorRateRaw); err != nil {
@@ -616,7 +643,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var dbThroughputRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&dbThroughputRaw); err != nil {
@@ -634,7 +661,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var dbRespTimeRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&dbRespTimeRaw); err != nil {
@@ -668,7 +695,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var dbErrorRateRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&dbErrorRateRaw); err != nil {
@@ -686,7 +713,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var httpThroughputRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&httpThroughputRaw); err != nil {
@@ -704,7 +731,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var httpRespTimeRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&httpRespTimeRaw); err != nil {
@@ -736,7 +763,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var httpErrorRateRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&httpErrorRateRaw); err != nil {
@@ -754,7 +781,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var messagingThroughputRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&messagingThroughputRaw); err != nil {
@@ -772,7 +799,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var messagingRespTimeRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&messagingRespTimeRaw); err != nil {
@@ -804,7 +831,7 @@ func NewServiceOperationsSummaryHandler(client *http.Client, cfg models.Config) 
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service operations summary: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service operations summary")
 		}
 		var messagingErrorRateRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&messagingErrorRateRaw); err != nil {
@@ -1124,7 +1151,7 @@ func NewServiceDependencyGraphHandler(client *http.Client, cfg models.Config) fu
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service dependency graph details: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service dependency graph")
 		}
 		var incomingThroughputRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&incomingThroughputRaw); err != nil {
@@ -1141,7 +1168,7 @@ func NewServiceDependencyGraphHandler(client *http.Client, cfg models.Config) fu
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service dependency graph details: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service dependency graph")
 		}
 		var incomingRespTimeRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&incomingRespTimeRaw); err != nil {
@@ -1158,7 +1185,7 @@ func NewServiceDependencyGraphHandler(client *http.Client, cfg models.Config) fu
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service dependency graph details: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service dependency graph")
 		}
 		var incomingErrorRateRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&incomingErrorRateRaw); err != nil {
@@ -1234,7 +1261,7 @@ func NewServiceDependencyGraphHandler(client *http.Client, cfg models.Config) fu
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service dependency graph details: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service dependency graph")
 		}
 		var outgoingThroughputRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&outgoingThroughputRaw); err != nil {
@@ -1251,7 +1278,7 @@ func NewServiceDependencyGraphHandler(client *http.Client, cfg models.Config) fu
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service dependency graph details: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service dependency graph")
 		}
 		var outgoingRespTimeRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&outgoingRespTimeRaw); err != nil {
@@ -1268,7 +1295,7 @@ func NewServiceDependencyGraphHandler(client *http.Client, cfg models.Config) fu
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service dependency graph details: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service dependency graph")
 		}
 		var outgoingErrorRateRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&outgoingErrorRateRaw); err != nil {
@@ -1345,7 +1372,7 @@ func NewServiceDependencyGraphHandler(client *http.Client, cfg models.Config) fu
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service dependency graph details: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service dependency graph")
 		}
 		var infrastructureThroughputRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&infrastructureThroughputRaw); err != nil {
@@ -1362,7 +1389,7 @@ func NewServiceDependencyGraphHandler(client *http.Client, cfg models.Config) fu
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service dependency graph details: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service dependency graph")
 		}
 		var infrastructureRespTimeRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&infrastructureRespTimeRaw); err != nil {
@@ -1379,7 +1406,7 @@ func NewServiceDependencyGraphHandler(client *http.Client, cfg models.Config) fu
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to get service dependency graph details: %s", httpResp.Status)
+			return nil, nil, promErr(httpResp, "service dependency graph")
 		}
 		var infrastructureErrorRateRaw apiPromInstantResp
 		if err := json.NewDecoder(httpResp.Body).Decode(&infrastructureErrorRateRaw); err != nil {
@@ -1544,6 +1571,15 @@ func resolveDatasourceCfg(cfg models.Config, datasourceName string) (models.Conf
 	return cfg, nil
 }
 
+func promToolError(resp *http.Response, op string) (*mcp.CallToolResult, any, error) {
+	err := utils.NewUpstreamHTTPError(resp, op)
+	return utils.ToolErrorResult(err.Error()), nil, nil
+}
+
+func promErr(resp *http.Response, op string) error {
+	return utils.NewUpstreamHTTPError(resp, op)
+}
+
 func NewPromqlRangeQueryHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, PromqlRangeQueryArgs) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, args PromqlRangeQueryArgs) (*mcp.CallToolResult, any, error) {
 		query := args.Query
@@ -1568,10 +1604,10 @@ func NewPromqlRangeQueryHandler(client *http.Client, cfg models.Config) func(con
 		if httpResp == nil {
 			return nil, nil, fmt.Errorf("received nil response from Prometheus")
 		}
-		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to execute Prometheus range query: %s", httpResp.Status)
-		}
 		defer httpResp.Body.Close()
+		if httpResp.StatusCode != http.StatusOK {
+			return promToolError(httpResp, "Prometheus range query")
+		}
 		// return the response body string as the content without parsing
 		responseBodyBytes, err := io.ReadAll(httpResp.Body)
 		if err != nil {
@@ -1612,10 +1648,10 @@ func NewPromqlInstantQueryHandler(client *http.Client, cfg models.Config) func(c
 		if httpResp == nil {
 			return nil, nil, fmt.Errorf("received nil response from Prometheus")
 		}
-		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to execute Prometheus instant query: %s", httpResp.Status)
-		}
 		defer httpResp.Body.Close()
+		if httpResp.StatusCode != http.StatusOK {
+			return promToolError(httpResp, "Prometheus instant query")
+		}
 		responseBodyBytes, err := io.ReadAll(httpResp.Body)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to read response body: %w", err)
@@ -1654,10 +1690,10 @@ func NewServiceEnvironmentsHandler(client *http.Client, cfg models.Config) func(
 		if httpResp == nil {
 			return nil, nil, fmt.Errorf("received nil response from Prometheus")
 		}
-		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to execute Prometheus label values query: %s", httpResp.Status)
-		}
 		defer httpResp.Body.Close()
+		if httpResp.StatusCode != http.StatusOK {
+			return promToolError(httpResp, "Prometheus label values")
+		}
 		// Read the response body
 		responseBodyBytes, err := io.ReadAll(httpResp.Body)
 		if err != nil {
@@ -1702,10 +1738,10 @@ func NewPromqlLabelValuesHandler(client *http.Client, cfg models.Config) func(co
 		if httpResp == nil {
 			return nil, nil, fmt.Errorf("received nil response from Prometheus")
 		}
-		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to execute Prometheus range query: %s", httpResp.Status)
-		}
 		defer httpResp.Body.Close()
+		if httpResp.StatusCode != http.StatusOK {
+			return promToolError(httpResp, "Prometheus range query")
+		}
 		// return the response body string as the content without parsing
 		responseBodyBytes, err := io.ReadAll(httpResp.Body)
 		if err != nil {
@@ -1745,10 +1781,10 @@ func NewPromqlLabelsHandler(client *http.Client, cfg models.Config) func(context
 		if httpResp == nil {
 			return nil, nil, fmt.Errorf("received nil response from Prometheus")
 		}
-		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, fmt.Errorf("failed to execute Prometheus range query: %s", httpResp.Status)
-		}
 		defer httpResp.Body.Close()
+		if httpResp.StatusCode != http.StatusOK {
+			return promToolError(httpResp, "Prometheus range query")
+		}
 		// return the response body string as the content without parsing
 		responseBodyBytes, err := io.ReadAll(httpResp.Body)
 		if err != nil {

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -234,7 +234,8 @@ type ServicePerformanceDetails struct {
 		ByResponseTime []map[string]float64 `json:"by_response_time"`
 		ByErrorRate    []map[string]int64   `json:"by_error_rate"`
 	} `json:"top_operations"`
-	TopErrors []map[string]int64 `json:"top_errors"`
+	TopErrors     []map[string]int64 `json:"top_errors"`
+	PartialErrors []string           `json:"partial_errors,omitempty"`
 }
 
 func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, ServicePerformanceDetailsArgs) (*mcp.CallToolResult, any, error) {
@@ -275,9 +276,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		defer httpResp.Body.Close()
 
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, promErr(httpResp, "service performance details")
-		}
-		{
+			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details apdex").Error())
+		} else {
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
@@ -301,9 +301,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		defer httpResp.Body.Close()
 
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, promErr(httpResp, "service performance details")
-		}
-		{
+			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details response_times").Error())
+		} else {
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
@@ -327,9 +326,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		defer httpResp.Body.Close()
 
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, promErr(httpResp, "service performance details")
-		}
-		{
+			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details availability").Error())
+		} else {
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
@@ -353,9 +351,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		defer httpResp.Body.Close()
 
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, promErr(httpResp, "service performance details")
-		}
-		{
+			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details throughput").Error())
+		} else {
 			// read response body to byte array
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
@@ -380,9 +377,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		defer httpResp.Body.Close()
 
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, promErr(httpResp, "service performance details")
-		}
-		{
+			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details error_rate").Error())
+		} else {
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
@@ -405,9 +401,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		defer httpResp.Body.Close()
 
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, promErr(httpResp, "service performance details")
-		}
-		{
+			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details error_percent").Error())
+		} else {
 			data, err := io.ReadAll(httpResp.Body)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
@@ -430,9 +425,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		defer httpResp.Body.Close()
 
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, promErr(httpResp, "service performance details")
-		}
-		{
+			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details top_operations_by_response_time").Error())
+		} else {
 			var topErrResp apiPromInstantResp
 			if err := json.NewDecoder(httpResp.Body).Decode(&topErrResp); err == nil {
 				details.TopOperations.ByResponseTime = make([]map[string]float64, 0)
@@ -472,9 +466,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		defer httpResp.Body.Close()
 
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, promErr(httpResp, "service performance details")
-		}
-		{
+			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details top_operations_by_error_rate").Error())
+		} else {
 			var topErrResp apiPromInstantResp
 			if err := json.NewDecoder(httpResp.Body).Decode(&topErrResp); err == nil {
 				details.TopOperations.ByErrorRate = make([]map[string]int64, 0)
@@ -513,9 +506,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return nil, nil, promErr(httpResp, "service performance details")
-		}
-		{
+			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details top_errors").Error())
+		} else {
 			var topErrResp apiPromInstantResp
 			if err := json.NewDecoder(httpResp.Body).Decode(&topErrResp); err == nil {
 				details.TopErrors = make([]map[string]int64, 0)
@@ -1740,7 +1732,7 @@ func NewPromqlLabelValuesHandler(client *http.Client, cfg models.Config) func(co
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return promToolError(httpResp, "Prometheus range query")
+			return promToolError(httpResp, "Prometheus label values")
 		}
 		// return the response body string as the content without parsing
 		responseBodyBytes, err := io.ReadAll(httpResp.Body)
@@ -1783,7 +1775,7 @@ func NewPromqlLabelsHandler(client *http.Client, cfg models.Config) func(context
 		}
 		defer httpResp.Body.Close()
 		if httpResp.StatusCode != http.StatusOK {
-			return promToolError(httpResp, "Prometheus range query")
+			return promToolError(httpResp, "Prometheus labels")
 		}
 		// return the response body string as the content without parsing
 		responseBodyBytes, err := io.ReadAll(httpResp.Body)

--- a/internal/apm/apm_test.go
+++ b/internal/apm/apm_test.go
@@ -636,3 +636,98 @@ func TestServiceEnvironmentsHandler_FilterUsesServiceName(t *testing.T) {
 		t.Fatalf("expected service_name=\"checkout\" in matches, got: %v", captured)
 	}
 }
+
+func TestPromqlRangeQueryRelays400AndDrains502(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		body       string
+		wantSubstr string
+		forbid     string
+	}{
+		{
+			name:       "400 includes parse body",
+			status:     http.StatusBadRequest,
+			body:       `{"error":"parse error: unexpected identifier \"foo\""}`,
+			wantSubstr: "parse error",
+		},
+		{
+			name:       "502 omits body",
+			status:     http.StatusBadGateway,
+			body:       `{"error":"gateway SECRET"}`,
+			wantSubstr: "HTTP 502",
+			forbid:     "SECRET",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			cfg := models.Config{
+				APIBaseURL: server.URL,
+				Region:     "us-east-1",
+				TokenManager: &auth.TokenManager{
+					AccessToken: "test-token",
+					ExpiresAt:   time.Now().Add(24 * time.Hour),
+				},
+			}
+			handler := NewPromqlRangeQueryHandler(server.Client(), cfg)
+			result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, PromqlRangeQueryArgs{
+				Query:           "up",
+				LookbackMinutes: 5,
+			})
+			if err != nil {
+				t.Fatalf("handler returned Go error %v; want IsError result", err)
+			}
+			if result == nil || !result.IsError {
+				t.Fatal("expected IsError result")
+			}
+			text := result.Content[0].(*mcp.TextContent).Text
+			if !strings.Contains(text, tt.wantSubstr) {
+				t.Fatalf("error %q missing %q", text, tt.wantSubstr)
+			}
+			if tt.forbid != "" && strings.Contains(text, tt.forbid) {
+				t.Fatalf("error leaked %q: %s", tt.forbid, text)
+			}
+		})
+	}
+}
+
+func TestServicePerformanceDetailsAnyPromFailureIsError(t *testing.T) {
+	var n atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if n.Add(1) == 1 {
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `[]`)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"bad selector"}`)
+	}))
+	defer server.Close()
+
+	cfg := models.Config{
+		APIBaseURL: server.URL,
+		Region:     "us-east-1",
+		TokenManager: &auth.TokenManager{
+			AccessToken: "test-token",
+			ExpiresAt:   time.Now().Add(24 * time.Hour),
+		},
+	}
+	handler := NewServicePerformanceDetailsHandler(server.Client(), cfg)
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ServicePerformanceDetailsArgs{
+		ServiceName:     "checkout",
+		Env:             "prod",
+		LookbackMinutes: 15,
+	})
+	if err == nil {
+		t.Fatal("expected error when a PromQL call fails")
+	}
+	if !strings.Contains(err.Error(), "bad selector") {
+		t.Fatalf("expected 400 body in error, got %v", err)
+	}
+}

--- a/internal/apm/apm_test.go
+++ b/internal/apm/apm_test.go
@@ -697,7 +697,7 @@ func TestPromqlRangeQueryRelays400AndDrains502(t *testing.T) {
 	}
 }
 
-func TestServicePerformanceDetailsAnyPromFailureIsError(t *testing.T) {
+func TestServicePerformanceDetailsPromFailureRecordsPartialErrors(t *testing.T) {
 	var n atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if n.Add(1) == 1 {
@@ -719,15 +719,24 @@ func TestServicePerformanceDetailsAnyPromFailureIsError(t *testing.T) {
 		},
 	}
 	handler := NewServicePerformanceDetailsHandler(server.Client(), cfg)
-	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ServicePerformanceDetailsArgs{
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ServicePerformanceDetailsArgs{
 		ServiceName:     "checkout",
 		Env:             "prod",
 		LookbackMinutes: 15,
 	})
-	if err == nil {
-		t.Fatal("expected error when a PromQL call fails")
+	if err != nil {
+		t.Fatalf("HTTP PromQL failures should stay in partial_errors, got Go error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "bad selector") {
-		t.Fatalf("expected 400 body in error, got %v", err)
+	text := utils.GetTextContent(t, result)
+	var details ServicePerformanceDetails
+	if err := json.Unmarshal([]byte(text), &details); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	joined := strings.Join(details.PartialErrors, "\n")
+	if !strings.Contains(joined, "bad selector") {
+		t.Fatalf("expected sanitized 400 body in partial_errors, got %#v", details.PartialErrors)
+	}
+	if details.ServiceName != "checkout" {
+		t.Fatalf("surviving payload missing service_name, got %#v", details)
 	}
 }

--- a/internal/apm/service_summary.go
+++ b/internal/apm/service_summary.go
@@ -286,7 +286,7 @@ func fetchPromInstantSeries(ctx context.Context, client *http.Client, cfg models
 	}
 	defer httpResp.Body.Close()
 	if httpResp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get service summary %s: %s", classKey, httpResp.Status)
+		return nil, promErr(httpResp, "service summary "+classKey)
 	}
 	var parsed apiPromInstantResp
 	if err := json.NewDecoder(httpResp.Body).Decode(&parsed); err != nil {

--- a/internal/prompts/descriptions/get_exceptions.md
+++ b/internal/prompts/descriptions/get_exceptions.md
@@ -31,6 +31,9 @@ Investigation flow — follow this exactly:
      a `limit` — a handful of lines is enough to read the error, and an unlimited
      raw fetch is what times out. Use `get_service_logs` or a non-aggregate
      `get_logs`. Report the actual error text you read.
+   - For HTTP 4xx/5xx log search, call `get_service_logs` with `http_status_class`
+     or `http_status_code`. Do not write a `get_logs` pipeline for service
+     status-class questions.
 
 limit: (Optional) The maximum number of exceptions to return. Defaults to 20.
 lookback_minutes: (Recommended) Number of minutes to look back from now. Default: 60 minutes.

--- a/internal/prompts/descriptions/get_logs_base.md
+++ b/internal/prompts/descriptions/get_logs_base.md
@@ -19,7 +19,7 @@
 
 **Free-text IDs** (EPL_…) → `{"$contains":["Body","…"]}` — not `ServiceName`.
 
-**HTTP 5xx:** filter status field with literal code (e.g. `$eq` on `attributes['status_code']`, `"500"`) — never `SeverityText`/`ERROR`; avoid regex-only when user names a code.
+**HTTP 5xx:** known service → `get_service_logs` (`http_status_class`/`http_status_code`). Ad-hoc: `$eq` on discovered status field — never `SeverityText`.
 
 **Time:** `lookback_minutes` (default **5**). **Absolute ISO bounds** → `start_time_iso`+`end_time_iso` on the tool call — never `Timestamp`/`$gte`/`$lte` in the pipeline.
 

--- a/internal/prompts/descriptions/get_service_logs_base.md
+++ b/internal/prompts/descriptions/get_service_logs_base.md
@@ -1,10 +1,12 @@
-Fetch raw log lines for one service (`service_name`, optional `severity_filters`, `body_filters`, `env`, `index`, `limit`).
+Fetch raw log lines for one service (`service_name`, optional `severity_filters`, `body_filters`, `http_status_class`/`http_status_code`, `attribute_filters`, `env`, `index`, `limit`).
 
-**Use this tool when:** filtering by log severity levels (`severity_filters`: error/warn/fatal) or plain-text message search (`body_filters`) for a single known service—no pipeline needed.
+**Use this tool when:** filtering one known service by severity, HTTP status, named attributes, or plain-text `body_filters`—no pipeline needed.
 
-**Prefer `get_logs` instead when:** filtering HTTP/gRPC status, user IDs, latency, URIs, or any structured attribute. Discover fields with `get_log_attributes` / `get_log_attributes_for_pipeline`, then call `get_logs` with a `logjson_query`. Indexed attribute filters beat `body_filters`.
+**HTTP status:** Pass `http_status_class` (`5xx`) or `http_status_code` (`500`). This tool discovers the status field for the service/env/window. If discovery finds none or more than one, pass `http_status_field` (e.g. `attributes['http.status_code']`). Severity is not an HTTP-error proxy (5xx often INFO)—do not use `severity_filters` for status.
 
-**HTTP errors:** Severity is not an HTTP-error proxy (5xx often INFO). Use `get_logs` + discovered status field—not `severity_filters`/`SeverityText`.
+**Named attributes:** `attribute_filters` is `[{field, value}]` equality. `field` uses logjson syntax (`attributes['user_id']`). Invalid syntax is rejected; unknown org fields are allowed. Discover names with `get_log_attributes` / `get_log_attributes_for_pipeline` if unsure.
+
+**Prefer `get_logs` when:** you need parse/aggregate/`window_aggregate`, or an ad-hoc pipeline.
 
 **Time:** Prefer `lookback_minutes` for relative windows; `start_time_iso`+`end_time_iso` (RFC3339) for absolute. Pass `index` only when the user names one (`physical_index:<name>` / `rehydration_index:<block>`).
 

--- a/internal/prompts/descriptions/get_service_performance_details.md
+++ b/internal/prompts/descriptions/get_service_performance_details.md
@@ -2,7 +2,7 @@ Service performance metrics over a time range.
 
 Returns: service name, env, throughput (rpm), error rate (rpm, 4xx/5xx), error percentage, response times in seconds (p50, p90, p95, avg, max), apdex score, availability (%), top 10 operations by response time and error rate, top 10 errors/exceptions by count.
 
-Use `get_service_operation_details` for per-operation drill-down. Use for performance summaries, bottlenecks, and error overview.
+Use `get_service_operations_summary` for per-operation drill-down. Use for performance summaries, bottlenecks, and error overview.
 
 Many metric fields use PromQL timeseries format: `[{"metric":{...},"values":[[timestamp_seconds,"value"]]}]`. Top operations/errors are dicts/lists of name→value.
 

--- a/internal/prompts/descriptions/get_traces_base.md
+++ b/internal/prompts/descriptions/get_traces_base.md
@@ -16,8 +16,10 @@ Query traces with `tracejson_query` — a JSON **array of stages**. Each stage M
 
 **Fields:** Top-level: `TraceId`, `SpanId`, `ServiceName`, `SpanName`, `SpanKind`, `StatusCode`, `Duration`, `Timestamp`, `ParentSpanId`. SpanKind/StatusCode need full OTel prefixes (`SPAN_KIND_SERVER`, `STATUS_CODE_ERROR`—not `SERVER`/`ERROR`). **`Duration` is nanoseconds** (1000ms = `1000000000`). Span/resource attrs → `get_trace_attributes*`; use `attributes['key']` / `resources['key']` (never `SpanAttributes.foo`).
 
-**Aggregate:** `aggregates`+`groupby` (not `aggregations`/`group_by`); each entry `{"function":{"$count":[]},"as":"name"}`.
+**Aggregate:** `aggregates`+`groupby`; each `{"function":{"$count":[]},"as":"name"}`.
 
-**Order:** filter first (match-all on `TraceId`/`SpanId` before aggregate). Show/find → filter only; aggregate/window_aggregate only for counts/analysis.
+**window_aggregate:** `{"type":"window_aggregate","function":{"$count":[]},"as":"c","window":["1","minutes"]}` — not the aggregate stage.
+
+**Order:** filter first (match-all `TraceId`/`SpanId` before aggregate). Show/find → filter only; aggregate/window_aggregate for counts.
 
 Full manual: resource `last9://reference/tracejson`

--- a/internal/prompts/descriptions/get_traces_base.md
+++ b/internal/prompts/descriptions/get_traces_base.md
@@ -1,4 +1,4 @@
-Query traces with `tracejson_query` — a JSON **array of stages**. Each stage MUST set `"type"` to `filter`|`parse`|`aggregate`|`window_aggregate`. Do **not** use `"stage"` or `"conditions"`. For an exact `trace_id`, prefer `get_service_traces`.
+Query traces with `tracejson_query` — a JSON **array of stages**. Each stage MUST set `"type"` to `filter`|`parse`|`aggregate`|`window_aggregate`. Do **not** use `"stage"` or `"conditions"`. For an exact `trace_id` or recent traces of one service, prefer `get_service_traces`.
 
 **Filter shape:**
 ```json

--- a/internal/prompts/references/service_logs.md
+++ b/internal/prompts/references/service_logs.md
@@ -1,33 +1,32 @@
-Use this tool to fetch raw log entries for a single service using simple filters.
+Use this tool to fetch raw log entries for a single service using structured filters. Do not write a `logjson_query`.
 
-## When to use `get_logs` instead
+## When to use this tool vs `get_logs`
 
-**CRITICAL:** If the query involves a structured attribute — HTTP status codes (401, 500, etc.), gRPC status codes, `user_id`, latency, or any field discoverable via `get_log_attributes` — **use `get_logs`** with a `logjson_query` attribute filter instead of this tool.
+**Use `get_service_logs` when:** the question is about one known service and you can express it with `severity_filters`, `http_status_class` / `http_status_code`, `attribute_filters`, or `body_filters`.
 
-**Why:** `body_filters` performs plain-text substring search on the log message body only. It will miss all logs where the value is stored as a structured attribute (e.g. `attributes['http_status_code']`). Structured attribute queries are also **faster** because they are indexed.
+**Use `get_logs` when:** you need parse/aggregate/`window_aggregate`, or an ad-hoc pipeline the structured args cannot express.
 
-**Decision rule:**
-- Query involves a known or discoverable structured attribute → **use `get_logs`**
-- Query is simple severity filtering or keyword/phrase match against log text → use `get_service_logs`
+**Do not** send HTTP status or named-attribute questions to `get_logs` by default. This tool compiles those filters server-side.
 
-## Check log attributes first
+## HTTP status
 
-Before using `body_filters`, call `get_log_attributes` to discover what structured attributes are available for the service. If the value you are filtering on is stored as a structured attribute, **prefer an attribute filter via `get_logs`** over a body text search.
+Pass `http_status_class` (`2xx`/`3xx`/`4xx`/`5xx`) or `http_status_code` (`500`, `401`). The server discovers the status field for this service/env/window via the same path as `get_log_attributes_for_pipeline`.
 
-**Do not assume an attribute's key name** — which fields exist and how they're keyed depend on the scope you've filtered to (for example, HTTP status is keyed `status_code` on some sources and `http.status_code` on others; neither is a safe default). To get the field that is actually present for your scope, build a pipeline scoped to this service (e.g. `{"$eq":["ServiceName","<service>"]}`, plus any other filters such as namespace or environment), call `get_log_attributes_for_pipeline`, then use the `filter_field` it returns. Entries marked `source: "body"` live inside the log `Body` (JSON, logfmt, or plaintext matched by regexp) and require the parse stage from their `hint` — that path needs `get_logs`, not this tool.
+If discovery finds no status-like field, or more than one, the tool errors and asks you to pass `http_status_field` with the exact logjson field (e.g. `attributes['http.status_code']`). Do not guess a field name.
 
-**Severity is not an HTTP-error proxy** — access logs commonly carry INFO severity even for 5xx responses, and severity can be empty. `severity_filters: ["error"]` returns 0 for such services. For HTTP error questions, use `get_logs` with the discovered status field instead.
+`http_status_code` takes precedence over `http_status_class` when both are set.
 
-Structured attribute queries are:
-- **Faster**: indexed, not a full-text scan
-- **More precise**: exact value match, not partial text
-- **More reliable**: work even when the value is not embedded in the log message body
+**Severity is not an HTTP-error proxy** — access logs commonly carry INFO severity even for 5xx responses, and severity can be empty. `severity_filters: ["error"]` returns 0 for such services. Use `http_status_class` / `http_status_code` instead.
 
-`body_filters` is a **last resort** — use it only when no structured attribute captures the information you need.
+## Named attributes
 
-## Available structured attributes
+`attribute_filters` is an array of `{field, value}` equality matches compiled into logjson `$eq`. `field` must use logjson syntax: `attributes['user_id']`, `resources['k8s.namespace.name']`, or a simple name that this tool wraps as `attributes['name']`.
 
-Do not invent org-specific attribute names. Discover fields with `get_log_attributes` / `get_log_attributes_for_pipeline` before filtering.
+Invalid syntax (double quotes, `resource_` prefixes) is a local error. An unknown org field is not rejected — it is forwarded and may match nothing.
+
+Do not invent org-specific attribute names. Discover fields with `get_log_attributes` / `get_log_attributes_for_pipeline` if you are unsure of the key. Entries marked `source: "body"` live inside the log `Body` and need a parse stage; prefer `get_logs` with the hint pipeline for those.
+
+`body_filters` is a last resort for plaintext that is not stored as a structured attribute.
 
 ## Parameters
 
@@ -36,7 +35,11 @@ Do not invent org-specific attribute names. Discover fields with `get_log_attrib
 - `lookback_minutes` (optional): Relative time range only when the user did not give explicit timestamps.
 - `limit` (optional): Maximum number of log entries to return.
 - `severity_filters` (optional): Array of severity strings such as `["error", "fatal", "critical"]`.
-- `body_filters` (optional): Array of substrings that should appear in the log body. **Last resort only — prefer `get_logs` with attribute filters for structured values.**
+- `http_status_class` (optional): `2xx`, `3xx`, `4xx`, or `5xx`.
+- `http_status_code` (optional): Exact 3-digit HTTP status such as `500` or `401`.
+- `http_status_field` (optional): Explicit logjson field when discovery is ambiguous or empty.
+- `attribute_filters` (optional): Array of `{field, value}` equality filters.
+- `body_filters` (optional): Array of substrings that should appear in the log body. Last resort only.
 - `env` (optional): Deployment environment string.
 - `index` (optional): Explicit log index in the form `physical_index:<name>` or `rehydration_index:<block_name>`.
 
@@ -55,7 +58,7 @@ Do not invent org-specific attribute names. Discover fields with `get_log_attrib
 - Prefer `start_time_iso` and `end_time_iso` over `lookback_minutes` when the user provides absolute times.
 - Keep `severity_filters` and `body_filters` as arrays of strings.
 - Do not invent `index` or `env` unless the user explicitly asked for them or supplied that context.
-- **NEVER use `body_filters` for values stored as structured attributes.** Call `get_log_attributes` to check first, then use `get_logs` if an attribute exists.
+- **NEVER use `body_filters` for HTTP status codes or values stored as structured attributes.** Use `http_status_*` or `attribute_filters`.
 
 ## Examples
 
@@ -70,21 +73,39 @@ Do not invent org-specific attribute names. Discover fields with `get_log_attrib
 }
 ```
 
-This misses all logs where `401` is stored as `attributes['http_status_code']` and the body doesn't contain the literal string.
-
-### ✅ CORRECT — HTTP 401 via `get_logs` attribute filter
-
-Use `get_logs` instead:
+### ✅ CORRECT — HTTP 401 via this tool
 
 ```json
 {
-  "logjson_query": [{"type": "filter", "query": {"$eq": ["attributes['http_status_code']", "401"]}}],
   "service_name": "auth-sanic",
-  "lookback_minutes": 5
+  "env": "production",
+  "lookback_minutes": 60,
+  "http_status_code": "401"
 }
 ```
 
-### ✅ CORRECT — Simple severity filter (valid use of this tool)
+### ✅ CORRECT — HTTP 5xx class
+
+```json
+{
+  "service_name": "checkout",
+  "env": "production",
+  "lookback_minutes": 15,
+  "http_status_class": "5xx"
+}
+```
+
+### ✅ CORRECT — Named attribute equality
+
+```json
+{
+  "service_name": "checkout",
+  "lookback_minutes": 15,
+  "attribute_filters": [{"field": "attributes['user_id']", "value": "abc"}]
+}
+```
+
+### ✅ CORRECT — Simple severity filter
 
 ```json
 {
@@ -96,7 +117,7 @@ Use `get_logs` instead:
 }
 ```
 
-### ✅ CORRECT — Plain keyword search (valid use of this tool)
+### ✅ CORRECT — Plain keyword search
 
 ```json
 {

--- a/internal/prompts/workflows/on_call_runbook.md
+++ b/internal/prompts/workflows/on_call_runbook.md
@@ -3,7 +3,7 @@ Workflow: on-call triage for symptom "{{.symptom}}"{{if .service}} on {{.service
 {{if not .service}}No service given, so start with fleet triage: call get_alerts to find firing alerts, then get_service_summary as a volume leaderboard (unless sort_by names an error class) to identify high-traffic services, and scope the branch below to the worst offender.
 {{end}}Route by symptom:
 {{if eq .symptom "latency"}}Latency: get_service_performance_details, then get_apm_service_deviations, then get_service_traces, then get_service_dependency_graph. Decide whether the slowness is local or downstream.
-{{else if eq .symptom "errors"}}Errors: get_service_performance_details, then get_exceptions, then get_service_traces, then aggregate get_logs (count by logger, gate on ERROR/FATAL) before reading raw lines.
+{{else if eq .symptom "errors"}}Errors: get_service_performance_details, then get_exceptions, then get_service_traces. For HTTP 5xx/4xx log search use get_service_logs (http_status_class or http_status_code)—do not write logjson. For severity-less logger counts, aggregate get_logs first, then read lines with get_service_logs.
 {{else if eq .symptom "database"}}Database: get_database_slow_queries, then get_database_server_metrics. Separate query-shape problems from server-resource pressure.
 {{else}}Unknown symptom: call get_alerts first to see what is actually firing, then follow the matching branch above (latency, errors, or database).
 {{end}}

--- a/internal/telemetry/logs/attributes_for_pipeline.go
+++ b/internal/telemetry/logs/attributes_for_pipeline.go
@@ -469,6 +469,52 @@ func fetchLogSeriesFieldNames(ctx context.Context, client *http.Client, cfg mode
 	return names, nil
 }
 
+// discoverLogAttributes returns indexed plus body-derived attributes for a
+// pipeline, using the same merge rules as get_log_attributes_for_pipeline.
+func discoverLogAttributes(ctx context.Context, client *http.Client, cfg models.Config, pipeline []map[string]interface{}, startSec, endSec int64, index string, queryParams url.Values) ([]LogAttribute, error) {
+	bodyCh := make(chan []LogAttribute, 1)
+	go func() {
+		bodyCh <- sampleBodyDerivedAttributes(ctx, client, cfg, pipeline, startSec, endSec, index)
+	}()
+
+	names, err := fetchLogSeriesFieldNames(ctx, client, cfg, pipeline, queryParams)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]LogAttribute, 0, len(names))
+	indexedFilterFields := make(map[string]struct{}, len(names))
+	indexedHasSeverity := hasIndexedSeverityFamily(names)
+	for _, name := range names {
+		filterField := logFieldFilterField(name)
+		indexedFilterFields[filterField] = struct{}{}
+		out = append(out, LogAttribute{
+			Name:        name,
+			FilterField: filterField,
+			Hint:        fmt.Sprintf("{\"$eq\":[\"%s\",\"<value>\"]}", filterField),
+		})
+	}
+
+	// Merge: drop a body-derived entry when (a) an indexed entry already
+	// exposes the SAME filter_field (true duplicate), or (b) it is a
+	// severity-family name (level/severity/SeverityText) and any indexed
+	// severity-family field is already present. Indexed severity is the
+	// directly-filterable signal the product UI renders; a parallel
+	// body-derived level that requires a regexp parse is inferior and
+	// must not be advertised alongside it.
+	for _, attr := range <-bodyCh {
+		if _, dup := indexedFilterFields[attr.FilterField]; dup {
+			continue
+		}
+		if indexedHasSeverity && isSeverityFamilyName(attr.Name) {
+			continue
+		}
+		out = append(out, attr)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
 // NewGetLogAttributesForPipelineHandler creates a handler that returns the log
 // attributes present for a given pipeline, each enriched with its filter_field.
 func NewGetLogAttributesForPipelineHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetLogAttributesForPipelineArgs) (*mcp.CallToolResult, any, error) {
@@ -524,51 +570,12 @@ func NewGetLogAttributesForPipelineHandler(client *http.Client, cfg models.Confi
 			queryParams.Set("index", normalizedIndex)
 		}
 
-		// Best-effort, in parallel with the series fetch: fields that exist only
-		// inside the log Body as JSON — they need a parse stage (carried in the
-		// hint) before use. The sampling honors the same region override.
 		samplingCfg := cfg
 		samplingCfg.Region = region
-		bodyCh := make(chan []LogAttribute, 1)
-		go func() {
-			bodyCh <- sampleBodyDerivedAttributes(ctx, client, samplingCfg, validatedPipeline, startTime, endTime, normalizedIndex)
-		}()
-
-		names, err := fetchLogSeriesFieldNames(ctx, client, cfg, validatedPipeline, queryParams)
+		out, err := discoverLogAttributes(ctx, client, samplingCfg, validatedPipeline, startTime, endTime, normalizedIndex, queryParams)
 		if err != nil {
 			return nil, nil, err
 		}
-
-		out := make([]LogAttribute, 0, len(names))
-		indexedFilterFields := make(map[string]struct{}, len(names))
-		indexedHasSeverity := hasIndexedSeverityFamily(names)
-		for _, name := range names {
-			filterField := logFieldFilterField(name)
-			indexedFilterFields[filterField] = struct{}{}
-			out = append(out, LogAttribute{
-				Name:        name,
-				FilterField: filterField,
-				Hint:        fmt.Sprintf("{\"$eq\":[\"%s\",\"<value>\"]}", filterField),
-			})
-		}
-
-		// Merge: drop a body-derived entry when (a) an indexed entry already
-		// exposes the SAME filter_field (true duplicate), or (b) it is a
-		// severity-family name (level/severity/SeverityText) and any indexed
-		// severity-family field is already present. Indexed severity is the
-		// directly-filterable signal the product UI renders; a parallel
-		// body-derived level that requires a regexp parse is inferior and
-		// must not be advertised alongside it.
-		for _, attr := range <-bodyCh {
-			if _, dup := indexedFilterFields[attr.FilterField]; dup {
-				continue
-			}
-			if indexedHasSeverity && isSeverityFamilyName(attr.Name) {
-				continue
-			}
-			out = append(out, attr)
-		}
-		sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 
 		payload, err := json.MarshalIndent(out, "", "  ")
 		if err != nil {

--- a/internal/telemetry/logs/attributes_for_pipeline.go
+++ b/internal/telemetry/logs/attributes_for_pipeline.go
@@ -407,7 +407,12 @@ func logFieldFilterField(name string) string {
 
 // fetchLogSeriesFieldNames POSTs the given pipeline to /logs/api/v2/series/json
 // and returns the union of field names present across all returned label-sets.
+// Bounded by PerChunkHTTPTimeout so a slow series call cannot stall
+// get_service_logs / attribute discovery before the real query starts.
 func fetchLogSeriesFieldNames(ctx context.Context, client *http.Client, cfg models.Config, pipeline []map[string]interface{}, queryParams url.Values) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, constants.PerChunkHTTPTimeout)
+	defer cancel()
+
 	apiURL := fmt.Sprintf("%s%s?%s", cfg.APIBaseURL, constants.EndpointLogsSeries, queryParams.Encode())
 
 	requestBody := map[string]interface{}{

--- a/internal/telemetry/logs/chunking_test.go
+++ b/internal/telemetry/logs/chunking_test.go
@@ -332,7 +332,7 @@ func TestGetLogsHandlerTreatsMissingStreamsResultAsEmptyChunk(t *testing.T) {
 	}
 }
 
-func TestGetLogsHandlerReturnsPartialResultsAfterLaterChunkParseError(t *testing.T) {
+func TestGetLogsHandlerReturnsErrorAfterLaterChunkParseError(t *testing.T) {
 	rec := newRequestRecorder()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
@@ -536,7 +536,7 @@ func TestFetchServiceLogsReturnsEmptyPartialWhenAllSuccessChunksAreEmpty(t *test
 	}
 }
 
-func TestFetchServiceLogsReturnsPartialResultsAfterLaterChunkError(t *testing.T) {
+func TestFetchServiceLogsReturnsErrorAfterLaterChunkError(t *testing.T) {
 	rec := newRequestRecorder()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()

--- a/internal/telemetry/logs/chunking_test.go
+++ b/internal/telemetry/logs/chunking_test.go
@@ -488,10 +488,9 @@ func TestFetchServiceLogsHardErrorsWhenAllChunksFail(t *testing.T) {
 	}
 }
 
-func TestFetchServiceLogsReturnsEmptyPartialWhenAllSuccessChunksAreEmpty(t *testing.T) {
-	// Regression: previously fetchServiceLogs returned a hard error when no log
-	// entries were collected, even if most chunks succeeded with empty payloads.
-	// Now matches fetchLogJSONQuery — empty + partial annotation, not hard fail.
+func TestFetchServiceLogsReturnsErrorWhenLaterChunkFailsAfterEmptySuccesses(t *testing.T) {
+	// A later chunk hole is a tool error even when earlier chunks succeeded with
+	// empty payloads — not an empty partial_result.
 	rec := newRequestRecorder()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()

--- a/internal/telemetry/logs/chunking_test.go
+++ b/internal/telemetry/logs/chunking_test.go
@@ -371,29 +371,17 @@ func TestGetLogsHandlerReturnsPartialResultsAfterLaterChunkParseError(t *testing
 		EndTimeISO:   "1970-01-01T01:30:00Z",
 		Limit:        10,
 	})
-	if err != nil {
-		t.Fatalf("handler returned error: %v", err)
+	if err == nil {
+		t.Fatal("expected tool error when a chunk fails to parse")
 	}
-
+	if result != nil {
+		t.Fatalf("expected no OK payload on chunk hole, got %#v", result)
+	}
 	if rec.count() != 6 {
 		t.Fatalf("expected 6 chunk requests, got %d", rec.count())
 	}
-
-	payload := parseToolJSONResult(t, result)
-	if entryCount := countEntriesInPayload(t, payload); entryCount != 3 {
-		t.Fatalf("expected 3 merged log entries in payload, got %d", entryCount)
-	}
-
-	meta, ok := payload[partialResultMetadataKey].(map[string]any)
-	if !ok {
-		t.Fatalf("expected partial metadata in payload, got %#v", payload)
-	}
-	if partial, ok := meta["partial_result"].(bool); !ok || !partial {
-		t.Fatalf("expected partial_result=true, got %#v", meta["partial_result"])
-	}
-	warning, ok := meta["warning"].(string)
-	if !ok || !strings.Contains(warning, "chunk 6/6 failed to parse") {
-		t.Fatalf("expected parse warning naming chunk 6/6, got %#v", meta["warning"])
+	if !strings.Contains(err.Error(), "chunk 6/6 failed to parse") {
+		t.Fatalf("expected parse error naming chunk 6/6, got %v", err)
 	}
 }
 
@@ -534,17 +522,17 @@ func TestFetchServiceLogsReturnsEmptyPartialWhenAllSuccessChunksAreEmpty(t *test
 		buildServiceLogsQuery("api", nil, nil),
 		"",
 	)
-	if err != nil {
-		t.Fatalf("expected partial result, got hard error: %v", err)
+	if err == nil {
+		t.Fatal("expected tool error when a chunk fails")
 	}
-	if response.Count != 0 || len(response.Logs) != 0 {
-		t.Fatalf("expected empty logs from all-empty successes, got count=%d logs=%v", response.Count, response.Logs)
+	if response != nil {
+		t.Fatalf("expected nil response on chunk hole, got %#v", response)
 	}
-	if !response.PartialResult {
-		t.Fatalf("expected partial result flag set, got %#v", response)
+	if rec.count() != 6 {
+		t.Fatalf("expected 6 chunk requests, got %d", rec.count())
 	}
-	if !strings.Contains(response.Warning, "chunk 6/") {
-		t.Fatalf("expected partial warning naming chunk 6, got %q", response.Warning)
+	if !strings.Contains(err.Error(), "chunk 6/") {
+		t.Fatalf("expected error naming chunk 6, got %v", err)
 	}
 }
 
@@ -587,21 +575,17 @@ func TestFetchServiceLogsReturnsPartialResultsAfterLaterChunkError(t *testing.T)
 		buildServiceLogsQuery("api", nil, nil),
 		"",
 	)
-	if err != nil {
-		t.Fatalf("fetchServiceLogs returned error: %v", err)
+	if err == nil {
+		t.Fatal("expected tool error when a later chunk fails")
 	}
-
+	if response != nil {
+		t.Fatalf("expected nil response on chunk hole, got %#v", response)
+	}
 	if rec.count() != 6 {
 		t.Fatalf("expected 6 chunk requests, got %d", rec.count())
 	}
-	if response.Count != 3 {
-		t.Fatalf("expected count=3, got %d", response.Count)
-	}
-	if !response.PartialResult {
-		t.Fatalf("expected partial result flag, got %#v", response)
-	}
-	if !strings.Contains(response.Warning, "chunk 6/") || !strings.Contains(response.Warning, "failed") {
-		t.Fatalf("expected partial warning naming chunk 6, got %q", response.Warning)
+	if !strings.Contains(err.Error(), "chunk 6/") || !strings.Contains(err.Error(), "failed") {
+		t.Fatalf("expected error naming chunk 6, got %v", err)
 	}
 }
 

--- a/internal/telemetry/logs/http_error_test.go
+++ b/internal/telemetry/logs/http_error_test.go
@@ -1,0 +1,62 @@
+package logs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestGetLogsRelays400BodyAndDrains502(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     int
+		body       string
+		wantSubstr string
+		forbid     string
+	}{
+		{
+			name:       "400 includes parse body",
+			status:     http.StatusBadRequest,
+			body:       `{"error":"invalid json pipeline: unknown stage"}`,
+			wantSubstr: "unknown stage",
+		},
+		{
+			name:       "502 omits body",
+			status:     http.StatusBadGateway,
+			body:       `{"error":"gateway SECRET"}`,
+			wantSubstr: "HTTP 502",
+			forbid:     "SECRET",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			handler := NewGetLogsHandler(server.Client(), testLogsConfig(server.URL))
+			_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetLogsArgs{
+				LogjsonQuery: []map[string]interface{}{
+					{"type": "filter", "query": map[string]interface{}{"$eq": []interface{}{"ServiceName", "checkout"}}},
+				},
+				LookbackMinutes: 5,
+			})
+			if err == nil {
+				t.Fatal("expected tool error")
+			}
+			got := err.Error()
+			if !strings.Contains(got, tt.wantSubstr) {
+				t.Fatalf("error %q missing %q", got, tt.wantSubstr)
+			}
+			if tt.forbid != "" && strings.Contains(got, tt.forbid) {
+				t.Fatalf("error leaked %q: %s", tt.forbid, got)
+			}
+		})
+	}
+}

--- a/internal/telemetry/logs/http_error_test.go
+++ b/internal/telemetry/logs/http_error_test.go
@@ -19,10 +19,11 @@ func TestGetLogsRelays400BodyAndDrains502(t *testing.T) {
 		forbid     string
 	}{
 		{
-			name:       "400 includes parse body",
+			name:       "400 includes parse body and redacts URL",
 			status:     http.StatusBadRequest,
-			body:       `{"error":"invalid json pipeline: unknown stage"}`,
+			body:       `{"error":"invalid json pipeline: unknown stage","url":"https://internal.example/query?token=SECRET"}`,
 			wantSubstr: "unknown stage",
+			forbid:     "https://",
 		},
 		{
 			name:       "502 omits body",
@@ -56,6 +57,17 @@ func TestGetLogsRelays400BodyAndDrains502(t *testing.T) {
 			}
 			if tt.forbid != "" && strings.Contains(got, tt.forbid) {
 				t.Fatalf("error leaked %q: %s", tt.forbid, got)
+			}
+			if tt.status == http.StatusBadRequest {
+				if !strings.Contains(got, "[redacted-url]") {
+					t.Fatalf("expected URL redaction in 400 error, got %s", got)
+				}
+				if !strings.Contains(got, "get_log_attributes_for_pipeline") {
+					t.Fatalf("expected pipeline schema hint, got %s", got)
+				}
+				if strings.Contains(got, "SECRET") {
+					t.Fatalf("400 body leaked SECRET: %s", got)
+				}
 			}
 		})
 	}

--- a/internal/telemetry/logs/logs.go
+++ b/internal/telemetry/logs/logs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"log/slog"
 	"net/http"
@@ -357,8 +356,7 @@ func executeLogJSONQuery(ctx context.Context, client *http.Client, cfg models.Co
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("logs API request failed with status %d: %s", resp.StatusCode, string(body))
+		return nil, utils.NewUpstreamHTTPError(resp, "logs query")
 	}
 
 	var result map[string]interface{}

--- a/internal/telemetry/logs/logs.go
+++ b/internal/telemetry/logs/logs.go
@@ -20,7 +20,6 @@ import (
 )
 
 const defaultGetLogsLookbackMinutes = 5
-const partialResultMetadataKey = "_last9_mcp"
 
 // GetLogsArgs represents the input arguments for the get_logs tool
 type GetLogsArgs struct {
@@ -285,20 +284,8 @@ func fetchLogJSONQuery(ctx context.Context, client *http.Client, cfg models.Conf
 	data["result"] = mergedItems
 	data["resultType"] = "streams"
 	if partialErr != nil {
-		annotatePartialGetLogsResponse(baseResponse, partialErr, len(chunks), countLogEntriesInResultItems(mergedItems))
-		if chunkingDebug {
-			log.Printf(
-				"[chunking] get_logs chunking partial chunks=%d returned_entries=%d start_ms=%d end_ms=%d err=%v",
-				len(chunks),
-				countLogEntriesInResultItems(mergedItems),
-				startTime,
-				endTime,
-				partialErr,
-			)
-		}
-		return baseResponse, nil
+		return nil, fmt.Errorf("%w (window start_ms=%d end_ms=%d)", partialErr, startTime, endTime)
 	}
-
 	if chunkingDebug {
 		log.Printf(
 			"[chunking] get_logs chunking complete chunks=%d returned_entries=%d start_ms=%d end_ms=%d",
@@ -310,15 +297,6 @@ func fetchLogJSONQuery(ctx context.Context, client *http.Client, cfg models.Conf
 	}
 
 	return baseResponse, nil
-}
-
-func annotatePartialGetLogsResponse(response map[string]interface{}, err error, totalChunks, returnedEntries int) {
-	response[partialResultMetadataKey] = map[string]interface{}{
-		"partial_result":   true,
-		"warning":          fmt.Sprintf("Returning partial results: %v", err),
-		"total_chunks":     totalChunks,
-		"returned_entries": returnedEntries,
-	}
 }
 
 func effectiveGetLogsChunkLimit(cfg models.Config, requestedLimit int) int {

--- a/internal/telemetry/logs/logs.go
+++ b/internal/telemetry/logs/logs.go
@@ -334,7 +334,7 @@ func executeLogJSONQuery(ctx context.Context, client *http.Client, cfg models.Co
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, utils.NewUpstreamHTTPError(resp, "logs query")
+		return nil, utils.NewUpstreamHTTPError(resp, "logs query", utils.LogsPipelineSchemaHint)
 	}
 
 	var result map[string]interface{}

--- a/internal/telemetry/logs/service_logs.go
+++ b/internal/telemetry/logs/service_logs.go
@@ -277,7 +277,6 @@ func fetchServiceLogs(ctx context.Context, client *http.Client, cfg models.Confi
 		// partial-result annotation when some chunks succeeded. Wrapping the
 		// underlying error via %w preserves errors.Is/As behaviour.
 		partialErr error
-		anySuccess bool
 	)
 
 	for _, r := range results {
@@ -298,11 +297,6 @@ func fetchServiceLogs(ctx context.Context, client *http.Client, cfg models.Confi
 			}
 			continue
 		}
-
-		// A successful chunk — even an empty one — counts as positive
-		// evidence about its window. This mirrors fetchLogJSONQuery, where
-		// a successful empty streams response sets baseResponse.
-		anySuccess = true
 
 		remaining := limit - len(logs)
 		chunkLogs := r.Value
@@ -330,37 +324,27 @@ func fetchServiceLogs(ctx context.Context, client *http.Client, cfg models.Confi
 		}
 	}
 
-	// Hard-error only when NO chunk succeeded. If even one chunk returned a
-	// valid (possibly empty) response, surface what we have with a partial
-	// annotation — same contract as fetchLogJSONQuery.
-	if !anySuccess && partialErr != nil {
-		return nil, partialErr
+	if partialErr != nil {
+		return nil, fmt.Errorf("%w (window start_ms=%d end_ms=%d)", partialErr, startMs, endMs)
 	}
 
 	if chunkingDebug {
 		log.Printf(
-			"[chunking] get_service_logs chunking complete service=%q returned_entries=%d start_ms=%d end_ms=%d partial=%t",
+			"[chunking] get_service_logs chunking complete service=%q returned_entries=%d start_ms=%d end_ms=%d",
 			service,
 			len(logs),
 			startMs,
 			endMs,
-			partialErr != nil,
 		)
 	}
 
-	response := &ServiceLogsResponse{
+	return &ServiceLogsResponse{
 		Service:   service,
 		StartTime: startTime.Format(time.RFC3339),
 		EndTime:   endTime.Format(time.RFC3339),
 		Count:     len(logs),
 		Logs:      logs,
-	}
-	if partialErr != nil {
-		response.PartialResult = true
-		response.Warning = fmt.Sprintf("Returning partial results: %v", partialErr)
-	}
-
-	return response, nil
+	}, nil
 }
 
 func fetchServiceLogsChunk(ctx context.Context, client *http.Client, cfg models.Config, service string, logjsonQuery []map[string]interface{}, startTimeMs, endTimeMs int64, limit int, index string) ([]LogEntry, error) {

--- a/internal/telemetry/logs/service_logs.go
+++ b/internal/telemetry/logs/service_logs.go
@@ -20,13 +20,12 @@ import (
 
 // ServiceLogsResponse represents the response structure for service logs
 type ServiceLogsResponse struct {
-	Service       string     `json:"service"`
-	StartTime     string     `json:"start_time"`
-	EndTime       string     `json:"end_time"`
-	Count         int        `json:"count"`
-	Logs          []LogEntry `json:"logs"`
-	PartialResult bool       `json:"partial_result,omitempty"`
-	Warning       string     `json:"warning,omitempty"`
+	Service         string     `json:"service"`
+	StartTime       string     `json:"start_time"`
+	EndTime         string     `json:"end_time"`
+	Count           int        `json:"count"`
+	Logs            []LogEntry `json:"logs"`
+	HTTPStatusField string     `json:"http_status_field,omitempty"`
 }
 
 // LogEntry represents a single log entry
@@ -99,7 +98,7 @@ func NewGetServiceLogsHandler(client *http.Client, cfg models.Config) func(conte
 			return nil, nil, fmt.Errorf("invalid index: %w", err)
 		}
 
-		extraConditions, parseStages, err := compileServiceLogsStructuredFilters(ctx, client, cfg, args, startTime, endTime, normalizedIndex)
+		extraConditions, parseStages, statusField, err := compileServiceLogsStructuredFilters(ctx, client, cfg, args, startTime, endTime, normalizedIndex)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -108,7 +107,10 @@ func NewGetServiceLogsHandler(client *http.Client, cfg models.Config) func(conte
 		if args.Env != "" {
 			logjsonQuery = addServiceLogsEnvFilter(logjsonQuery, args.Env)
 		}
-		logjsonQuery = applyServiceLogsStructuredFilters(logjsonQuery, extraConditions, parseStages)
+		logjsonQuery, err = applyServiceLogsStructuredFilters(logjsonQuery, extraConditions, parseStages)
+		if err != nil {
+			return nil, nil, err
+		}
 
 		// Fetch raw logs using the existing logs API approach. When index is omitted,
 		// keep the query on the no-index path that matches the live dashboard/API.
@@ -116,6 +118,7 @@ func NewGetServiceLogsHandler(client *http.Client, cfg models.Config) func(conte
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to fetch service logs: %w", err)
 		}
+		logs.HTTPStatusField = statusField
 
 		// Format response as JSON for better readability
 		responseJSON, err := json.MarshalIndent(logs, "", "  ")

--- a/internal/telemetry/logs/service_logs.go
+++ b/internal/telemetry/logs/service_logs.go
@@ -39,15 +39,25 @@ type LogEntry struct {
 
 // GetServiceLogsArgs represents the input arguments for the get_service_logs tool
 type GetServiceLogsArgs struct {
-	ServiceName     string   `json:"service_name" jsonschema:"Name of the service to retrieve logs for (e.g. api) (required)"`
-	StartTimeISO    string   `json:"start_time_iso,omitempty" jsonschema:"Start time in RFC3339/ISO8601 format (e.g. 2023-10-01T10:00:00Z). If not provided lookback_minutes is used"`
-	EndTimeISO      string   `json:"end_time_iso,omitempty" jsonschema:"End time in RFC3339/ISO8601 format (e.g. 2023-10-01T11:00:00Z). If not provided current time is used"`
-	LookbackMinutes int      `json:"lookback_minutes,omitempty" jsonschema:"Number of minutes to look back from current time if start_time_iso not provided (default: 60, minimum: 1)"`
-	Limit           int      `json:"limit,omitempty" jsonschema:"Maximum number of log entries to return (optional, default: 20)"`
-	SeverityFilters []string `json:"severity_filters,omitempty" jsonschema:"Array of severity patterns to match (uses OR logic) (e.g. [error warn])"`
-	BodyFilters     []string `json:"body_filters,omitempty" jsonschema:"Array of message content patterns to match (uses OR logic) (e.g. [timeout failed])"`
-	Env             string   `json:"env,omitempty" jsonschema:"Environment to filter by. Empty string if environment is unknown (e.g. production)"`
-	Index           string   `json:"index,omitempty" jsonschema:"Optional log index in the form physical_index:<name> or rehydration_index:<block_name>. Omit this when the user did not specify an index."`
+	ServiceName      string                      `json:"service_name" jsonschema:"Name of the service to retrieve logs for (e.g. api) (required)"`
+	StartTimeISO     string                      `json:"start_time_iso,omitempty" jsonschema:"Start time in RFC3339/ISO8601 format (e.g. 2023-10-01T10:00:00Z). If not provided lookback_minutes is used"`
+	EndTimeISO       string                      `json:"end_time_iso,omitempty" jsonschema:"End time in RFC3339/ISO8601 format (e.g. 2023-10-01T11:00:00Z). If not provided current time is used"`
+	LookbackMinutes  int                         `json:"lookback_minutes,omitempty" jsonschema:"Number of minutes to look back from current time if start_time_iso not provided (default: 60, minimum: 1)"`
+	Limit            int                         `json:"limit,omitempty" jsonschema:"Maximum number of log entries to return (optional, default: 20)"`
+	SeverityFilters  []string                    `json:"severity_filters,omitempty" jsonschema:"Array of severity patterns to match (uses OR logic) (e.g. [error warn])"`
+	BodyFilters      []string                    `json:"body_filters,omitempty" jsonschema:"Array of message content patterns to match (uses OR logic) (e.g. [timeout failed])"`
+	HTTPStatusClass  string                      `json:"http_status_class,omitempty" jsonschema:"HTTP status class to match: 2xx, 3xx, 4xx, or 5xx. Discovers the status field unless http_status_field is set."`
+	HTTPStatusCode   string                      `json:"http_status_code,omitempty" jsonschema:"Exact HTTP status code (e.g. 500, 401). Discovers the status field unless http_status_field is set. Takes precedence over http_status_class."`
+	HTTPStatusField  string                      `json:"http_status_field,omitempty" jsonschema:"Explicit logjson field for HTTP status (e.g. attributes['http.status_code']). Required when discovery finds zero or multiple status-like fields."`
+	AttributeFilters []ServiceLogAttributeFilter `json:"attribute_filters,omitempty" jsonschema:"Equality filters on named log attributes. Each entry is field plus value. field uses logjson syntax such as attributes['user_id']. Unknown org fields are allowed; invalid syntax is rejected."`
+	Env              string                      `json:"env,omitempty" jsonschema:"Environment to filter by. Empty string if environment is unknown (e.g. production)"`
+	Index            string                      `json:"index,omitempty" jsonschema:"Optional log index in the form physical_index:<name> or rehydration_index:<block_name>. Omit this when the user did not specify an index."`
+}
+
+// ServiceLogAttributeFilter is a structured equality filter compiled into logjson.
+type ServiceLogAttributeFilter struct {
+	Field string `json:"field" jsonschema:"(Required) logjson field, e.g. attributes['user_id'] or resources['k8s.namespace.name']"`
+	Value string `json:"value" jsonschema:"(Required) exact value matched with $eq"`
 }
 
 // NewGetServiceLogsHandler creates a new handler for the get_service_logs tool
@@ -89,10 +99,16 @@ func NewGetServiceLogsHandler(client *http.Client, cfg models.Config) func(conte
 			return nil, nil, fmt.Errorf("invalid index: %w", err)
 		}
 
+		extraConditions, parseStages, err := compileServiceLogsStructuredFilters(ctx, client, cfg, args, startTime, endTime, normalizedIndex)
+		if err != nil {
+			return nil, nil, err
+		}
+
 		logjsonQuery := buildServiceLogsQuery(args.ServiceName, args.SeverityFilters, args.BodyFilters)
 		if args.Env != "" {
 			logjsonQuery = addServiceLogsEnvFilter(logjsonQuery, args.Env)
 		}
+		logjsonQuery = applyServiceLogsStructuredFilters(logjsonQuery, extraConditions, parseStages)
 
 		// Fetch raw logs using the existing logs API approach. When index is omitted,
 		// keep the query on the no-index path that matches the live dashboard/API.

--- a/internal/telemetry/logs/service_logs_filters.go
+++ b/internal/telemetry/logs/service_logs_filters.go
@@ -19,12 +19,12 @@ var (
 	httpStatusCodePattern  = regexp.MustCompile(`^[1-5][0-9]{2}$`)
 )
 
-func compileServiceLogsStructuredFilters(ctx context.Context, client *http.Client, cfg models.Config, args GetServiceLogsArgs, startTime, endTime time.Time, index string) ([]map[string]interface{}, []map[string]interface{}, error) {
+func compileServiceLogsStructuredFilters(ctx context.Context, client *http.Client, cfg models.Config, args GetServiceLogsArgs, startTime, endTime time.Time, index string) ([]map[string]interface{}, []map[string]interface{}, string, error) {
 	extra := make([]map[string]interface{}, 0, len(args.AttributeFilters)+1)
 	for i, filter := range args.AttributeFilters {
 		field, err := compileServiceLogAttributeField(filter.Field, fmt.Sprintf("attribute_filters[%d].field", i))
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, "", err
 		}
 		extra = append(extra, map[string]interface{}{
 			"$eq": []interface{}{field, filter.Value},
@@ -35,16 +35,16 @@ func compileServiceLogsStructuredFilters(ctx context.Context, client *http.Clien
 	code := strings.TrimSpace(args.HTTPStatusCode)
 	if class == "" && code == "" {
 		if strings.TrimSpace(args.HTTPStatusField) != "" {
-			return nil, nil, fmt.Errorf("http_status_field requires http_status_class or http_status_code")
+			return nil, nil, "", fmt.Errorf("http_status_field requires http_status_class or http_status_code")
 		}
-		return extra, nil, nil
+		return extra, nil, "", nil
 	}
 
 	if class != "" && !httpStatusClassPattern.MatchString(class) {
-		return nil, nil, fmt.Errorf("invalid http_status_class %q: use 2xx, 3xx, 4xx, or 5xx", class)
+		return nil, nil, "", fmt.Errorf("invalid http_status_class %q: use 2xx, 3xx, 4xx, or 5xx", class)
 	}
 	if code != "" && !httpStatusCodePattern.MatchString(code) {
-		return nil, nil, fmt.Errorf("invalid http_status_code %q: use a 3-digit HTTP status such as 500 or 401", code)
+		return nil, nil, "", fmt.Errorf("invalid http_status_code %q: use a 3-digit HTTP status such as 500 or 401", code)
 	}
 
 	explicitField := strings.TrimSpace(args.HTTPStatusField)
@@ -56,17 +56,21 @@ func compileServiceLogsStructuredFilters(ctx context.Context, client *http.Clien
 	if explicitField != "" {
 		statusField, err = compileServiceLogAttributeField(explicitField, "http_status_field")
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, "", err
 		}
 	} else {
 		statusField, parseStages, err = resolveHTTPStatusField(ctx, client, cfg, args, startTime, endTime, index)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, "", err
 		}
 	}
 
-	extra = append(extra, httpStatusCondition(statusField, class, code))
-	return extra, parseStages, nil
+	cond, err := httpStatusCondition(statusField, class, code)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	extra = append(extra, cond)
+	return extra, parseStages, statusField, nil
 }
 
 func compileServiceLogAttributeField(field, path string) (string, error) {
@@ -93,16 +97,19 @@ func compileServiceLogAttributeField(field, path string) (string, error) {
 	return "", fmt.Errorf("invalid log field reference %q at %s: use ServiceName, attributes['field'], or resources['field']", field, path)
 }
 
-func httpStatusCondition(field, class, code string) map[string]interface{} {
+func httpStatusCondition(field, class, code string) (map[string]interface{}, error) {
 	if httpStatusCodePattern.MatchString(code) {
 		return map[string]interface{}{
 			"$eq": []interface{}{field, code},
-		}
+		}, nil
 	}
-	digit := httpStatusClassPattern.FindStringSubmatch(class)[1]
+	parts := httpStatusClassPattern.FindStringSubmatch(class)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid http_status_class %q: use 2xx, 3xx, 4xx, or 5xx", class)
+	}
 	return map[string]interface{}{
-		"$regex": []interface{}{field, "^" + digit},
-	}
+		"$regex": []interface{}{field, "^" + parts[1]},
+	}, nil
 }
 
 func resolveHTTPStatusField(ctx context.Context, client *http.Client, cfg models.Config, args GetServiceLogsArgs, startTime, endTime time.Time, index string) (string, []map[string]interface{}, error) {
@@ -163,22 +170,33 @@ func isHTTPStatusLikeAttribute(attr LogAttribute) bool {
 	if strings.Contains(combined, "grpc") {
 		return false
 	}
-	needles := []string{
-		"http.response.status_code",
-		"http_response_status_code",
-		"http.status_code",
-		"http_status_code",
-		"http.status",
-		"http_status",
-		"status_code",
-		"statuscode",
+	if strings.Contains(n, "http") && strings.Contains(n, "status") {
+		return true
 	}
-	for _, needle := range needles {
-		if n == needle || strings.Contains(n, needle) || strings.Contains(f, needle) {
-			return true
-		}
+	if strings.Contains(f, "http") && strings.Contains(f, "status") {
+		return true
 	}
-	return false
+	base := httpStatusAttributeBase(attr.Name)
+	if base == "" {
+		base = httpStatusAttributeBase(attr.FilterField)
+	}
+	switch base {
+	case "status_code", "statuscode", "status":
+		return true
+	default:
+		return false
+	}
+}
+
+func httpStatusAttributeBase(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.TrimPrefix(s, "attributes['")
+	s = strings.TrimPrefix(s, "resources['")
+	s = strings.TrimSuffix(s, "']")
+	if i := strings.LastIndexAny(s, "./"); i >= 0 {
+		s = s[i+1:]
+	}
+	return strings.ReplaceAll(s, "-", "_")
 }
 
 func parseStagesFromAttributeHint(attr LogAttribute) []map[string]interface{} {
@@ -198,24 +216,29 @@ func parseStagesFromAttributeHint(attr LogAttribute) []map[string]interface{} {
 	return out
 }
 
-func applyServiceLogsStructuredFilters(query []map[string]interface{}, extra []map[string]interface{}, parseStages []map[string]interface{}) []map[string]interface{} {
+func applyServiceLogsStructuredFilters(query []map[string]interface{}, extra []map[string]interface{}, parseStages []map[string]interface{}) ([]map[string]interface{}, error) {
 	if len(extra) == 0 && len(parseStages) == 0 {
-		return query
+		return query, nil
+	}
+	if len(query) == 0 {
+		return nil, fmt.Errorf("internal error: service log query is missing the service filter; cannot apply status/attribute filters")
+	}
+
+	out := make([]map[string]interface{}, len(query))
+	for i, stage := range query {
+		out[i] = mapsClone(stage)
 	}
 
 	if len(parseStages) == 0 {
-		if len(query) == 0 {
-			return query
-		}
-		filterStage := mapsClone(query[0])
+		filterStage := mapsClone(out[0])
 		queryMap, ok := filterStage["query"].(map[string]interface{})
 		if !ok {
-			return query
+			return nil, fmt.Errorf("internal error: service log query filter is missing query; cannot apply status/attribute filters")
 		}
 		clonedQuery := mapsClone(queryMap)
 		andConditions, ok := clonedQuery["$and"].([]interface{})
 		if !ok {
-			return query
+			return nil, fmt.Errorf("internal error: service log query filter is missing $and; cannot apply status/attribute filters")
 		}
 		clonedConditions := append([]interface{}(nil), andConditions...)
 		for _, cond := range extra {
@@ -223,11 +246,10 @@ func applyServiceLogsStructuredFilters(query []map[string]interface{}, extra []m
 		}
 		clonedQuery["$and"] = clonedConditions
 		filterStage["query"] = clonedQuery
-		query[0] = filterStage
-		return query
+		out[0] = filterStage
+		return out, nil
 	}
 
-	out := append([]map[string]interface{}{}, query...)
 	out = append(out, parseStages...)
 	if len(extra) > 0 {
 		conds := make([]interface{}, 0, len(extra))
@@ -241,5 +263,5 @@ func applyServiceLogsStructuredFilters(query []map[string]interface{}, extra []m
 			},
 		})
 	}
-	return out
+	return out, nil
 }

--- a/internal/telemetry/logs/service_logs_filters.go
+++ b/internal/telemetry/logs/service_logs_filters.go
@@ -1,0 +1,238 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
+)
+
+var (
+	httpStatusClassPattern = regexp.MustCompile(`(?i)^([1-5])xx$`)
+	httpStatusCodePattern  = regexp.MustCompile(`^[1-5][0-9]{2}$`)
+)
+
+func compileServiceLogsStructuredFilters(ctx context.Context, client *http.Client, cfg models.Config, args GetServiceLogsArgs, startTime, endTime time.Time, index string) ([]map[string]interface{}, []map[string]interface{}, error) {
+	extra := make([]map[string]interface{}, 0, len(args.AttributeFilters)+1)
+	for i, filter := range args.AttributeFilters {
+		field, err := compileServiceLogAttributeField(filter.Field, fmt.Sprintf("attribute_filters[%d].field", i))
+		if err != nil {
+			return nil, nil, err
+		}
+		extra = append(extra, map[string]interface{}{
+			"$eq": []interface{}{field, filter.Value},
+		})
+	}
+
+	class := strings.TrimSpace(args.HTTPStatusClass)
+	code := strings.TrimSpace(args.HTTPStatusCode)
+	if class == "" && code == "" {
+		if strings.TrimSpace(args.HTTPStatusField) != "" {
+			return nil, nil, fmt.Errorf("http_status_field requires http_status_class or http_status_code")
+		}
+		return extra, nil, nil
+	}
+
+	if class != "" && !httpStatusClassPattern.MatchString(class) {
+		return nil, nil, fmt.Errorf("invalid http_status_class %q: use 2xx, 3xx, 4xx, or 5xx", class)
+	}
+	if code != "" && !httpStatusCodePattern.MatchString(code) {
+		return nil, nil, fmt.Errorf("invalid http_status_code %q: use a 3-digit HTTP status such as 500 or 401", code)
+	}
+
+	explicitField := strings.TrimSpace(args.HTTPStatusField)
+	var (
+		statusField string
+		parseStages []map[string]interface{}
+		err         error
+	)
+	if explicitField != "" {
+		statusField, err = compileServiceLogAttributeField(explicitField, "http_status_field")
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		statusField, parseStages, err = resolveHTTPStatusField(ctx, client, cfg, args, startTime, endTime, index)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	extra = append(extra, httpStatusCondition(statusField, class, code))
+	return extra, parseStages, nil
+}
+
+func compileServiceLogAttributeField(field, path string) (string, error) {
+	next, err := sanitizeLogFieldRef(field, path)
+	if err != nil {
+		return "", err
+	}
+	if next == "" {
+		return "", fmt.Errorf("invalid log field reference %q at %s: use ServiceName, attributes['field'], or resources['field']", field, path)
+	}
+	if isCanonicalLogFieldRef(next) {
+		return next, nil
+	}
+	if logSimpleFieldRefPattern.MatchString(next) {
+		return fmt.Sprintf("attributes['%s']", next), nil
+	}
+	return "", fmt.Errorf("invalid log field reference %q at %s: use ServiceName, attributes['field'], or resources['field']", field, path)
+}
+
+func httpStatusCondition(field, class, code string) map[string]interface{} {
+	if httpStatusCodePattern.MatchString(code) {
+		return map[string]interface{}{
+			"$eq": []interface{}{field, code},
+		}
+	}
+	digit := httpStatusClassPattern.FindStringSubmatch(class)[1]
+	return map[string]interface{}{
+		"$regex": []interface{}{field, "^" + digit},
+	}
+}
+
+func resolveHTTPStatusField(ctx context.Context, client *http.Client, cfg models.Config, args GetServiceLogsArgs, startTime, endTime time.Time, index string) (string, []map[string]interface{}, error) {
+	pipeline := buildServiceLogsQuery(args.ServiceName, nil, nil)
+	if args.Env != "" {
+		pipeline = addServiceLogsEnvFilter(pipeline, args.Env)
+	}
+	validatedPipeline, err := prepareLogJSONQuery(pipeline, "pipeline")
+	if err != nil {
+		return "", nil, err
+	}
+
+	startSec := startTime.Unix()
+	endSec := endTime.Unix()
+	maxWindowSeconds := int64(utils.MaxLogAttributeLookbackMinutes * 60)
+	if endSec-startSec > maxWindowSeconds {
+		startSec = endSec - maxWindowSeconds
+	}
+
+	queryParams := url.Values{}
+	queryParams.Set("region", cfg.Region)
+	queryParams.Set("start", fmt.Sprintf("%d", startSec))
+	queryParams.Set("end", fmt.Sprintf("%d", endSec))
+	if index != "" {
+		queryParams.Set("index", index)
+	}
+
+	attrs, err := discoverLogAttributes(ctx, client, cfg, validatedPipeline, startSec, endSec, index, queryParams)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to discover HTTP status field: %w", err)
+	}
+
+	matches := make([]LogAttribute, 0)
+	for _, attr := range attrs {
+		if isHTTPStatusLikeAttribute(attr) {
+			matches = append(matches, attr)
+		}
+	}
+
+	if len(matches) == 0 {
+		return "", nil, fmt.Errorf("no HTTP status field found for this service/env/window; pass http_status_field with the logjson field to use (e.g. attributes['http.status_code'])")
+	}
+	if len(matches) > 1 {
+		names := make([]string, 0, len(matches))
+		for _, attr := range matches {
+			names = append(names, attr.FilterField)
+		}
+		return "", nil, fmt.Errorf("multiple HTTP status fields found (%s); pass http_status_field with the filter_field to use", strings.Join(names, ", "))
+	}
+
+	return matches[0].FilterField, parseStagesFromAttributeHint(matches[0]), nil
+}
+
+func isHTTPStatusLikeAttribute(attr LogAttribute) bool {
+	n := strings.ToLower(attr.Name)
+	f := strings.ToLower(attr.FilterField)
+	combined := n + " " + f
+	if strings.Contains(combined, "grpc") {
+		return false
+	}
+	needles := []string{
+		"http.response.status_code",
+		"http_response_status_code",
+		"http.status_code",
+		"http_status_code",
+		"http.status",
+		"http_status",
+		"status_code",
+		"statuscode",
+	}
+	for _, needle := range needles {
+		if n == needle || strings.Contains(n, needle) || strings.Contains(f, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseStagesFromAttributeHint(attr LogAttribute) []map[string]interface{} {
+	if attr.Source != "body" || strings.TrimSpace(attr.Hint) == "" {
+		return nil
+	}
+	var stages []map[string]interface{}
+	if err := json.Unmarshal([]byte(attr.Hint), &stages); err != nil {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, 1)
+	for _, stage := range stages {
+		if stageType, _ := stage["type"].(string); stageType == "parse" {
+			out = append(out, stage)
+		}
+	}
+	return out
+}
+
+func applyServiceLogsStructuredFilters(query []map[string]interface{}, extra []map[string]interface{}, parseStages []map[string]interface{}) []map[string]interface{} {
+	if len(extra) == 0 && len(parseStages) == 0 {
+		return query
+	}
+
+	if len(parseStages) == 0 {
+		if len(query) == 0 {
+			return query
+		}
+		filterStage := mapsClone(query[0])
+		queryMap, ok := filterStage["query"].(map[string]interface{})
+		if !ok {
+			return query
+		}
+		clonedQuery := mapsClone(queryMap)
+		andConditions, ok := clonedQuery["$and"].([]interface{})
+		if !ok {
+			return query
+		}
+		clonedConditions := append([]interface{}(nil), andConditions...)
+		for _, cond := range extra {
+			clonedConditions = append(clonedConditions, cond)
+		}
+		clonedQuery["$and"] = clonedConditions
+		filterStage["query"] = clonedQuery
+		query[0] = filterStage
+		return query
+	}
+
+	out := append([]map[string]interface{}{}, query...)
+	out = append(out, parseStages...)
+	if len(extra) > 0 {
+		conds := make([]interface{}, 0, len(extra))
+		for _, cond := range extra {
+			conds = append(conds, cond)
+		}
+		out = append(out, map[string]interface{}{
+			"type": "filter",
+			"query": map[string]interface{}{
+				"$and": conds,
+			},
+		})
+	}
+	return out
+}

--- a/internal/telemetry/logs/service_logs_filters.go
+++ b/internal/telemetry/logs/service_logs_filters.go
@@ -70,7 +70,17 @@ func compileServiceLogsStructuredFilters(ctx context.Context, client *http.Clien
 }
 
 func compileServiceLogAttributeField(field, path string) (string, error) {
-	next, err := sanitizeLogFieldRef(field, path)
+	trimmed := strings.TrimSpace(field)
+	// get_service_logs accepts a short attribute name and wraps it; fail-closed
+	// sanitize then checks the bracket form. Leave resource_ / trace-only / quoted
+	// syntax for sanitize to reject with its existing tips.
+	if logSimpleFieldRefPattern.MatchString(trimmed) &&
+		!isCanonicalLogFieldRef(trimmed) &&
+		!isTraceOnlyLogField(trimmed) &&
+		!strings.HasPrefix(trimmed, "resource_") {
+		trimmed = fmt.Sprintf("attributes['%s']", trimmed)
+	}
+	next, err := sanitizeLogFieldRef(trimmed, path)
 	if err != nil {
 		return "", err
 	}
@@ -79,9 +89,6 @@ func compileServiceLogAttributeField(field, path string) (string, error) {
 	}
 	if isCanonicalLogFieldRef(next) {
 		return next, nil
-	}
-	if logSimpleFieldRefPattern.MatchString(next) {
-		return fmt.Sprintf("attributes['%s']", next), nil
 	}
 	return "", fmt.Errorf("invalid log field reference %q at %s: use ServiceName, attributes['field'], or resources['field']", field, path)
 }

--- a/internal/telemetry/logs/service_logs_filters.go
+++ b/internal/telemetry/logs/service_logs_filters.go
@@ -193,9 +193,6 @@ func httpStatusAttributeBase(s string) string {
 	s = strings.TrimPrefix(s, "attributes['")
 	s = strings.TrimPrefix(s, "resources['")
 	s = strings.TrimSuffix(s, "']")
-	if i := strings.LastIndexAny(s, "./"); i >= 0 {
-		s = s[i+1:]
-	}
 	return strings.ReplaceAll(s, "-", "_")
 }
 

--- a/internal/telemetry/logs/service_logs_filters_test.go
+++ b/internal/telemetry/logs/service_logs_filters_test.go
@@ -1,0 +1,240 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"last9-mcp/internal/constants"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestCompileServiceLogAttributeField(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   string
+		want    string
+		wantErr string
+	}{
+		{name: "bracket attribute", field: "attributes['user_id']", want: "attributes['user_id']"},
+		{name: "simple name wraps as attribute", field: "user_id", want: "attributes['user_id']"},
+		{name: "canonical ServiceName", field: "ServiceName", want: "ServiceName"},
+		{name: "double quotes are invalid syntax", field: `attributes["user_id"]`, wantErr: "single quotes"},
+		{name: "flat resource_ prefix is invalid syntax", field: "resource_department", wantErr: "resources["},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := compileServiceLogAttributeField(tt.field, "attribute_filters[0].field")
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected syntax error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q missing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyServiceLogsStructuredFilters_CompilesEquality(t *testing.T) {
+	base := buildServiceLogsQuery("api", nil, nil)
+	extra := []map[string]interface{}{
+		{"$eq": []interface{}{"attributes['user_id']", "abc"}},
+	}
+	got := applyServiceLogsStructuredFilters(base, extra, nil)
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(raw)
+	if !strings.Contains(s, `attributes['user_id']`) || !strings.Contains(s, `"abc"`) {
+		t.Fatalf("compiled filter missing attribute equality: %s", s)
+	}
+	if strings.Contains(s, `"type":"parse"`) {
+		t.Fatalf("indexed attribute filter must not add parse: %s", s)
+	}
+}
+
+func TestGetServiceLogs_HTTP5xxUsesDiscoveredField(t *testing.T) {
+	var queryRangeHits atomic.Int32
+	var capturedPipeline string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, constants.EndpointLogsSeries):
+			_, _ = w.Write([]byte(`{"status":"success","data":[{"service":"checkout","status_code":"500"}]}`))
+		case r.URL.Path == constants.EndpointLogsQueryRange:
+			raw, _ := io.ReadAll(r.Body)
+			if strings.Contains(string(raw), `"$regex"`) {
+				queryRangeHits.Add(1)
+				capturedPipeline = string(raw)
+			}
+			_, _ = w.Write([]byte(streamsAPIResponse([]logValue{{Timestamp: "1000000000", Message: "boom"}})))
+		default:
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[]}}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	handler := NewGetServiceLogsHandler(server.Client(), testLogsConfig(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceLogsArgs{
+		ServiceName:     "checkout",
+		Env:             "production",
+		LookbackMinutes: 5,
+		HTTPStatusClass: "5xx",
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if queryRangeHits.Load() < 1 {
+		t.Fatal("expected query_range after successful status-field discovery")
+	}
+	if !strings.Contains(capturedPipeline, `attributes['status_code']`) {
+		t.Fatalf("compiled pipeline missing discovered status field: %s", capturedPipeline)
+	}
+	if !strings.Contains(capturedPipeline, `"$regex"`) || !strings.Contains(capturedPipeline, `"^5"`) {
+		t.Fatalf("compiled pipeline missing 5xx regex: %s", capturedPipeline)
+	}
+	if !strings.Contains(capturedPipeline, `"checkout"`) {
+		t.Fatalf("compiled pipeline missing service filter: %s", capturedPipeline)
+	}
+
+	payload := parseServiceLogsToolResult(t, result)
+	if payload["count"] != float64(1) {
+		t.Fatalf("expected 1 log, got %#v", payload["count"])
+	}
+}
+
+func TestGetServiceLogs_AmbiguousStatusFieldsMakeZeroQueryRange(t *testing.T) {
+	var queryRangeHits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == constants.EndpointLogsQueryRange {
+			raw, _ := io.ReadAll(r.Body)
+			if strings.Contains(string(raw), `"$regex"`) {
+				queryRangeHits.Add(1)
+			}
+		}
+		if strings.Contains(r.URL.Path, constants.EndpointLogsSeries) {
+			_, _ = w.Write([]byte(`{"status":"success","data":[{"http.status_code":"500","http_status_code":"500"}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[]}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	handler := NewGetServiceLogsHandler(server.Client(), testLogsConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceLogsArgs{
+		ServiceName:     "checkout",
+		LookbackMinutes: 5,
+		HTTPStatusClass: "5xx",
+	})
+	if err == nil {
+		t.Fatal("expected tool error asking for http_status_field")
+	}
+	if !strings.Contains(err.Error(), "http_status_field") {
+		t.Fatalf("error should ask for http_status_field, got %v", err)
+	}
+	if got := queryRangeHits.Load(); got != 0 {
+		t.Fatalf("ambiguous discovery made %d query_range calls, want 0", got)
+	}
+}
+
+func TestGetServiceLogs_InvalidAttributeSyntaxMakesZeroUpstream(t *testing.T) {
+	var n atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	t.Cleanup(server.Close)
+
+	handler := NewGetServiceLogsHandler(server.Client(), testLogsConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceLogsArgs{
+		ServiceName:     "checkout",
+		LookbackMinutes: 5,
+		AttributeFilters: []ServiceLogAttributeFilter{
+			{Field: `attributes["user_id"]`, Value: "abc"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected local syntax error")
+	}
+	if !strings.Contains(err.Error(), "single quotes") {
+		t.Fatalf("error %v should mention single quotes", err)
+	}
+	if got := n.Load(); got != 0 {
+		t.Fatalf("invalid syntax made %d upstream requests, want 0", got)
+	}
+}
+
+func TestGetServiceLogs_ExplicitStatusFieldSkipsDiscovery(t *testing.T) {
+	var seriesHits, queryRangeHits atomic.Int32
+	var capturedPipeline string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, constants.EndpointLogsSeries) {
+			seriesHits.Add(1)
+			_, _ = w.Write([]byte(`{"status":"success","data":[]}`))
+			return
+		}
+		if r.URL.Path == constants.EndpointLogsQueryRange {
+			queryRangeHits.Add(1)
+			raw, _ := io.ReadAll(r.Body)
+			capturedPipeline = string(raw)
+			_, _ = w.Write([]byte(streamsAPIResponse([]logValue{{Timestamp: "1", Message: "ok"}})))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[]}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	handler := NewGetServiceLogsHandler(server.Client(), testLogsConfig(server.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetServiceLogsArgs{
+		ServiceName:     "checkout",
+		LookbackMinutes: 5,
+		HTTPStatusCode:  "401",
+		HTTPStatusField: "attributes['http.status_code']",
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if got := seriesHits.Load(); got != 0 {
+		t.Fatalf("explicit field should skip series discovery, got %d", got)
+	}
+	if queryRangeHits.Load() < 1 {
+		t.Fatal("expected query_range")
+	}
+	if !strings.Contains(capturedPipeline, `attributes['http.status_code']`) || !strings.Contains(capturedPipeline, `"401"`) {
+		t.Fatalf("pipeline missing explicit 401 filter: %s", capturedPipeline)
+	}
+}
+
+func parseServiceLogsToolResult(t *testing.T, result *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	if result == nil || len(result.Content) == 0 {
+		t.Fatal("expected tool content")
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected text content, got %T", result.Content[0])
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(text.Text), &payload); err != nil {
+		t.Fatalf("parse result: %v", err)
+	}
+	return payload
+}

--- a/internal/telemetry/logs/service_logs_filters_test.go
+++ b/internal/telemetry/logs/service_logs_filters_test.go
@@ -82,14 +82,23 @@ func TestApplyServiceLogsStructuredFilters_MissingAndIsError(t *testing.T) {
 }
 
 func TestIsHTTPStatusLikeAttributeRejectsJobStatusCode(t *testing.T) {
-	if isHTTPStatusLikeAttribute(LogAttribute{Name: "job_status_code", FilterField: "attributes['job_status_code']"}) {
-		t.Fatal("job_status_code must not count as HTTP status")
+	cases := []struct {
+		name string
+		attr LogAttribute
+		want bool
+	}{
+		{name: "bare status_code", attr: LogAttribute{Name: "status_code", FilterField: "attributes['status_code']"}, want: true},
+		{name: "http.status_code", attr: LogAttribute{Name: "http.status_code", FilterField: "attributes['http.status_code']"}, want: true},
+		{name: "job_status_code", attr: LogAttribute{Name: "job_status_code", FilterField: "attributes['job_status_code']"}, want: false},
+		{name: "job.status_code", attr: LogAttribute{Name: "job.status_code", FilterField: "attributes['job.status_code']"}, want: false},
+		{name: "db.status_code", attr: LogAttribute{Name: "db.status_code", FilterField: "attributes['db.status_code']"}, want: false},
 	}
-	if !isHTTPStatusLikeAttribute(LogAttribute{Name: "status_code", FilterField: "attributes['status_code']"}) {
-		t.Fatal("status_code should count as HTTP status")
-	}
-	if !isHTTPStatusLikeAttribute(LogAttribute{Name: "http.status_code", FilterField: "attributes['http.status_code']"}) {
-		t.Fatal("http.status_code should count as HTTP status")
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isHTTPStatusLikeAttribute(tt.attr); got != tt.want {
+				t.Fatalf("isHTTPStatusLikeAttribute(%q) = %v, want %v", tt.attr.Name, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/telemetry/logs/service_logs_filters_test.go
+++ b/internal/telemetry/logs/service_logs_filters_test.go
@@ -55,7 +55,10 @@ func TestApplyServiceLogsStructuredFilters_CompilesEquality(t *testing.T) {
 	extra := []map[string]interface{}{
 		{"$eq": []interface{}{"attributes['user_id']", "abc"}},
 	}
-	got := applyServiceLogsStructuredFilters(base, extra, nil)
+	got, err := applyServiceLogsStructuredFilters(base, extra, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	raw, err := json.Marshal(got)
 	if err != nil {
 		t.Fatal(err)
@@ -66,6 +69,27 @@ func TestApplyServiceLogsStructuredFilters_CompilesEquality(t *testing.T) {
 	}
 	if strings.Contains(s, `"type":"parse"`) {
 		t.Fatalf("indexed attribute filter must not add parse: %s", s)
+	}
+}
+
+func TestApplyServiceLogsStructuredFilters_MissingAndIsError(t *testing.T) {
+	_, err := applyServiceLogsStructuredFilters(nil, []map[string]interface{}{
+		{"$eq": []interface{}{"attributes['status_code']", "500"}},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error when filters cannot be applied")
+	}
+}
+
+func TestIsHTTPStatusLikeAttributeRejectsJobStatusCode(t *testing.T) {
+	if isHTTPStatusLikeAttribute(LogAttribute{Name: "job_status_code", FilterField: "attributes['job_status_code']"}) {
+		t.Fatal("job_status_code must not count as HTTP status")
+	}
+	if !isHTTPStatusLikeAttribute(LogAttribute{Name: "status_code", FilterField: "attributes['status_code']"}) {
+		t.Fatal("status_code should count as HTTP status")
+	}
+	if !isHTTPStatusLikeAttribute(LogAttribute{Name: "http.status_code", FilterField: "attributes['http.status_code']"}) {
+		t.Fatal("http.status_code should count as HTTP status")
 	}
 }
 
@@ -116,6 +140,9 @@ func TestGetServiceLogs_HTTP5xxUsesDiscoveredField(t *testing.T) {
 	payload := parseServiceLogsToolResult(t, result)
 	if payload["count"] != float64(1) {
 		t.Fatalf("expected 1 log, got %#v", payload["count"])
+	}
+	if payload["http_status_field"] != "attributes['status_code']" {
+		t.Fatalf("expected discovered http_status_field in response, got %#v", payload["http_status_field"])
 	}
 }
 

--- a/internal/telemetry/traces/chunking_test.go
+++ b/internal/telemetry/traces/chunking_test.go
@@ -297,7 +297,12 @@ func TestGetTracesHandlerWindowAggregateAlsoUsesSingleRequest(t *testing.T) {
 	handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
 		TracejsonQuery: []map[string]interface{}{
-			{"type": "window_aggregate"},
+			{
+				"type":     "window_aggregate",
+				"function": map[string]interface{}{"$count": []interface{}{}},
+				"as":       "rate",
+				"window":   []interface{}{"5", "minutes"},
+			},
 		},
 		StartTimeISO: "2026-01-01T00:00:00Z",
 		EndTimeISO:   "2026-01-08T00:00:00Z",

--- a/internal/telemetry/traces/chunking_test.go
+++ b/internal/telemetry/traces/chunking_test.go
@@ -411,7 +411,7 @@ func TestGetTracesHandlerHardErrorsWhenAllChunksFail(t *testing.T) {
 	}
 }
 
-func TestGetTracesHandlerReturnsPartialResultAfterLaterChunkError(t *testing.T) {
+func TestGetTracesHandlerReturnsErrorAfterLaterChunkError(t *testing.T) {
 	rec := newTracesRequestRecorder()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()

--- a/internal/telemetry/traces/chunking_test.go
+++ b/internal/telemetry/traces/chunking_test.go
@@ -437,31 +437,20 @@ func TestGetTracesHandlerReturnsPartialResultAfterLaterChunkError(t *testing.T) 
 		Limit:        10,
 	})
 	if err != nil {
-		t.Fatalf("handler returned error on partial: %v", err)
+		t.Fatalf("expected tool execution error, got protocol error: %v", err)
 	}
-
+	if result == nil || !result.IsError {
+		t.Fatalf("expected IsError=true when a chunk fails, got %#v", result)
+	}
 	if rec.count() != 6 {
 		t.Fatalf("expected 6 chunk requests, got %d", rec.count())
 	}
-
-	payload := parseTracesToolResult(t, result)
-	if count := countTracesInPayload(t, payload); count != 3 {
-		t.Fatalf("expected 3 traces in partial result, got %d", count)
+	text := result.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(text, "chunk 6/6 failed") {
+		t.Fatalf("expected chunk 6/6 failure in error, got %q", text)
 	}
-
-	meta, ok := payload[partialResultMetadataKey].(map[string]interface{})
-	if !ok {
-		t.Fatalf("expected partial metadata in payload, got %#v", payload[partialResultMetadataKey])
-	}
-	if partial, ok := meta["partial_result"].(bool); !ok || !partial {
-		t.Fatalf("expected partial_result=true, got %#v", meta["partial_result"])
-	}
-	warning, ok := meta["warning"].(string)
-	if !ok || !strings.Contains(warning, "chunk 6/6 failed") {
-		t.Fatalf("expected chunk 6/6 failure in warning, got %q", warning)
-	}
-	if strings.Contains(warning, "backend error") {
-		t.Fatalf("partial-result warning leaked upstream body: %q", warning)
+	if strings.Contains(text, "backend error") {
+		t.Fatalf("error leaked upstream body: %q", text)
 	}
 }
 

--- a/internal/telemetry/traces/errors.go
+++ b/internal/telemetry/traces/errors.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
-	"unicode"
 
 	"last9-mcp/internal/utils"
 
@@ -21,13 +20,7 @@ var traceRequestIDPattern = regexp.MustCompile(`^[A-Za-z0-9-]{1,64}$`)
 
 var traceAPIStatusPattern = regexp.MustCompile(`^[a-z_]{1,32}$`)
 
-const traceUpstreamBodyLimit = 512
-
-var (
-	traceBodyURLPattern    = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.-]*://[^\s"'<>,}\]]+`)
-	traceBodyBearerPattern = regexp.MustCompile(`(?i)\bbearer\s+[^\s"',}]+`)
-	traceBodySecretPattern = regexp.MustCompile(`(?i)\b(token|api[_-]?key|secret|password|authorization)\b"?\s*[:=]\s*"?[^"',}\s]+`)
-)
+const traceUpstreamBodyLimit = utils.UpstreamBodyLimit
 
 type traceUpstreamError struct {
 	statusCode int
@@ -181,21 +174,5 @@ func readLimitedResponseBody(body io.Reader, limit int64) string {
 }
 
 func sanitizeUpstreamBody(raw string) string {
-	cleaned := traceBodyURLPattern.ReplaceAllString(raw, "[redacted-url]")
-	cleaned = traceBodyBearerPattern.ReplaceAllString(cleaned, "[redacted-credential]")
-	cleaned = traceBodySecretPattern.ReplaceAllString(cleaned, "[redacted-credential]")
-	cleaned = strings.Map(func(r rune) rune {
-		if r == '\n' || r == '\r' || r == '\t' {
-			return ' '
-		}
-		if unicode.IsControl(r) {
-			return -1
-		}
-		return r
-	}, cleaned)
-	cleaned = strings.Join(strings.Fields(cleaned), " ")
-	if len(cleaned) > traceUpstreamBodyLimit {
-		cleaned = strings.ToValidUTF8(cleaned[:traceUpstreamBodyLimit], "") + "… (truncated)"
-	}
-	return cleaned
+	return utils.SanitizeUpstreamBody(raw)
 }

--- a/internal/telemetry/traces/errors.go
+++ b/internal/telemetry/traces/errors.go
@@ -1,10 +1,8 @@
 package traces
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -19,8 +17,6 @@ const tracePipelineSchemaHint = `Pipeline stage schema: every stage needs "type"
 var traceRequestIDPattern = regexp.MustCompile(`^[A-Za-z0-9-]{1,64}$`)
 
 var traceAPIStatusPattern = regexp.MustCompile(`^[a-z_]{1,32}$`)
-
-const traceUpstreamBodyLimit = utils.UpstreamBodyLimit
 
 type traceUpstreamError struct {
 	statusCode int
@@ -86,14 +82,14 @@ func newTraceHTTPErrorWithHint(response *http.Response, hint string) error {
 		requestID:  traceRequestID(response.Header),
 	}
 	if status == http.StatusBadRequest || status == http.StatusUnprocessableEntity {
-		body := readLimitedResponseBody(response.Body, 4<<10)
+		body := utils.ReadLimitedResponseBody(response.Body, 4<<10)
 		err.message = fmt.Sprintf("Review the tool arguments and retry. Upstream response: %s", body)
 		if hint != "" {
 			err.message += "\n\n" + hint
 		}
 		return err
 	}
-	drainResponseBody(response.Body)
+	utils.DrainResponseBody(response.Body)
 	return err
 }
 
@@ -154,25 +150,4 @@ func traceLogCause(err error) error {
 		return upstreamErr.cause
 	}
 	return err
-}
-
-func drainResponseBody(body io.Reader) {
-	if body == nil {
-		return
-	}
-	_, _ = io.CopyN(io.Discard, body, 4<<10)
-}
-
-func readLimitedResponseBody(body io.Reader, limit int64) string {
-	if body == nil {
-		return ""
-	}
-	var buf bytes.Buffer
-	_, _ = io.CopyN(&buf, body, limit)
-	_, _ = io.CopyN(io.Discard, body, 4<<10)
-	return sanitizeUpstreamBody(buf.String())
-}
-
-func sanitizeUpstreamBody(raw string) string {
-	return utils.SanitizeUpstreamBody(raw)
 }

--- a/internal/telemetry/traces/errors_test.go
+++ b/internal/telemetry/traces/errors_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"last9-mcp/internal/utils"
+
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -232,7 +234,7 @@ func TestPipelineSchemaHintOnlyOnPipelineCallSites(t *testing.T) {
 
 func TestSanitizeUpstreamBodyRedactsAndBounds(t *testing.T) {
 	raw := `{"error":"bad pipeline","upstream_url":"https://internal-gw.example.com/v1/traces?token=SECRET_abc123","authorization":"Bearer eyJhbGciOi","host":"internal-gateway"}`
-	got := sanitizeUpstreamBody(raw)
+	got := utils.SanitizeUpstreamBody(raw)
 	for _, banned := range []string{"SECRET_abc123", "https://", "eyJhbGciOi"} {
 		if strings.Contains(got, banned) {
 			t.Fatalf("sanitizeUpstreamBody leaked %q: %s", banned, got)
@@ -244,7 +246,7 @@ func TestSanitizeUpstreamBodyRedactsAndBounds(t *testing.T) {
 }
 
 func TestSanitizeUpstreamBodyStripsControlCharacters(t *testing.T) {
-	got := sanitizeUpstreamBody("bad\x00pipeline\x1b[31m\nsecond line\tend")
+	got := utils.SanitizeUpstreamBody("bad\x00pipeline\x1b[31m\nsecond line\tend")
 	if strings.ContainsAny(got, "\x00\x1b\n\t") {
 		t.Fatalf("control characters survived: %q", got)
 	}
@@ -254,15 +256,15 @@ func TestSanitizeUpstreamBodyStripsControlCharacters(t *testing.T) {
 }
 
 func TestSanitizeUpstreamBodyTruncatesOnValidUTF8Boundary(t *testing.T) {
-	got := sanitizeUpstreamBody(strings.Repeat("é", 4096))
+	got := utils.SanitizeUpstreamBody(strings.Repeat("é", 4096))
 	if !utf8.ValidString(got) {
 		t.Fatalf("truncation produced invalid UTF-8: %q", got)
 	}
 	if !strings.Contains(got, "(truncated)") {
 		t.Fatalf("expected a truncation marker, got %q", got)
 	}
-	if len(got) > traceUpstreamBodyLimit+32 {
-		t.Fatalf("truncated body is %d bytes, want <= %d", len(got), traceUpstreamBodyLimit+32)
+	if len(got) > utils.UpstreamBodyLimit+32 {
+		t.Fatalf("truncated body is %d bytes, want <= %d", len(got), utils.UpstreamBodyLimit+32)
 	}
 }
 

--- a/internal/telemetry/traces/pipeline_fanout_verify_test.go
+++ b/internal/telemetry/traces/pipeline_fanout_verify_test.go
@@ -1,0 +1,81 @@
+package traces
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func countingTracesServer(t *testing.T) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var n atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"status":"error","error":"invalid pipeline"}`)
+	}))
+	t.Cleanup(server.Close)
+	return server, &n
+}
+
+func TestGetTraces_InvalidPipelinesMakeZeroUpstreamRequests(t *testing.T) {
+	cases := []struct {
+		name  string
+		query []map[string]interface{}
+	}{
+		{
+			name: "unknown stage type",
+			query: []map[string]interface{}{
+				{"type": "trace_filter"},
+			},
+		},
+		{
+			name: "window_aggregate aggregates+window_minutes",
+			query: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{"$and": []interface{}{map[string]interface{}{"$eq": []interface{}{"ServiceName", "checkout"}}}}},
+				{
+					"type":           "window_aggregate",
+					"aggregates":     []interface{}{map[string]interface{}{"function": map[string]interface{}{"$count": []interface{}{}}, "as": "_count"}},
+					"window_minutes": 5,
+				},
+			},
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			server, n := countingTracesServer(t)
+			handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
+			_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
+				TracejsonQuery:  tt.query,
+				LookbackMinutes: 5,
+			})
+			if err == nil {
+				t.Fatal("expected local validation error")
+			}
+			if got := n.Load(); got != 0 {
+				t.Fatalf("%s made %d upstream requests, want 0", tt.name, got)
+			}
+		})
+	}
+}
+
+func TestGetTraces_CanonicalWindowAggregateStillQueries(t *testing.T) {
+	server, n := countingTracesServer(t)
+	handler := NewGetTracesHandler(server.Client(), testChunkTracesConfig(server.URL))
+	_, _, _ = handler(context.Background(), &mcp.CallToolRequest{}, GetTracesArgs{
+		TracejsonQuery: []map[string]interface{}{
+			{"type": "filter", "query": map[string]interface{}{"$and": []interface{}{map[string]interface{}{"$eq": []interface{}{"ServiceName", "checkout"}}}}},
+			{"type": "window_aggregate", "function": map[string]interface{}{"$count": []interface{}{}}, "as": "rate", "window": []interface{}{"5", "minutes"}},
+		},
+		LookbackMinutes: 5,
+	})
+	if got := n.Load(); got < 1 {
+		t.Fatalf("canonical window_aggregate should still query upstream, got %d", got)
+	}
+}

--- a/internal/telemetry/traces/query_sanitize.go
+++ b/internal/telemetry/traces/query_sanitize.go
@@ -340,6 +340,45 @@ func normalizeTraceFilterField(field string) string {
 	return field
 }
 
+const (
+	traceCategoryUnknownStageType     = "unknown_stage_type"
+	traceCategoryUnknownStageKey      = "unknown_stage_key"
+	traceCategoryWindowAggregateShape = "window_aggregate_shape"
+)
+
+type tracePipelineError struct {
+	category string
+	path     string
+	msg      string
+}
+
+func (e *tracePipelineError) Error() string {
+	return fmt.Sprintf("%s (category=%s path=%s)", e.msg, e.category, e.path)
+}
+
+func (e *tracePipelineError) Category() string { return e.category }
+func (e *tracePipelineError) Path() string     { return e.path }
+
+// traceAllowedStageTypes is the last9/api tracejson stage set, including
+// traces-only transform and select. Unknown types fail closed locally.
+var traceAllowedStageTypes = map[string]struct{}{
+	"filter":           {},
+	"where":            {},
+	"parse":            {},
+	"transform":        {},
+	"select":           {},
+	"aggregate":        {},
+	"window_aggregate": {},
+}
+
+var windowAggregateAllowedKeys = map[string]struct{}{
+	"type":     {},
+	"function": {},
+	"as":       {},
+	"window":   {},
+	"groupby":  {},
+}
+
 func validateStageKeys(stage map[string]interface{}, stageType, path string) error {
 	if _, bad := stage["aggregations"]; bad {
 		return fmt.Errorf(
@@ -354,6 +393,62 @@ func validateStageKeys(stage map[string]interface{}, stageType, path string) err
 				"Example: \"groupby\": {\"ServiceName\": \"service\", \"SpanName\": \"span\"}",
 			path, stageType,
 		)
+	}
+
+	if _, ok := traceAllowedStageTypes[stageType]; !ok {
+		return &tracePipelineError{
+			category: traceCategoryUnknownStageType,
+			path:     path,
+			msg:      fmt.Sprintf("unknown trace pipeline stage type %q; allowed: filter, where, parse, transform, select, aggregate, window_aggregate", stageType),
+		}
+	}
+
+	if stageType == "window_aggregate" {
+		if err := validateWindowAggregateStage(stage, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateWindowAggregateStage(stage map[string]interface{}, path string) error {
+	for key := range stage {
+		if _, ok := windowAggregateAllowedKeys[key]; ok {
+			continue
+		}
+		if key == "aggregates" || key == "window_minutes" {
+			return &tracePipelineError{
+				category: traceCategoryWindowAggregateShape,
+				path:     path,
+				msg:      `window_aggregate accepts only {"type":"window_aggregate","function":{...},"as":"...","window":["N","minutes"]}`,
+			}
+		}
+		return &tracePipelineError{
+			category: traceCategoryUnknownStageKey,
+			path:     path,
+			msg:      fmt.Sprintf("unknown key %q on window_aggregate stage", key),
+		}
+	}
+	if _, ok := stage["function"]; !ok {
+		return &tracePipelineError{
+			category: traceCategoryWindowAggregateShape,
+			path:     path,
+			msg:      `window_aggregate requires "function", "as", and "window"`,
+		}
+	}
+	if _, ok := stage["as"]; !ok {
+		return &tracePipelineError{
+			category: traceCategoryWindowAggregateShape,
+			path:     path,
+			msg:      `window_aggregate requires "function", "as", and "window"`,
+		}
+	}
+	if _, ok := stage["window"]; !ok {
+		return &tracePipelineError{
+			category: traceCategoryWindowAggregateShape,
+			path:     path,
+			msg:      `window_aggregate requires "function", "as", and "window"`,
+		}
 	}
 	return nil
 }

--- a/internal/telemetry/traces/query_sanitize_test.go
+++ b/internal/telemetry/traces/query_sanitize_test.go
@@ -2,6 +2,7 @@ package traces
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -84,6 +85,19 @@ func TestSanitizeTraceJSONQuery_ValidPipelines(t *testing.T) {
 			},
 		},
 		{
+			name: "window_aggregate with groupby",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{"$neq": []interface{}{"TraceId", ""}}},
+				{
+					"type":     "window_aggregate",
+					"function": map[string]interface{}{"$count": []interface{}{}},
+					"as":       "requests_per_min",
+					"window":   []interface{}{"5", "minutes"},
+					"groupby":  map[string]interface{}{"ServiceName": "service"},
+				},
+			},
+		},
+		{
 			name: "filter after aggregate (HAVING-style)",
 			stages: []map[string]interface{}{
 				{"type": "filter", "query": map[string]interface{}{"$eq": []interface{}{"StatusCode", "STATUS_CODE_ERROR"}}},
@@ -126,6 +140,13 @@ func TestSanitizeTraceJSONQuery_ValidPipelines(t *testing.T) {
 			},
 		},
 		{
+			name: "select stage",
+			stages: []map[string]interface{}{
+				{"type": "filter", "query": map[string]interface{}{"$neq": []interface{}{"TraceId", ""}}},
+				{"type": "select", "labels": map[string]interface{}{"ServiceName": "service", "Duration": "duration"}},
+			},
+		},
+		{
 			name: "all statistical aggregate functions",
 			stages: []map[string]interface{}{
 				{"type": "filter", "query": map[string]interface{}{"$neq": []interface{}{"Duration", ""}}},
@@ -147,6 +168,79 @@ func TestSanitizeTraceJSONQuery_ValidPipelines(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := SanitizeTraceJSONQuery(tt.stages); err != nil {
 				t.Errorf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestSanitizeTraceJSONQuery_UnknownStageType(t *testing.T) {
+	err := SanitizeTraceJSONQuery([]map[string]interface{}{
+		{"type": "trace_filter"},
+	})
+	if err == nil {
+		t.Fatal("expected unknown stage type to fail closed")
+	}
+	var pipeErr *tracePipelineError
+	if !errors.As(err, &pipeErr) {
+		t.Fatalf("want tracePipelineError, got %T %v", err, err)
+	}
+	if pipeErr.Category() != traceCategoryUnknownStageType {
+		t.Fatalf("category=%s want %s err=%v", pipeErr.Category(), traceCategoryUnknownStageType, err)
+	}
+	if pipeErr.Path() != "tracejson_query[0]" {
+		t.Fatalf("path=%q want tracejson_query[0]", pipeErr.Path())
+	}
+}
+
+func TestSanitizeTraceJSONQuery_WindowAggregateWrongKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		stage    map[string]interface{}
+		category string
+	}{
+		{
+			name: "aggregates+window_minutes",
+			stage: map[string]interface{}{
+				"type":           "window_aggregate",
+				"aggregates":     []interface{}{map[string]interface{}{"function": map[string]interface{}{"$count": []interface{}{}}, "as": "_count"}},
+				"window_minutes": 5,
+			},
+			category: traceCategoryWindowAggregateShape,
+		},
+		{
+			name: "unknown extra key",
+			stage: map[string]interface{}{
+				"type":     "window_aggregate",
+				"function": map[string]interface{}{"$count": []interface{}{}},
+				"as":       "rate",
+				"window":   []interface{}{"5", "minutes"},
+				"bogus":    true,
+			},
+			category: traceCategoryUnknownStageKey,
+		},
+		{
+			name: "missing function as window",
+			stage: map[string]interface{}{
+				"type": "window_aggregate",
+			},
+			category: traceCategoryWindowAggregateShape,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := SanitizeTraceJSONQuery([]map[string]interface{}{tt.stage})
+			if err == nil {
+				t.Fatal("expected window_aggregate shape to fail closed")
+			}
+			var pipeErr *tracePipelineError
+			if !errors.As(err, &pipeErr) {
+				t.Fatalf("want tracePipelineError, got %T %v", err, err)
+			}
+			if pipeErr.Category() != tt.category {
+				t.Fatalf("category=%s want %s err=%v", pipeErr.Category(), tt.category, err)
+			}
+			if pipeErr.Path() == "" {
+				t.Fatal("expected JSON path on validation error")
 			}
 		})
 	}

--- a/internal/telemetry/traces/traces.go
+++ b/internal/telemetry/traces/traces.go
@@ -28,8 +28,6 @@ type GetTracesArgs struct {
 	Limit           int                      `json:"limit,omitempty" jsonschema:"Maximum number of traces to return (optional, default: 5000)"`
 }
 
-const partialResultMetadataKey = "_last9_mcp"
-
 // NewGetTracesHandler creates a handler for getting traces using tracejson_query parameter
 func NewGetTracesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetTracesArgs) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, args GetTracesArgs) (*mcp.CallToolResult, any, error) {
@@ -262,18 +260,9 @@ func fetchTraceJSONQuery(ctx context.Context, client *http.Client, cfg models.Co
 	data["result"] = mergedItems
 
 	if partialErr != nil {
-		annotatePartialGetTracesResponse(baseResponse, partialErr, len(chunks), len(mergedItems))
-		if chunkingDebug {
-			log.Printf(
-				"[chunking] get_traces chunking partial chunks=%d returned_traces=%d start_ms=%d end_ms=%d err=%v",
-				len(chunks),
-				len(mergedItems),
-				startMs,
-				endMs,
-				partialErr,
-			)
-		}
-	} else if chunkingDebug {
+		return nil, fmt.Errorf("%w (window start_ms=%d end_ms=%d)", partialErr, startMs, endMs)
+	}
+	if chunkingDebug {
 		log.Printf(
 			"[chunking] get_traces chunking complete chunks=%d returned_traces=%d start_ms=%d end_ms=%d",
 			len(chunks), len(mergedItems), startMs, endMs,
@@ -281,15 +270,6 @@ func fetchTraceJSONQuery(ctx context.Context, client *http.Client, cfg models.Co
 	}
 
 	return baseResponse, nil
-}
-
-func annotatePartialGetTracesResponse(response map[string]interface{}, err error, totalChunks, returnedTraces int) {
-	response[partialResultMetadataKey] = map[string]interface{}{
-		"partial_result":  true,
-		"warning":         fmt.Sprintf("Returning partial results: %v", err),
-		"total_chunks":    totalChunks,
-		"returned_traces": returnedTraces,
-	}
 }
 
 // executeTraceJSONQuery performs a single API call for a given time window.

--- a/internal/utils/service_logs.go
+++ b/internal/utils/service_logs.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -15,9 +14,9 @@ import (
 	"last9-mcp/internal/models"
 )
 
-// pipelineSchemaHint teaches the model how to fix a rejected pipeline instead
+// LogsPipelineSchemaHint teaches the model how to fix a rejected pipeline instead
 // of leaving it to guess from a bare status code.
-const pipelineSchemaHint = `Pipeline stage schema: every stage needs "type" (filter | parse | aggregate | window_aggregate). filter: {"type":"filter","query":{"$and":[{"$eq":["ServiceName","svc"]},{"$containsWords":["Body","text"]}]}}. Field names are exact: ServiceName (not service_name), Body, SeverityText; attributes['name'] / resources['name'] for others. Body-derived JSON fields need a parse stage first. To get exact field names + required parse stages for your scope, call get_log_attributes_for_pipeline with your filter stages.`
+const LogsPipelineSchemaHint = `Pipeline stage schema: every stage needs "type" (filter | parse | aggregate | window_aggregate). filter: {"type":"filter","query":{"$and":[{"$eq":["ServiceName","svc"]},{"$containsWords":["Body","text"]}]}}. Field names are exact: ServiceName (not service_name), Body, SeverityText; attributes['name'] / resources['name'] for others. Body-derived JSON fields need a parse stage first. To get exact field names + required parse stages for your scope, call get_log_attributes_for_pipeline with your filter stages.`
 
 // MakeLogsJSONQueryAPI posts a raw log JSON pipeline to the query_range API with the given time range.
 func MakeLogsJSONQueryAPI(ctx context.Context, client *http.Client, cfg models.Config, pipeline any, startMs, endMs int64, limit int, index string) (*http.Response, error) {
@@ -73,15 +72,6 @@ func MakeLogsJSONQueryAPI(ctx context.Context, client *http.Client, cfg models.C
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
-	}
-
-	// Self-healing errors: a 400 means the pipeline itself was rejected, so
-	// teach the fix in-band instead of returning a bare status to the model.
-	// Other statuses are left for the caller to handle unchanged.
-	if resp.StatusCode == http.StatusBadRequest {
-		defer resp.Body.Close()
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("logs API request failed with status %d: %s\n\n%s", resp.StatusCode, string(respBody), pipelineSchemaHint)
 	}
 
 	return resp, nil

--- a/internal/utils/service_logs_test.go
+++ b/internal/utils/service_logs_test.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 )
 
-func TestMakeLogsJSONQueryAPI_400WrapsSelfHealingHint(t *testing.T) {
-	const bodyText = `{"error":"invalid pipeline: unknown stage type"}`
+func TestMakeLogsJSONQueryAPI_400ReturnsResponse(t *testing.T) {
+	const bodyText = `{"error":"invalid pipeline: unknown stage type","url":"https://internal.example/query"}`
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(bodyText))
@@ -20,17 +19,15 @@ func TestMakeLogsJSONQueryAPI_400WrapsSelfHealingHint(t *testing.T) {
 	pipeline := []map[string]interface{}{{"type": "filter"}}
 
 	resp, err := MakeLogsJSONQueryAPI(context.Background(), srv.Client(), cfg, pipeline, 0, 60000, 100, "")
-	if resp != nil {
-		t.Fatalf("expected nil response on 400, got %#v", resp)
+	if err != nil {
+		t.Fatalf("400 must return the response so the caller can sanitize: %v", err)
 	}
-	if err == nil {
-		t.Fatal("expected an error for a 400 response, got nil")
+	if resp == nil {
+		t.Fatal("expected 400 response")
 	}
-	if !strings.Contains(err.Error(), "get_log_attributes_for_pipeline") {
-		t.Errorf("error missing self-healing hint: %v", err)
-	}
-	if !strings.Contains(err.Error(), bodyText) {
-		t.Errorf("error missing original body: %v", err)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
 	}
 }
 

--- a/internal/utils/upstream_http.go
+++ b/internal/utils/upstream_http.go
@@ -1,0 +1,91 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+const UpstreamBodyLimit = 512
+
+var (
+	upstreamBodyURLPattern    = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.-]*://[^\s"'<>,}\]]+`)
+	upstreamBodyBearerPattern = regexp.MustCompile(`(?i)\bbearer\s+[^\s"',}]+`)
+	upstreamBodySecretPattern = regexp.MustCompile(`(?i)\b(token|api[_-]?key|secret|password|authorization)\b"?\s*[:=]\s*"?[^"',}\s]+`)
+)
+
+// SanitizeUpstreamBody redacts URLs/credentials, strips controls, and bounds size
+// so 400 bodies can be relayed to the model without leaking internals.
+func SanitizeUpstreamBody(raw string) string {
+	cleaned := upstreamBodyURLPattern.ReplaceAllString(raw, "[redacted-url]")
+	cleaned = upstreamBodyBearerPattern.ReplaceAllString(cleaned, "[redacted-credential]")
+	cleaned = upstreamBodySecretPattern.ReplaceAllString(cleaned, "[redacted-credential]")
+	cleaned = strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r == '\t' {
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, cleaned)
+	cleaned = strings.Join(strings.Fields(cleaned), " ")
+	if len(cleaned) > UpstreamBodyLimit {
+		cleaned = strings.ToValidUTF8(cleaned[:UpstreamBodyLimit], "") + "… (truncated)"
+	}
+	return cleaned
+}
+
+// NewUpstreamHTTPError maps a non-OK HTTP response to a tool-facing error.
+// 400/422 bodies are sanitized and included. 5xx bodies are drained and omitted.
+func NewUpstreamHTTPError(resp *http.Response, op string) error {
+	if resp == nil {
+		return fmt.Errorf("%s failed: empty upstream response", op)
+	}
+	status := resp.StatusCode
+	if status == http.StatusBadRequest || status == http.StatusUnprocessableEntity {
+		body := readLimitedResponseBody(resp.Body, 4<<10)
+		return fmt.Errorf("%s failed with HTTP %d. Review the tool arguments and retry. Upstream response: %s", op, status, body)
+	}
+	drainResponseBody(resp.Body)
+	return fmt.Errorf("%s failed with HTTP %d. %s", op, status, upstreamStatusAdvice(status))
+}
+
+func upstreamStatusAdvice(statusCode int) string {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return "Check the connection credentials and data access."
+	case http.StatusNotFound:
+		return "The capability may be unavailable or disabled."
+	case http.StatusRequestTimeout:
+		return "Retry after a short delay or request a smaller time window."
+	case http.StatusTooManyRequests:
+		return "Rate limited; retry after a short delay."
+	default:
+		if statusCode >= http.StatusInternalServerError {
+			return "The upstream service is temporarily unavailable; retry later."
+		}
+		return "Review the tool arguments and retry."
+	}
+}
+
+func drainResponseBody(body io.Reader) {
+	if body == nil {
+		return
+	}
+	_, _ = io.CopyN(io.Discard, body, 4<<10)
+}
+
+func readLimitedResponseBody(body io.Reader, limit int64) string {
+	if body == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	_, _ = io.CopyN(&buf, body, limit)
+	_, _ = io.CopyN(io.Discard, body, 4<<10)
+	return SanitizeUpstreamBody(buf.String())
+}

--- a/internal/utils/upstream_http.go
+++ b/internal/utils/upstream_http.go
@@ -42,16 +42,21 @@ func SanitizeUpstreamBody(raw string) string {
 
 // NewUpstreamHTTPError maps a non-OK HTTP response to a tool-facing error.
 // 400/422 bodies are sanitized and included. 5xx bodies are drained and omitted.
-func NewUpstreamHTTPError(resp *http.Response, op string) error {
+// Optional hint is appended after 400/422 bodies (e.g. pipeline schema reminder).
+func NewUpstreamHTTPError(resp *http.Response, op string, hint ...string) error {
 	if resp == nil {
 		return fmt.Errorf("%s failed: empty upstream response", op)
 	}
 	status := resp.StatusCode
 	if status == http.StatusBadRequest || status == http.StatusUnprocessableEntity {
-		body := readLimitedResponseBody(resp.Body, 4<<10)
-		return fmt.Errorf("%s failed with HTTP %d. Review the tool arguments and retry. Upstream response: %s", op, status, body)
+		body := ReadLimitedResponseBody(resp.Body, 4<<10)
+		msg := fmt.Sprintf("%s failed with HTTP %d. Review the tool arguments and retry. Upstream response: %s", op, status, body)
+		if len(hint) > 0 && strings.TrimSpace(hint[0]) != "" {
+			msg += "\n\n" + hint[0]
+		}
+		return fmt.Errorf("%s", msg)
 	}
-	drainResponseBody(resp.Body)
+	DrainResponseBody(resp.Body)
 	return fmt.Errorf("%s failed with HTTP %d. %s", op, status, upstreamStatusAdvice(status))
 }
 
@@ -73,14 +78,14 @@ func upstreamStatusAdvice(statusCode int) string {
 	}
 }
 
-func drainResponseBody(body io.Reader) {
+func DrainResponseBody(body io.Reader) {
 	if body == nil {
 		return
 	}
 	_, _ = io.CopyN(io.Discard, body, 4<<10)
 }
 
-func readLimitedResponseBody(body io.Reader, limit int64) string {
+func ReadLimitedResponseBody(body io.Reader, limit int64) string {
 	if body == nil {
 		return ""
 	}

--- a/internal/utils/upstream_http_test.go
+++ b/internal/utils/upstream_http_test.go
@@ -1,0 +1,61 @@
+package utils
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestNewUpstreamHTTPErrorRelays400Body(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body:       io.NopCloser(strings.NewReader(`{"error":"parse error: unexpected identifier"}`)),
+	}
+	err := NewUpstreamHTTPError(resp, "Prometheus range query")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "parse error: unexpected identifier") {
+		t.Fatalf("400 body missing from error: %s", got)
+	}
+	if !strings.Contains(got, "HTTP 400") {
+		t.Fatalf("status missing from error: %s", got)
+	}
+}
+
+func TestNewUpstreamHTTPErrorDrains502Body(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Body:       io.NopCloser(strings.NewReader(`{"error":"gateway SECRET https://internal.example/x"}`)),
+	}
+	err := NewUpstreamHTTPError(resp, "logs query")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	if strings.Contains(got, "SECRET") || strings.Contains(got, "https://") {
+		t.Fatalf("502 body leaked: %s", got)
+	}
+	if !strings.Contains(got, "HTTP 502") {
+		t.Fatalf("status missing from error: %s", got)
+	}
+}
+
+func TestSanitizeUpstreamBodyRedactsAndBounds(t *testing.T) {
+	raw := `{"error":"bad pipeline","upstream_url":"https://internal-gw.example.com/v1/traces?token=SECRET_abc123","authorization":"Bearer eyJhbGciOi"}`
+	got := SanitizeUpstreamBody(raw)
+	for _, banned := range []string{"SECRET_abc123", "https://", "eyJhbGciOi"} {
+		if strings.Contains(got, banned) {
+			t.Fatalf("SanitizeUpstreamBody leaked %q: %s", banned, got)
+		}
+	}
+	if !strings.Contains(got, "bad pipeline") {
+		t.Fatalf("SanitizeUpstreamBody dropped the actionable rejection text: %s", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("invalid utf8: %q", got)
+	}
+}

--- a/internal/utils/upstream_http_test.go
+++ b/internal/utils/upstream_http_test.go
@@ -11,7 +11,7 @@ import (
 func TestNewUpstreamHTTPErrorRelays400Body(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: http.StatusBadRequest,
-		Body:       io.NopCloser(strings.NewReader(`{"error":"parse error: unexpected identifier"}`)),
+		Body:       io.NopCloser(strings.NewReader(`{"error":"parse error: unexpected identifier","url":"https://internal.example/v1?token=SECRET"}`)),
 	}
 	err := NewUpstreamHTTPError(resp, "Prometheus range query")
 	if err == nil {
@@ -23,6 +23,30 @@ func TestNewUpstreamHTTPErrorRelays400Body(t *testing.T) {
 	}
 	if !strings.Contains(got, "HTTP 400") {
 		t.Fatalf("status missing from error: %s", got)
+	}
+	if !strings.Contains(got, "[redacted-url]") {
+		t.Fatalf("expected URL redaction, got %s", got)
+	}
+	if strings.Contains(got, "https://") || strings.Contains(got, "SECRET") {
+		t.Fatalf("400 body leaked internals: %s", got)
+	}
+}
+
+func TestNewUpstreamHTTPErrorTruncatesAndHints(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body:       io.NopCloser(strings.NewReader(`{"error":"` + strings.Repeat("x", 800) + `"}`)),
+	}
+	err := NewUpstreamHTTPError(resp, "logs query", LogsPipelineSchemaHint)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "… (truncated)") {
+		t.Fatalf("expected truncation marker, got %s", got)
+	}
+	if !strings.Contains(got, "get_log_attributes_for_pipeline") {
+		t.Fatalf("expected pipeline hint, got %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Align served whale descriptions with last9/api (`window_aggregate` is `function`/`as`/`window`; traces lookback 60) so description-only agents stop sending `aggregates`+`window_minutes` (ENG-1730).
- Honest failures: PromQL/logs 400s relay the sanitized API body; 5xx bodies are drained; any failed log/trace chunk is `isError` instead of OK `partial_result`.
- `get_traces` fail-closes unknown stages and illegal `window_aggregate` keys before upstream. `get_service_logs` compiles HTTP status class/code and named-attribute filters server-side. On-call / `get_exceptions` route status-class log search to `get_service_logs`.

Waterfall `evidence.partial` and deviations `partial_errors` are unchanged. Logs fail-closed stage allowlist from ENG-1729 is **not** in this PR (ships in #211).

## Test plan
- [x] `go test ./...`
- [x] `go test -run 'TestDumpTools|TestDumpToolsInvestigate|TestOnCallRunbook' .`
- [x] Live MCP against this branch: illegal trace `window_aggregate` local error; PromQL 400 includes parse body; `get_service_logs` invalid attribute syntax local error; HTTP 5xx discovers or asks for `http_status_field`
- [ ] Restart Cursor `last9_local` and try HTTP 5xx / bad PromQL in a fresh chat
- [ ] Follow-up: flip `log_tool_selection` evals from `get_logs` to `get_service_logs` for HTTP status (current fixtures would fail on purpose)


Made with [Cursor](https://cursor.com)