### PR TITLE
feat(mcp): add continuous profiling tools (ENG-1067)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Why markdown-only: Go constants are invisible to the eval harness and docs tooli
 
 ### Toolsets
 
-- CLI/env: `--toolsets` / `LAST9_TOOLSETS` (alias `LAST9_MCP_TOOLSETS`). Comma-separated: `logs`, `traces`, `metrics`, `alerts`, `dashboards`, `investigate`, `all`.
+- CLI/env: `--toolsets` / `LAST9_TOOLSETS` (alias `LAST9_MCP_TOOLSETS`). Comma-separated: `logs`, `traces`, `metrics`, `alerts`, `dashboards`, `profiles`, `investigate`, `all`.
 - Empty / unset / `all` → full surface. Unknown names fail fast with the valid list. Membership lives in `internal/toolsets`.
 - `dump-tools` honors the same flags/env (loads `.env` first). Canonical snapshot is unset/`all`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Continuous profiling MCP tools backed by `POST /profiles/api/v1/query_range/json` (same contract as the Profiling UI): `get_profile_services` (service index), `get_flamegraph` (nested tree), `get_top_functions` (self-sample ranking), and `get_profile_summary` (short NL triage). New `profiles` toolset; also included in `investigate`. Tenants without profiling enabled get a clear error asking them to contact the Last9 team (#214).
+
 ## [0.15.0] - 2026-08-10
 
 ### Fixed

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,7 +37,7 @@ Long DSL manuals, stage catalogs, and deep examples that used to bloat tool desc
 _Avoid_: stuffing manuals into the tool description; using prompts as a dump for reference docs
 
 **Named toolsets** (v1):
-Domain groups that partition the served tool surface: `logs`, `traces`, `metrics`, `alerts`, `dashboards`, plus `all` and the composite `investigate` (`logs`+`traces`+`metrics`+discovery helpers, no dashboard/alert writes). Operators may combine domain toolsets.
+Domain groups that partition the served tool surface: `logs`, `traces`, `metrics`, `alerts`, `dashboards`, `profiles`, plus `all` and the composite `investigate` (`logs`+`traces`+`metrics`+`profiles`+discovery helpers, no dashboard/alert writes). Operators may combine domain toolsets.
 _Avoid_: per-tool toggles as the primary UX; write-only toolset as a v1 requirement
 
 **Description whales**:

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The NPM route is easier on Windows — no path management.
 | `LAST9_REFRESH_TOKEN`        | *(required)*         | Refresh token from [API Access](https://app.last9.io/settings/api-access) |
 | `LAST9_DATASOURCE`           | org default          | Datasource/cluster name — useful when you have multiple Levitate clusters |
 | `LAST9_API_HOST`             | `app.last9.io`       | Override the API host |
-| `LAST9_TOOLSETS`             | all tools            | Comma-separated toolsets to expose (`logs`, `traces`, `metrics`, `alerts`, `dashboards`, `investigate`, `all`). Alias: `LAST9_MCP_TOOLSETS` |
+| `LAST9_TOOLSETS`             | all tools            | Comma-separated toolsets to expose (`logs`, `traces`, `metrics`, `alerts`, `dashboards`, `profiles`, `investigate`, `all`). Alias: `LAST9_MCP_TOOLSETS` |
 | `LAST9_MAX_GET_LOGS_ENTRIES` | `5000`               | Max entries for chunked `get_logs` requests |
 | `LAST9_DEBUG_CHUNKING`       | `false`              | Set `true` to log chunk-planning details for `get_logs`, `get_service_logs`, `get_traces` |
 | `LAST9_DISABLE_TELEMETRY`    | `true`               | Set `false` to enable internal OTel tracing |
@@ -308,7 +308,7 @@ Point these at a different datasource/cluster than the default by setting `LAST9
 
 **Deep links on every response.** Every tool returns a `deep_link` field — a direct URL into the Last9 dashboard for that exact query and time range. The agent can hand you the link; you click it; you're there.
 
-**Toolsets.** By default the server exposes every tool. Automation hosts that only need investigation (logs/traces/metrics) can set `LAST9_TOOLSETS=investigate` (or pass `--toolsets=investigate`) so `tools/list` stays small without client-side mass-disable. Named packs: `logs`, `traces`, `metrics`, `alerts`, `dashboards`, `investigate`, `all`. Unknown names fail fast. The `metrics` pack alone does **not** include `list_datasources` or `did_you_mean` — use `investigate` (or combine toolsets) when you need those discovery helpers.
+**Toolsets.** By default the server exposes every tool. Automation hosts that only need investigation (logs/traces/metrics/profiles) can set `LAST9_TOOLSETS=investigate` (or pass `--toolsets=investigate`) so `tools/list` stays small without client-side mass-disable. Named packs: `logs`, `traces`, `metrics`, `alerts`, `dashboards`, `profiles`, `investigate`, `all`. Unknown names fail fast. The `metrics` pack alone does **not** include `list_datasources` or `did_you_mean` — use `investigate` (or combine toolsets) when you need those discovery helpers.
 
 **Tool reference resources.** Long logjson/tracejson/service-logs/metrics manuals are MCP resources (`last9://reference/logjson`, `last9://reference/tracejson`, `last9://reference/service_logs`, `last9://reference/metrics`), not always-on tool description text. Critical query rules stay on the tool description so agents that never call `resources/read` still get correct construction guidance. Discover org-specific fields with `get_log_attributes` / `get_log_attributes_for_pipeline` (and the trace equivalents)—they are not injected into descriptions.
 

--- a/dump_test.go
+++ b/dump_test.go
@@ -32,8 +32,8 @@ func TestDumpTools(t *testing.T) {
 	// All registered tools must be covered — the whole point of dump-tools.
 	// A loose floor would let a regression silently drop tools. Tighten this
 	// when the committed snapshot + CI equality gate supersedes it.
-	if len(out.Tools) < 38 {
-		t.Fatalf("expected at least 38 tools, got %d", len(out.Tools))
+	if len(out.Tools) < 42 {
+		t.Fatalf("expected at least 42 tools, got %d", len(out.Tools))
 	}
 	if !sort.SliceIsSorted(out.Tools, func(i, j int) bool { return out.Tools[i].Name < out.Tools[j].Name }) {
 		t.Fatal("tools are not sorted by name (output must be deterministic for snapshot diffing)")

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -18,6 +18,9 @@ const (
 	// Used for pipeline-scoped attribute discovery.
 	EndpointLogsSeries = "/logs/api/v2/series/json"
 
+	// Profiles API endpoints (continuous profiling / flamegraphs — PDE-718).
+	EndpointProfilesQueryRange = "/profiles/api/v1/query_range/json"
+
 	// Prometheus API endpoints
 	EndpointPromQueryInstant = "/prom_query_instant"
 	EndpointPromQuery        = "/prom_query"

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -51,7 +51,7 @@ const (
 	DefaultHTTPTimeout = 3 * time.Minute
 
 	// PerChunkHTTPTimeout bounds a single chunked upstream call so one slow
-	// chunk can't stall the whole tool invocation. ENG-914.
+	// chunk can't stall the whole tool invocation.
 	PerChunkHTTPTimeout = 30 * time.Second
 )
 

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -18,7 +18,7 @@ const (
 	// Used for pipeline-scoped attribute discovery.
 	EndpointLogsSeries = "/logs/api/v2/series/json"
 
-	// Profiles API endpoints (continuous profiling / flamegraphs — PDE-718).
+	// Profiles API endpoints (continuous profiling / flamegraphs).
 	EndpointProfilesQueryRange = "/profiles/api/v1/query_range/json"
 
 	// Prometheus API endpoints

--- a/internal/prompts/descriptions/get_flamegraph.md
+++ b/internal/prompts/descriptions/get_flamegraph.md
@@ -7,14 +7,16 @@ the Profiling UI.
 Critical rules:
 - service is required. Discover candidates with get_profile_services first.
 - Default profile_type is cpu. Always pin a type; never omit it when comparing
-  windows or you will mix units.
+  windows or you will mix units. Unknown profile_type values are rejected.
 - value = inclusive samples; self = exclusive samples on that frame.
 - truncated=true means the API row limit was hit; tighten filters or the window.
 - Prefer lookback_minutes OR explicit start_time_iso/end_time_iso; default 60m.
+- If profiling is not enabled for the account, the tool returns an error asking
+  the user to contact the Last9 team.
 
 Parameters:
 - service: (Required) ServiceName
 - env / cluster / namespace / runtime: optional filters
 - profile_type: cpu (default), alloc, or wall
-- limit: max aggregated stack rows (default 1000)
+- limit: max aggregated stack rows (default 1000, max 10000)
 - region / lookback_minutes / start_time_iso / end_time_iso

--- a/internal/prompts/descriptions/get_flamegraph.md
+++ b/internal/prompts/descriptions/get_flamegraph.md
@@ -1,0 +1,20 @@
+Fetch a nested continuous-profiling flamegraph for one service.
+
+Calls POST /profiles/api/v1/query_range/json, aggregates stacks by StackHash,
+and derives a tree (name/value/self/children) client-side — same contract as
+the Profiling UI.
+
+Critical rules:
+- service is required. Discover candidates with get_profile_services first.
+- Default profile_type is cpu. Always pin a type; never omit it when comparing
+  windows or you will mix units.
+- value = inclusive samples; self = exclusive samples on that frame.
+- truncated=true means the API row limit was hit; tighten filters or the window.
+- Prefer lookback_minutes OR explicit start_time_iso/end_time_iso; default 60m.
+
+Parameters:
+- service: (Required) ServiceName
+- env / cluster / namespace / runtime: optional filters
+- profile_type: cpu (default), alloc, or wall
+- limit: max aggregated stack rows (default 1000)
+- region / lookback_minutes / start_time_iso / end_time_iso

--- a/internal/prompts/descriptions/get_profile_services.md
+++ b/internal/prompts/descriptions/get_profile_services.md
@@ -1,0 +1,22 @@
+List services that have continuous profiling samples in a time window.
+
+Returns each service's sample weight, relative share, dominant runtime
+(telemetry.sdk.language), and last profile timestamp when available.
+
+Use this before get_flamegraph / get_top_functions / get_profile_summary to
+discover which services actually have profile data.
+
+Critical rules:
+- Default profile_type is cpu. Pinning a type avoids mixing CPU nanoseconds
+  with allocation bytes into one meaningless ranking.
+- Prefer lookback_minutes OR an explicit start_time_iso/end_time_iso pair;
+  default lookback is 60 minutes.
+- Empty services means no profile samples in range (or profiles ingest is off
+  for the tenant) — do not invent services.
+
+Parameters:
+- env / cluster / namespace / runtime: optional resource filters
+- profile_type: cpu (default), alloc, or wall
+- region: optional override of the configured datasource region
+- lookback_minutes: default 60
+- start_time_iso / end_time_iso: RFC3339; override lookback when set

--- a/internal/prompts/descriptions/get_profile_services.md
+++ b/internal/prompts/descriptions/get_profile_services.md
@@ -11,8 +11,9 @@ Critical rules:
   with allocation bytes into one meaningless ranking.
 - Prefer lookback_minutes OR an explicit start_time_iso/end_time_iso pair;
   default lookback is 60 minutes.
-- Empty services means no profile samples in range (or profiles ingest is off
-  for the tenant) — do not invent services.
+- Empty services means no profile samples in range — do not invent services.
+- If profiling is not enabled for the account, the tool returns an error asking
+  the user to contact the Last9 team.
 
 Parameters:
 - env / cluster / namespace / runtime: optional resource filters

--- a/internal/prompts/descriptions/get_profile_summary.md
+++ b/internal/prompts/descriptions/get_profile_summary.md
@@ -9,6 +9,8 @@ Critical rules:
 - Use this for quick triage; use get_flamegraph for stack structure and
   get_top_functions for a longer ranked list.
 - Prefer lookback_minutes OR explicit start_time_iso/end_time_iso; default 60m.
+- If profiling is not enabled for the account, the tool returns an error asking
+  the user to contact the Last9 team.
 
 Parameters:
 - service: (Required) ServiceName

--- a/internal/prompts/descriptions/get_profile_summary.md
+++ b/internal/prompts/descriptions/get_profile_summary.md
@@ -1,0 +1,18 @@
+Natural-language summary of a service's continuous profile hot spots.
+
+Returns a short sentence like "Top 3 CPU consumers are X, Y, Z accounting for
+N% of total self samples" plus the underlying top_functions rows.
+
+Critical rules:
+- service is required. Prefer get_profile_services when unsure a service has data.
+- Default profile_type is cpu. Do not mix profile types across comparisons.
+- Use this for quick triage; use get_flamegraph for stack structure and
+  get_top_functions for a longer ranked list.
+- Prefer lookback_minutes OR explicit start_time_iso/end_time_iso; default 60m.
+
+Parameters:
+- service: (Required) ServiceName
+- env / cluster / namespace / runtime: optional filters
+- profile_type: cpu (default), alloc, or wall
+- top_n: how many consumers to mention (default 3, max 10)
+- region / lookback_minutes / start_time_iso / end_time_iso

--- a/internal/prompts/descriptions/get_top_functions.md
+++ b/internal/prompts/descriptions/get_top_functions.md
@@ -1,0 +1,18 @@
+Rank hottest functions for a service by self (exclusive) sample share.
+
+Fetches the same flamegraph stack rows as get_flamegraph, then folds frames
+into a sorted top-functions table with self/total samples and percentages.
+
+Critical rules:
+- service is required. Use get_profile_services when the service name is unknown.
+- Optimize by self_percent / self_samples first — that is exclusive cost.
+- Default profile_type is cpu; pin the type explicitly for alloc/wall questions.
+- limit caps the ranked list after folding (default 50), not the upstream fetch.
+- Prefer lookback_minutes OR explicit start_time_iso/end_time_iso; default 60m.
+
+Parameters:
+- service: (Required) ServiceName
+- env / cluster / namespace / runtime: optional filters
+- profile_type: cpu (default), alloc, or wall
+- limit: max ranked functions (default 50)
+- region / lookback_minutes / start_time_iso / end_time_iso

--- a/internal/prompts/descriptions/get_top_functions.md
+++ b/internal/prompts/descriptions/get_top_functions.md
@@ -8,7 +8,10 @@ Critical rules:
 - Optimize by self_percent / self_samples first — that is exclusive cost.
 - Default profile_type is cpu; pin the type explicitly for alloc/wall questions.
 - limit caps the ranked list after folding (default 50), not the upstream fetch.
+  total_samples is always the full-profile self total, not just the returned rows.
 - Prefer lookback_minutes OR explicit start_time_iso/end_time_iso; default 60m.
+- If profiling is not enabled for the account, the tool returns an error asking
+  the user to contact the Last9 team.
 
 Parameters:
 - service: (Required) ServiceName

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -146,6 +146,18 @@ var GetServiceTracesDescription string
 //go:embed descriptions/prometheus_range_query_base.md
 var PromqlRangeQueryDetails string
 
+//go:embed descriptions/get_profile_services.md
+var GetProfileServicesDescription string
+
+//go:embed descriptions/get_flamegraph.md
+var GetFlamegraphDescription string
+
+//go:embed descriptions/get_top_functions.md
+var GetTopFunctionsDescription string
+
+//go:embed descriptions/get_profile_summary.md
+var GetProfileSummaryDescription string
+
 //go:embed workflows/scoped_log_attribute_discovery.md
 var ScopedLogAttributeDiscoveryWorkflow string
 

--- a/internal/telemetry/profiles/client.go
+++ b/internal/telemetry/profiles/client.go
@@ -1,0 +1,118 @@
+package profiles
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"last9-mcp/internal/constants"
+	"last9-mcp/internal/models"
+)
+
+// MakeProfilesJSONQueryAPI posts a profiles JSON pipeline to query_range/json.
+// start/end are sent as RFC3339 (same as the dashboard ProfilesApis client).
+func MakeProfilesJSONQueryAPI(
+	ctx context.Context,
+	client *http.Client,
+	cfg models.Config,
+	pipeline any,
+	start, end time.Time,
+	limit int,
+	region string,
+) (*http.Response, error) {
+	if client == nil {
+		return nil, errors.New("http client cannot be nil")
+	}
+	if strings.TrimSpace(cfg.APIBaseURL) == "" {
+		return nil, errors.New("API base URL cannot be empty")
+	}
+	if cfg.TokenManager == nil || strings.TrimSpace(cfg.TokenManager.GetAccessToken(ctx)) == "" {
+		return nil, errors.New("access token cannot be empty")
+	}
+	if limit <= 0 {
+		limit = DefaultFlamegraphRowLimit
+	}
+	if strings.TrimSpace(region) == "" {
+		region = cfg.Region
+	}
+
+	profilesURL := fmt.Sprintf("%s%s", cfg.APIBaseURL, constants.EndpointProfilesQueryRange)
+	queryParams := url.Values{}
+	queryParams.Add("direction", "backward")
+	queryParams.Add("start", start.UTC().Format(time.RFC3339))
+	queryParams.Add("end", end.UTC().Format(time.RFC3339))
+	queryParams.Add("limit", fmt.Sprintf("%d", limit))
+	queryParams.Add("region", region)
+	fullURL := fmt.Sprintf("%s?%s", profilesURL, queryParams.Encode())
+
+	body := map[string]any{"pipeline": pipeline}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal pipeline: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set(constants.HeaderAccept, constants.HeaderAcceptJSON)
+	req.Header.Set(constants.HeaderContentType, constants.HeaderContentTypeJSON)
+	req.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+cfg.TokenManager.GetAccessToken(ctx))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	return resp, nil
+}
+
+// runQueryRange executes a pipeline and unwraps dataframe/array rows.
+func runQueryRange(
+	ctx context.Context,
+	client *http.Client,
+	cfg models.Config,
+	pipeline any,
+	start, end time.Time,
+	limit int,
+	region string,
+) ([]map[string]any, error) {
+	resp, err := MakeProfilesJSONQueryAPI(ctx, client, cfg, pipeline, start, end, limit, region)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read profiles response: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// continue
+	case http.StatusBadRequest:
+		return nil, fmt.Errorf("profiles API invalid range/query (400): %s", string(body))
+	case http.StatusNotFound:
+		// PDE-1117 / last9#11396: /profiles/api/v1 must be registered on the
+		// org-scoped Tempo proxy (same pattern as /logs/api/v2). Until that
+		// ships on the API host, callers see a gateway 404 — not a bad pipeline.
+		return nil, fmt.Errorf("profiles API 404 (Tempo proxy route missing on this API host; needs last9/last9#11396 / PDE-1117). body=%s", string(body))
+	case http.StatusRequestTimeout:
+		return nil, fmt.Errorf("profiles API timed out (408): %s", string(body))
+	default:
+		return nil, fmt.Errorf("profiles API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var decoded any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, fmt.Errorf("failed to decode profiles response: %w", err)
+	}
+	return unwrapQueryRangeRows(decoded), nil
+}

--- a/internal/telemetry/profiles/client.go
+++ b/internal/telemetry/profiles/client.go
@@ -39,6 +39,9 @@ func MakeProfilesJSONQueryAPI(
 	if limit <= 0 {
 		limit = DefaultFlamegraphRowLimit
 	}
+	if limit > MaxFlamegraphRowLimit {
+		limit = MaxFlamegraphRowLimit
+	}
 	if strings.TrimSpace(region) == "" {
 		region = cfg.Region
 	}
@@ -100,10 +103,8 @@ func runQueryRange(
 	case http.StatusBadRequest:
 		return nil, fmt.Errorf("profiles API invalid range/query (400): %s", string(body))
 	case http.StatusNotFound:
-		// PDE-1117 / last9#11396: /profiles/api/v1 must be registered on the
-		// org-scoped Tempo proxy (same pattern as /logs/api/v2). Until that
-		// ships on the API host, callers see a gateway 404 — not a bad pipeline.
-		return nil, fmt.Errorf("profiles API 404 (Tempo proxy route missing on this API host; needs last9/last9#11396 / PDE-1117). body=%s", string(body))
+		// Tempo only registers /profiles/api/v1 when ProfilesEnabled for the tenant.
+		return nil, fmt.Errorf("profiling is not enabled for your account. Please contact the Last9 team to enable it")
 	case http.StatusRequestTimeout:
 		return nil, fmt.Errorf("profiles API timed out (408): %s", string(body))
 	default:

--- a/internal/telemetry/profiles/get_flamegraph.go
+++ b/internal/telemetry/profiles/get_flamegraph.go
@@ -22,7 +22,7 @@ type GetFlamegraphArgs struct {
 	Runtime         string `json:"runtime,omitempty" jsonschema:"Filter by telemetry.sdk.language"`
 	ProfileType     string `json:"profile_type,omitempty" jsonschema:"Profile type: cpu (default), alloc, or wall. Prefer cpu unless the user asks for alloc/wall."`
 	Region          string `json:"region,omitempty" jsonschema:"Optional region override; defaults to the configured datasource region"`
-	Limit           int    `json:"limit,omitempty" jsonschema:"Max aggregated stack rows from the API (default: 1000)"`
+	Limit           int    `json:"limit,omitempty" jsonschema:"Max aggregated stack rows from the API (default: 1000, max: 10000)"`
 	LookbackMinutes int    `json:"lookback_minutes,omitempty" jsonschema:"Minutes to look back from now (default: 60, minimum: 1)"`
 	StartTimeISO    string `json:"start_time_iso,omitempty" jsonschema:"(Optional) Start time in RFC3339/ISO8601 format"`
 	EndTimeISO      string `json:"end_time_iso,omitempty" jsonschema:"(Optional) End time in RFC3339/ISO8601 format"`
@@ -44,12 +44,12 @@ func NewGetFlamegraphHandler(client *http.Client, cfg models.Config) func(contex
 			return nil, nil, err
 		}
 
-		limit := args.Limit
-		if limit <= 0 {
-			limit = DefaultFlamegraphRowLimit
-		}
+		limit := clampFlamegraphLimit(args.Limit)
 
-		filters := filtersFromArgs(args.Service, args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		filters, err := filtersFromArgs(args.Service, args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		if err != nil {
+			return nil, nil, err
+		}
 		rows, err := runQueryRange(ctx, client, cfg, flamegraphPipeline(filters, limit), start, end, limit, args.Region)
 		if err != nil {
 			return utils.ToolErrorResult(fmt.Sprintf("failed to fetch flamegraph: %v", err)), nil, nil
@@ -58,14 +58,14 @@ func NewGetFlamegraphHandler(client *http.Client, cfg models.Config) func(contex
 		flameRows := mapFlamegraphRows(rows)
 		tree := BuildFlameTree(flameRows)
 		result, err := jsonResult(map[string]any{
-			"service":      filters.Service,
-			"profile_type": string(filters.ProfileType),
-			"start":        start.UTC().Format(time.RFC3339),
-			"end":          end.UTC().Format(time.RFC3339),
-			"row_count":    len(flameRows),
-			"truncated":    len(flameRows) >= limit,
+			"service":       filters.Service,
+			"profile_type":  string(filters.ProfileType),
+			"start":         start.UTC().Format(time.RFC3339),
+			"end":           end.UTC().Format(time.RFC3339),
+			"row_count":     len(flameRows),
+			"truncated":     len(flameRows) >= limit,
 			"total_samples": tree.Value,
-			"flamegraph":   tree,
+			"flamegraph":    tree,
 		})
 		return result, nil, err
 	}

--- a/internal/telemetry/profiles/get_flamegraph.go
+++ b/internal/telemetry/profiles/get_flamegraph.go
@@ -1,0 +1,72 @@
+package profiles
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// GetFlamegraphArgs fetches a nested flamegraph for one service.
+type GetFlamegraphArgs struct {
+	Service         string `json:"service" jsonschema:"(Required) Service name (ServiceName) to profile"`
+	Env             string `json:"env,omitempty" jsonschema:"Filter by deployment.environment.name"`
+	Cluster         string `json:"cluster,omitempty" jsonschema:"Filter by k8s.cluster.name"`
+	Namespace       string `json:"namespace,omitempty" jsonschema:"Filter by k8s.namespace.name"`
+	Runtime         string `json:"runtime,omitempty" jsonschema:"Filter by telemetry.sdk.language"`
+	ProfileType     string `json:"profile_type,omitempty" jsonschema:"Profile type: cpu (default), alloc, or wall. Prefer cpu unless the user asks for alloc/wall."`
+	Region          string `json:"region,omitempty" jsonschema:"Optional region override; defaults to the configured datasource region"`
+	Limit           int    `json:"limit,omitempty" jsonschema:"Max aggregated stack rows from the API (default: 1000)"`
+	LookbackMinutes int    `json:"lookback_minutes,omitempty" jsonschema:"Minutes to look back from now (default: 60, minimum: 1)"`
+	StartTimeISO    string `json:"start_time_iso,omitempty" jsonschema:"(Optional) Start time in RFC3339/ISO8601 format"`
+	EndTimeISO      string `json:"end_time_iso,omitempty" jsonschema:"(Optional) End time in RFC3339/ISO8601 format"`
+}
+
+// NewGetFlamegraphHandler returns a structured flamegraph tree for a service.
+func NewGetFlamegraphHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetFlamegraphArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args GetFlamegraphArgs) (*mcp.CallToolResult, any, error) {
+		if strings.TrimSpace(args.Service) == "" {
+			return nil, nil, fmt.Errorf("service is required")
+		}
+
+		start, end, err := resolveProfileTimeRange(timeArgs{
+			StartTimeISO:    args.StartTimeISO,
+			EndTimeISO:      args.EndTimeISO,
+			LookbackMinutes: args.LookbackMinutes,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		limit := args.Limit
+		if limit <= 0 {
+			limit = DefaultFlamegraphRowLimit
+		}
+
+		filters := filtersFromArgs(args.Service, args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		rows, err := runQueryRange(ctx, client, cfg, flamegraphPipeline(filters, limit), start, end, limit, args.Region)
+		if err != nil {
+			return utils.ToolErrorResult(fmt.Sprintf("failed to fetch flamegraph: %v", err)), nil, nil
+		}
+
+		flameRows := mapFlamegraphRows(rows)
+		tree := BuildFlameTree(flameRows)
+		result, err := jsonResult(map[string]any{
+			"service":      filters.Service,
+			"profile_type": string(filters.ProfileType),
+			"start":        start.UTC().Format(time.RFC3339),
+			"end":          end.UTC().Format(time.RFC3339),
+			"row_count":    len(flameRows),
+			"truncated":    len(flameRows) >= limit,
+			"total_samples": tree.Value,
+			"flamegraph":   tree,
+		})
+		return result, nil, err
+	}
+}

--- a/internal/telemetry/profiles/get_profile_services.go
+++ b/internal/telemetry/profiles/get_profile_services.go
@@ -1,0 +1,64 @@
+package profiles
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// GetProfileServicesArgs lists services that have continuous profile samples.
+type GetProfileServicesArgs struct {
+	Env             string `json:"env,omitempty" jsonschema:"Filter by deployment.environment.name"`
+	Cluster         string `json:"cluster,omitempty" jsonschema:"Filter by k8s.cluster.name"`
+	Namespace       string `json:"namespace,omitempty" jsonschema:"Filter by k8s.namespace.name"`
+	Runtime         string `json:"runtime,omitempty" jsonschema:"Filter by telemetry.sdk.language (go, java, python, …)"`
+	ProfileType     string `json:"profile_type,omitempty" jsonschema:"Profile type: cpu (default), alloc, or wall"`
+	Region          string `json:"region,omitempty" jsonschema:"Optional region override; defaults to the configured datasource region"`
+	LookbackMinutes int    `json:"lookback_minutes,omitempty" jsonschema:"Minutes to look back from now (default: 60, minimum: 1)"`
+	StartTimeISO    string `json:"start_time_iso,omitempty" jsonschema:"(Optional) Start time in RFC3339/ISO8601 format"`
+	EndTimeISO      string `json:"end_time_iso,omitempty" jsonschema:"(Optional) End time in RFC3339/ISO8601 format"`
+}
+
+// NewGetProfileServicesHandler returns services with relative sample share in range.
+func NewGetProfileServicesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetProfileServicesArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args GetProfileServicesArgs) (*mcp.CallToolResult, any, error) {
+		start, end, err := resolveProfileTimeRange(timeArgs{
+			StartTimeISO:    args.StartTimeISO,
+			EndTimeISO:      args.EndTimeISO,
+			LookbackMinutes: args.LookbackMinutes,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		filters := filtersFromArgs("", args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		region := args.Region
+
+		sampleRows, err := runQueryRange(ctx, client, cfg, serviceIndexSamplePipeline(filters, DefaultFlamegraphRowLimit), start, end, DefaultFlamegraphRowLimit, region)
+		if err != nil {
+			return utils.ToolErrorResult(fmt.Sprintf("failed to fetch profile services: %v", err)), nil, nil
+		}
+
+		lastRows, err := runQueryRange(ctx, client, cfg, serviceIndexLastPipeline(filters, DefaultFlamegraphRowLimit), start, end, DefaultFlamegraphRowLimit, region)
+		if err != nil {
+			// Soft-fail last-profile probe — matches dashboard ProfilesApis.
+			lastRows = nil
+		}
+
+		services := buildProfileServiceIndex(sampleRows, lastRows)
+		result, err := jsonResult(map[string]any{
+			"services":     services,
+			"count":        len(services),
+			"profile_type": string(filters.ProfileType),
+			"start":        start.UTC().Format(time.RFC3339),
+			"end":          end.UTC().Format(time.RFC3339),
+		})
+		return result, nil, err
+	}
+}

--- a/internal/telemetry/profiles/get_profile_services.go
+++ b/internal/telemetry/profiles/get_profile_services.go
@@ -37,7 +37,10 @@ func NewGetProfileServicesHandler(client *http.Client, cfg models.Config) func(c
 			return nil, nil, err
 		}
 
-		filters := filtersFromArgs("", args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		filters, err := filtersFromArgs("", args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		if err != nil {
+			return nil, nil, err
+		}
 		region := args.Region
 
 		sampleRows, err := runQueryRange(ctx, client, cfg, serviceIndexSamplePipeline(filters, DefaultFlamegraphRowLimit), start, end, DefaultFlamegraphRowLimit, region)

--- a/internal/telemetry/profiles/get_profile_summary.go
+++ b/internal/telemetry/profiles/get_profile_summary.go
@@ -1,0 +1,108 @@
+package profiles
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// GetProfileSummaryArgs returns a short natural-language CPU/profile summary.
+type GetProfileSummaryArgs struct {
+	Service         string `json:"service" jsonschema:"(Required) Service name (ServiceName) to profile"`
+	Env             string `json:"env,omitempty" jsonschema:"Filter by deployment.environment.name"`
+	Cluster         string `json:"cluster,omitempty" jsonschema:"Filter by k8s.cluster.name"`
+	Namespace       string `json:"namespace,omitempty" jsonschema:"Filter by k8s.namespace.name"`
+	Runtime         string `json:"runtime,omitempty" jsonschema:"Filter by telemetry.sdk.language"`
+	ProfileType     string `json:"profile_type,omitempty" jsonschema:"Profile type: cpu (default), alloc, or wall"`
+	Region          string `json:"region,omitempty" jsonschema:"Optional region override; defaults to the configured datasource region"`
+	TopN            int    `json:"top_n,omitempty" jsonschema:"How many top consumers to mention (default: 3, max: 10)"`
+	LookbackMinutes int    `json:"lookback_minutes,omitempty" jsonschema:"Minutes to look back from now (default: 60, minimum: 1)"`
+	StartTimeISO    string `json:"start_time_iso,omitempty" jsonschema:"(Optional) Start time in RFC3339/ISO8601 format"`
+	EndTimeISO      string `json:"end_time_iso,omitempty" jsonschema:"(Optional) End time in RFC3339/ISO8601 format"`
+}
+
+// NewGetProfileSummaryHandler summarizes the hottest functions for a service.
+func NewGetProfileSummaryHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetProfileSummaryArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args GetProfileSummaryArgs) (*mcp.CallToolResult, any, error) {
+		if strings.TrimSpace(args.Service) == "" {
+			return nil, nil, fmt.Errorf("service is required")
+		}
+
+		start, end, err := resolveProfileTimeRange(timeArgs{
+			StartTimeISO:    args.StartTimeISO,
+			EndTimeISO:      args.EndTimeISO,
+			LookbackMinutes: args.LookbackMinutes,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		topN := args.TopN
+		if topN <= 0 {
+			topN = 3
+		}
+		if topN > 10 {
+			topN = 10
+		}
+
+		filters := filtersFromArgs(args.Service, args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		rows, err := runQueryRange(ctx, client, cfg, flamegraphPipeline(filters, DefaultFlamegraphRowLimit), start, end, DefaultFlamegraphRowLimit, args.Region)
+		if err != nil {
+			return utils.ToolErrorResult(fmt.Sprintf("failed to fetch profile summary: %v", err)), nil, nil
+		}
+
+		functions := FoldToTopFunctions(mapFlamegraphRows(rows))
+		total := getProfileTotalSamples(functions)
+		top := limitTopFunctions(functions, topN)
+		summary := buildProfileSummaryText(filters.Service, string(filters.ProfileType), top, total)
+
+		result, err := jsonResult(map[string]any{
+			"service":       filters.Service,
+			"profile_type":  string(filters.ProfileType),
+			"start":         start.UTC().Format(time.RFC3339),
+			"end":           end.UTC().Format(time.RFC3339),
+			"total_samples": total,
+			"summary":       summary,
+			"top_functions": top,
+		})
+		return result, nil, err
+	}
+}
+
+func buildProfileSummaryText(service, profileType string, top []TopFunction, total float64) string {
+	if len(top) == 0 || total <= 0 {
+		return fmt.Sprintf("No %s profile samples found for service %q in the selected window.", profileType, service)
+	}
+
+	names := make([]string, 0, len(top))
+	var topShare float64
+	for _, fn := range top {
+		names = append(names, fn.Name)
+		topShare += fn.SelfSamples
+	}
+	pct := (topShare / total) * 100
+
+	label := "CPU"
+	switch profileType {
+	case string(ProfileTypeAlloc):
+		label = "allocation"
+	case string(ProfileTypeWall):
+		label = "wall-time"
+	}
+
+	return fmt.Sprintf(
+		"Top %d %s consumers for %s are %s, accounting for %.1f%% of total self samples.",
+		len(top),
+		label,
+		service,
+		strings.Join(names, ", "),
+		pct,
+	)
+}

--- a/internal/telemetry/profiles/get_profile_summary.go
+++ b/internal/telemetry/profiles/get_profile_summary.go
@@ -52,7 +52,10 @@ func NewGetProfileSummaryHandler(client *http.Client, cfg models.Config) func(co
 			topN = 10
 		}
 
-		filters := filtersFromArgs(args.Service, args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		filters, err := filtersFromArgs(args.Service, args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		if err != nil {
+			return nil, nil, err
+		}
 		rows, err := runQueryRange(ctx, client, cfg, flamegraphPipeline(filters, DefaultFlamegraphRowLimit), start, end, DefaultFlamegraphRowLimit, args.Region)
 		if err != nil {
 			return utils.ToolErrorResult(fmt.Sprintf("failed to fetch profile summary: %v", err)), nil, nil

--- a/internal/telemetry/profiles/get_top_functions.go
+++ b/internal/telemetry/profiles/get_top_functions.go
@@ -49,19 +49,24 @@ func NewGetTopFunctionsHandler(client *http.Client, cfg models.Config) func(cont
 			rankLimit = DefaultTopFunctionsLimit
 		}
 
-		filters := filtersFromArgs(args.Service, args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		filters, err := filtersFromArgs(args.Service, args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		if err != nil {
+			return nil, nil, err
+		}
 		rows, err := runQueryRange(ctx, client, cfg, flamegraphPipeline(filters, DefaultFlamegraphRowLimit), start, end, DefaultFlamegraphRowLimit, args.Region)
 		if err != nil {
 			return utils.ToolErrorResult(fmt.Sprintf("failed to fetch top functions: %v", err)), nil, nil
 		}
 
-		functions := limitTopFunctions(FoldToTopFunctions(mapFlamegraphRows(rows)), rankLimit)
+		all := FoldToTopFunctions(mapFlamegraphRows(rows))
+		total := getProfileTotalSamples(all)
+		functions := limitTopFunctions(all, rankLimit)
 		result, err := jsonResult(map[string]any{
 			"service":        filters.Service,
 			"profile_type":   string(filters.ProfileType),
 			"start":          start.UTC().Format(time.RFC3339),
 			"end":            end.UTC().Format(time.RFC3339),
-			"total_samples":  getProfileTotalSamples(functions),
+			"total_samples":  total,
 			"function_count": len(functions),
 			"functions":      functions,
 		})

--- a/internal/telemetry/profiles/get_top_functions.go
+++ b/internal/telemetry/profiles/get_top_functions.go
@@ -1,0 +1,70 @@
+package profiles
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// GetTopFunctionsArgs ranks hottest functions by self samples for a service.
+type GetTopFunctionsArgs struct {
+	Service         string `json:"service" jsonschema:"(Required) Service name (ServiceName) to profile"`
+	Env             string `json:"env,omitempty" jsonschema:"Filter by deployment.environment.name"`
+	Cluster         string `json:"cluster,omitempty" jsonschema:"Filter by k8s.cluster.name"`
+	Namespace       string `json:"namespace,omitempty" jsonschema:"Filter by k8s.namespace.name"`
+	Runtime         string `json:"runtime,omitempty" jsonschema:"Filter by telemetry.sdk.language"`
+	ProfileType     string `json:"profile_type,omitempty" jsonschema:"Profile type: cpu (default), alloc, or wall"`
+	Region          string `json:"region,omitempty" jsonschema:"Optional region override; defaults to the configured datasource region"`
+	Limit           int    `json:"limit,omitempty" jsonschema:"Max ranked functions to return after folding (default: 50)"`
+	LookbackMinutes int    `json:"lookback_minutes,omitempty" jsonschema:"Minutes to look back from now (default: 60, minimum: 1)"`
+	StartTimeISO    string `json:"start_time_iso,omitempty" jsonschema:"(Optional) Start time in RFC3339/ISO8601 format"`
+	EndTimeISO      string `json:"end_time_iso,omitempty" jsonschema:"(Optional) End time in RFC3339/ISO8601 format"`
+}
+
+// NewGetTopFunctionsHandler returns functions ranked by self sample share.
+func NewGetTopFunctionsHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetTopFunctionsArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args GetTopFunctionsArgs) (*mcp.CallToolResult, any, error) {
+		if strings.TrimSpace(args.Service) == "" {
+			return nil, nil, fmt.Errorf("service is required")
+		}
+
+		start, end, err := resolveProfileTimeRange(timeArgs{
+			StartTimeISO:    args.StartTimeISO,
+			EndTimeISO:      args.EndTimeISO,
+			LookbackMinutes: args.LookbackMinutes,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		rankLimit := args.Limit
+		if rankLimit <= 0 {
+			rankLimit = DefaultTopFunctionsLimit
+		}
+
+		filters := filtersFromArgs(args.Service, args.Env, args.Cluster, args.Namespace, args.Runtime, args.ProfileType)
+		rows, err := runQueryRange(ctx, client, cfg, flamegraphPipeline(filters, DefaultFlamegraphRowLimit), start, end, DefaultFlamegraphRowLimit, args.Region)
+		if err != nil {
+			return utils.ToolErrorResult(fmt.Sprintf("failed to fetch top functions: %v", err)), nil, nil
+		}
+
+		functions := limitTopFunctions(FoldToTopFunctions(mapFlamegraphRows(rows)), rankLimit)
+		result, err := jsonResult(map[string]any{
+			"service":        filters.Service,
+			"profile_type":   string(filters.ProfileType),
+			"start":          start.UTC().Format(time.RFC3339),
+			"end":            end.UTC().Format(time.RFC3339),
+			"total_samples":  getProfileTotalSamples(functions),
+			"function_count": len(functions),
+			"functions":      functions,
+		})
+		return result, nil, err
+	}
+}

--- a/internal/telemetry/profiles/handlers_test.go
+++ b/internal/telemetry/profiles/handlers_test.go
@@ -1,0 +1,176 @@
+package profiles
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func testCfg(baseURL string) models.Config {
+	return models.Config{
+		APIBaseURL: baseURL,
+		Region:     "us-east-1",
+		TokenManager: &auth.TokenManager{
+			AccessToken: "test-token",
+			ExpiresAt:   time.Now().Add(time.Hour),
+		},
+	}
+}
+
+func dataframeBody(metrics ...map[string]any) []byte {
+	result := make([]any, 0, len(metrics))
+	for _, m := range metrics {
+		result = append(result, map[string]any{"metric": m})
+	}
+	body, _ := json.Marshal(map[string]any{
+		"status": "success",
+		"data": map[string]any{
+			"resultType": "dataframe",
+			"result":     result,
+		},
+	})
+	return body
+}
+
+func TestGetFlamegraphHandler(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path + "?" + r.URL.RawQuery
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(dataframeBody(
+			map[string]any{
+				"StackHash": "1",
+				"Frames":    "leaf" + FrameDelimiter + "main",
+				"samples":   float64(10),
+			},
+		))
+	}))
+	defer server.Close()
+
+	handler := NewGetFlamegraphHandler(server.Client(), testCfg(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetFlamegraphArgs{
+		Service:         "api",
+		Env:             "prod",
+		LookbackMinutes: 30,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result == nil || result.IsError {
+		t.Fatalf("result=%+v", result)
+	}
+	if !strings.Contains(gotPath, "/profiles/api/v1/query_range/json?") {
+		t.Fatalf("path=%s", gotPath)
+	}
+	if !strings.Contains(gotPath, "region=us-east-1") {
+		t.Fatalf("missing region in %s", gotPath)
+	}
+	pipeline, _ := gotBody["pipeline"].([]any)
+	if len(pipeline) < 1 {
+		t.Fatalf("pipeline=%v", gotBody)
+	}
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(text, `"name": "main"`) || !strings.Contains(text, `"total_samples": 10`) {
+		t.Fatalf("response=%s", text)
+	}
+}
+
+func TestGetTopFunctionsHandler(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(dataframeBody(
+			map[string]any{"StackHash": "1", "Frames": "hot" + FrameDelimiter + "main", "samples": float64(8)},
+			map[string]any{"StackHash": "2", "Frames": "cool" + FrameDelimiter + "main", "samples": float64(2)},
+		))
+	}))
+	defer server.Close()
+
+	handler := NewGetTopFunctionsHandler(server.Client(), testCfg(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetTopFunctionsArgs{
+		Service: "api",
+		Limit:   10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := result.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(text, `"name": "hot"`) || !strings.Contains(text, `"self_samples": 8`) {
+		t.Fatalf("response=%s", text)
+	}
+}
+
+func TestGetProfileSummaryHandler(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(dataframeBody(
+			map[string]any{"StackHash": "1", "Frames": "a", "samples": float64(60)},
+			map[string]any{"StackHash": "2", "Frames": "b", "samples": float64(40)},
+		))
+	}))
+	defer server.Close()
+
+	handler := NewGetProfileSummaryHandler(server.Client(), testCfg(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetProfileSummaryArgs{
+		Service: "api",
+		TopN:    2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := result.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(text, "Top 2 CPU consumers for api are a, b") {
+		t.Fatalf("response=%s", text)
+	}
+}
+
+func TestGetProfileServicesHandler(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			_, _ = w.Write(dataframeBody(
+				map[string]any{"name": "svc-a", "samples": float64(90), "runtime": "go"},
+				map[string]any{"name": "svc-b", "samples": float64(10), "runtime": "java"},
+			))
+			return
+		}
+		_, _ = w.Write(dataframeBody(
+			map[string]any{"name": "svc-a", "last_profile": "2026-08-13T10:00:00Z"},
+		))
+	}))
+	defer server.Close()
+
+	handler := NewGetProfileServicesHandler(server.Client(), testCfg(server.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetProfileServicesArgs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := result.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(text, `"name": "svc-a"`) || !strings.Contains(text, `"count": 2`) {
+		t.Fatalf("response=%s", text)
+	}
+	if calls != 2 {
+		t.Fatalf("calls=%d want 2", calls)
+	}
+}
+
+func TestGetFlamegraphRequiresService(t *testing.T) {
+	handler := NewGetFlamegraphHandler(http.DefaultClient, testCfg("http://example.invalid"))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetFlamegraphArgs{})
+	if err == nil || !strings.Contains(err.Error(), "service is required") {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/internal/telemetry/profiles/helpers.go
+++ b/internal/telemetry/profiles/helpers.go
@@ -1,0 +1,56 @@
+package profiles
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type timeArgs struct {
+	StartTimeISO    string
+	EndTimeISO      string
+	LookbackMinutes int
+}
+
+func resolveProfileTimeRange(args timeArgs) (time.Time, time.Time, error) {
+	lookback := args.LookbackMinutes
+	if lookback == 0 {
+		lookback = DefaultLookbackMinutes
+	}
+	params := map[string]any{
+		"lookback_minutes": lookback,
+	}
+	if args.StartTimeISO != "" {
+		params["start_time_iso"] = args.StartTimeISO
+	}
+	if args.EndTimeISO != "" {
+		params["end_time_iso"] = args.EndTimeISO
+	}
+	return utils.GetTimeRange(params, DefaultLookbackMinutes)
+}
+
+func jsonResult(v any) (*mcp.CallToolResult, error) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(b)}},
+	}, nil
+}
+
+func filtersFromArgs(service, env, cluster, namespace, runtime, profileType string) ProfileFilters {
+	return ProfileFilters{
+		Service:     strings.TrimSpace(service),
+		Env:         strings.TrimSpace(env),
+		Cluster:     strings.TrimSpace(cluster),
+		Namespace:   strings.TrimSpace(namespace),
+		Runtime:     strings.TrimSpace(runtime),
+		ProfileType: normalizeProfileType(profileType),
+	}
+}

--- a/internal/telemetry/profiles/helpers.go
+++ b/internal/telemetry/profiles/helpers.go
@@ -44,13 +44,17 @@ func jsonResult(v any) (*mcp.CallToolResult, error) {
 	}, nil
 }
 
-func filtersFromArgs(service, env, cluster, namespace, runtime, profileType string) ProfileFilters {
+func filtersFromArgs(service, env, cluster, namespace, runtime, profileType string) (ProfileFilters, error) {
+	pt, err := parseProfileType(profileType)
+	if err != nil {
+		return ProfileFilters{}, err
+	}
 	return ProfileFilters{
 		Service:     strings.TrimSpace(service),
 		Env:         strings.TrimSpace(env),
 		Cluster:     strings.TrimSpace(cluster),
 		Namespace:   strings.TrimSpace(namespace),
 		Runtime:     strings.TrimSpace(runtime),
-		ProfileType: normalizeProfileType(profileType),
-	}
+		ProfileType: pt,
+	}, nil
 }

--- a/internal/telemetry/profiles/live_smoke_test.go
+++ b/internal/telemetry/profiles/live_smoke_test.go
@@ -18,10 +18,10 @@ import (
 
 // Live smoke against a real org. Opt-in only.
 //
-// Prod (app.last9.io) 404s until last9/last9#11396 (PDE-1117) merges — the
-// /profiles/api/v1 Tempo proxy route is only on alpha today. Point at alpha:
+// Tenants without ProfilesEnabled get a clear "profiling is not enabled" error
+// (Tempo omits /profiles/api/v1). Example:
 //
-//	LAST9_LIVE_PROFILES=1 LAST9_API_HOST=alpha.last9.io go test ./internal/telemetry/profiles/ -run TestLiveProfilesSmoke -v
+//	LAST9_LIVE_PROFILES=1 go test ./internal/telemetry/profiles/ -run TestLiveProfilesSmoke -v
 func TestLiveProfilesSmoke(t *testing.T) {
 	if os.Getenv("LAST9_LIVE_PROFILES") != "1" {
 		t.Skip("set LAST9_LIVE_PROFILES=1 to run")
@@ -40,8 +40,8 @@ func TestLiveProfilesSmoke(t *testing.T) {
 	}
 	if res.IsError {
 		text := liveText(res)
-		if strings.Contains(text, "last9/last9#11396") || strings.Contains(text, "PDE-1117") {
-			t.Skipf("profiles Tempo proxy not on this API host yet: %s", text)
+		if strings.Contains(text, "profiling is not enabled") {
+			t.Skipf("profiles unavailable on this tenant: %s", text)
 		}
 		t.Fatalf("get_profile_services soft-error: %s", text)
 	}

--- a/internal/telemetry/profiles/live_smoke_test.go
+++ b/internal/telemetry/profiles/live_smoke_test.go
@@ -1,0 +1,147 @@
+package profiles
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Live smoke against a real org. Opt-in only.
+//
+// Prod (app.last9.io) 404s until last9/last9#11396 (PDE-1117) merges — the
+// /profiles/api/v1 Tempo proxy route is only on alpha today. Point at alpha:
+//
+//	LAST9_LIVE_PROFILES=1 LAST9_API_HOST=alpha.last9.io go test ./internal/telemetry/profiles/ -run TestLiveProfilesSmoke -v
+func TestLiveProfilesSmoke(t *testing.T) {
+	if os.Getenv("LAST9_LIVE_PROFILES") != "1" {
+		t.Skip("set LAST9_LIVE_PROFILES=1 to run")
+	}
+
+	cfg := liveProfilesConfig(t)
+	t.Logf("org=%s region=%s api_host=%s", cfg.OrgSlug, cfg.Region, hostOf(cfg.APIBaseURL))
+
+	client := auth.GetHTTPClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	res, _, err := NewGetProfileServicesHandler(client, cfg)(ctx, &mcp.CallToolRequest{}, GetProfileServicesArgs{LookbackMinutes: 60})
+	if err != nil {
+		t.Fatalf("get_profile_services: %v", err)
+	}
+	if res.IsError {
+		text := liveText(res)
+		if strings.Contains(text, "last9/last9#11396") || strings.Contains(text, "PDE-1117") {
+			t.Skipf("profiles Tempo proxy not on this API host yet: %s", text)
+		}
+		t.Fatalf("get_profile_services soft-error: %s", text)
+	}
+
+	var parsed struct {
+		Count    int `json:"count"`
+		Services []struct {
+			Name string `json:"name"`
+		} `json:"services"`
+	}
+	if err := json.Unmarshal([]byte(liveText(res)), &parsed); err != nil {
+		t.Fatalf("decode services: %v", err)
+	}
+	t.Logf("service_count=%d", parsed.Count)
+	if parsed.Count == 0 {
+		t.Log("API reachable (200); no profile samples in window")
+		return
+	}
+
+	svc := parsed.Services[0].Name
+	t.Logf("using_service_len=%d", len(svc))
+
+	fg, _, err := NewGetFlamegraphHandler(client, cfg)(ctx, &mcp.CallToolRequest{}, GetFlamegraphArgs{
+		Service: svc, LookbackMinutes: 60,
+	})
+	if err != nil {
+		t.Fatalf("get_flamegraph: %v", err)
+	}
+	if fg.IsError {
+		t.Fatalf("get_flamegraph soft-error: %s", liveText(fg))
+	}
+	var flame struct {
+		RowCount     int     `json:"row_count"`
+		TotalSamples float64 `json:"total_samples"`
+		Truncated    bool    `json:"truncated"`
+	}
+	if err := json.Unmarshal([]byte(liveText(fg)), &flame); err != nil {
+		t.Fatalf("decode flamegraph: %v", err)
+	}
+	t.Logf("flamegraph row_count=%d total_samples=%v truncated=%v", flame.RowCount, flame.TotalSamples, flame.Truncated)
+
+	top, _, err := NewGetTopFunctionsHandler(client, cfg)(ctx, &mcp.CallToolRequest{}, GetTopFunctionsArgs{
+		Service: svc, Limit: 10, LookbackMinutes: 60,
+	})
+	if err != nil {
+		t.Fatalf("get_top_functions: %v", err)
+	}
+	if top.IsError {
+		t.Fatalf("get_top_functions soft-error: %s", liveText(top))
+	}
+	var tops struct {
+		FunctionCount int     `json:"function_count"`
+		TotalSamples  float64 `json:"total_samples"`
+	}
+	if err := json.Unmarshal([]byte(liveText(top)), &tops); err != nil {
+		t.Fatalf("decode top: %v", err)
+	}
+	t.Logf("top_functions function_count=%d total_samples=%v", tops.FunctionCount, tops.TotalSamples)
+
+	sum, _, err := NewGetProfileSummaryHandler(client, cfg)(ctx, &mcp.CallToolRequest{}, GetProfileSummaryArgs{
+		Service: svc, TopN: 3, LookbackMinutes: 60,
+	})
+	if err != nil {
+		t.Fatalf("get_profile_summary: %v", err)
+	}
+	if sum.IsError {
+		t.Fatalf("get_profile_summary soft-error: %s", liveText(sum))
+	}
+	var summary struct {
+		Summary      string  `json:"summary"`
+		TotalSamples float64 `json:"total_samples"`
+	}
+	if err := json.Unmarshal([]byte(liveText(sum)), &summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	t.Logf("summary_len=%d total_samples=%v", len(summary.Summary), summary.TotalSamples)
+}
+
+func liveProfilesConfig(t *testing.T) models.Config {
+	t.Helper()
+	// Prefer shared token exchange (walks up to repo .env), then optionally
+	// retarget APIBaseURL at alpha where the profiles Tempo proxy exists.
+	base, err := utils.SetupTestConfig()
+	if err != nil {
+		t.Skipf("skip live smoke: %v", err)
+	}
+	cfg := *base
+	if host := strings.TrimSpace(os.Getenv("LAST9_API_HOST")); host != "" {
+		cfg.APIHost = host
+		cfg.APIBaseURL = fmt.Sprintf("https://%s/api/v4/organizations/%s", host, cfg.OrgSlug)
+	}
+	return cfg
+}
+
+func liveText(r *mcp.CallToolResult) string {
+	if r == nil || len(r.Content) == 0 {
+		return ""
+	}
+	if t, ok := r.Content[0].(*mcp.TextContent); ok {
+		return t.Text
+	}
+	return ""
+}

--- a/internal/telemetry/profiles/path_probe_test.go
+++ b/internal/telemetry/profiles/path_probe_test.go
@@ -1,0 +1,67 @@
+package profiles
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/auth"
+)
+
+// Compares path variants. Opt-in. Prefer LAST9_API_HOST=alpha.last9.io until
+// last9/last9#11396 lands on app.last9.io.
+func TestLiveProfilesPathProbe(t *testing.T) {
+	if os.Getenv("LAST9_LIVE_PROFILES") != "1" {
+		t.Skip("opt-in")
+	}
+	cfg := liveProfilesConfig(t)
+	token := cfg.TokenManager.GetAccessToken(context.Background())
+	client := auth.GetHTTPClient()
+	end := time.Now().UTC()
+	start := end.Add(-time.Hour)
+	body := []byte(`{"pipeline":[{"type":"filter","query":{"$eq":["ProfileType","cpu"]}},{"type":"aggregate","function":{"$count":["Value"]},"as":"samples","groupby":{"ServiceName":"name"}},{"type":"select","labels":null,"order":null,"limit":1}]}`)
+
+	type cand struct{ name, base string }
+	cands := []cand{
+		{"org_profiles", cfg.APIBaseURL + "/profiles/api/v1/query_range/json"},
+		{"org_logs_control", cfg.APIBaseURL + "/logs/api/v2/query_range/json"},
+	}
+	for _, c := range cands {
+		q := url.Values{}
+		q.Set("start", start.Format(time.RFC3339))
+		q.Set("end", end.Format(time.RFC3339))
+		q.Set("limit", "1")
+		q.Set("direction", "backward")
+		q.Set("region", cfg.Region)
+		req, err := http.NewRequest("POST", c.base+"?"+q.Encode(), bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("X-LAST9-API-TOKEN", "Bearer "+token)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Logf("%s ERR %v", c.name, err)
+			continue
+		}
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 160))
+		resp.Body.Close()
+		t.Logf("%s host=%s status=%d body=%q", c.name, hostOf(cfg.APIBaseURL), resp.StatusCode, strings.ReplaceAll(string(b), "\n", " "))
+	}
+}
+
+func hostOf(u string) string {
+	u = strings.TrimPrefix(u, "https://")
+	u = strings.TrimPrefix(u, "http://")
+	if i := strings.IndexByte(u, '/'); i >= 0 {
+		return u[:i]
+	}
+	return u
+}

--- a/internal/telemetry/profiles/path_probe_test.go
+++ b/internal/telemetry/profiles/path_probe_test.go
@@ -14,8 +14,7 @@ import (
 	"last9-mcp/internal/auth"
 )
 
-// Compares path variants. Opt-in. Prefer LAST9_API_HOST=alpha.last9.io until
-// last9/last9#11396 lands on app.last9.io.
+// Compares path variants. Opt-in via LAST9_LIVE_PROFILES=1.
 func TestLiveProfilesPathProbe(t *testing.T) {
 	if os.Getenv("LAST9_LIVE_PROFILES") != "1" {
 		t.Skip("opt-in")

--- a/internal/telemetry/profiles/pipeline.go
+++ b/internal/telemetry/profiles/pipeline.go
@@ -22,7 +22,7 @@ func parseProfileType(raw string) (ProfileType, error) {
 	}
 }
 
-// clampFlamegraphLimit applies default (1000) and PDE-718 hard cap (10000).
+// clampFlamegraphLimit applies default (1000) and hard cap (10000).
 func clampFlamegraphLimit(limit int) int {
 	if limit <= 0 {
 		return DefaultFlamegraphRowLimit

--- a/internal/telemetry/profiles/pipeline.go
+++ b/internal/telemetry/profiles/pipeline.go
@@ -1,22 +1,36 @@
 package profiles
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 type buildFilterOptions struct {
 	includeProfileType bool
 }
 
-func normalizeProfileType(raw string) ProfileType {
+func parseProfileType(raw string) (ProfileType, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case string(ProfileTypeAlloc):
-		return ProfileTypeAlloc
+		return ProfileTypeAlloc, nil
 	case string(ProfileTypeWall):
-		return ProfileTypeWall
+		return ProfileTypeWall, nil
 	case string(ProfileTypeCPU), "":
-		return ProfileTypeCPU
+		return ProfileTypeCPU, nil
 	default:
-		return ProfileTypeCPU
+		return "", fmt.Errorf("profile_type must be cpu, alloc, or wall (got %q)", raw)
 	}
+}
+
+// clampFlamegraphLimit applies default (1000) and PDE-718 hard cap (10000).
+func clampFlamegraphLimit(limit int) int {
+	if limit <= 0 {
+		return DefaultFlamegraphRowLimit
+	}
+	if limit > MaxFlamegraphRowLimit {
+		return MaxFlamegraphRowLimit
+	}
+	return limit
 }
 
 func buildFilterConditions(filters ProfileFilters, opts buildFilterOptions) []any {

--- a/internal/telemetry/profiles/pipeline.go
+++ b/internal/telemetry/profiles/pipeline.go
@@ -1,0 +1,148 @@
+package profiles
+
+import "strings"
+
+type buildFilterOptions struct {
+	includeProfileType bool
+}
+
+func normalizeProfileType(raw string) ProfileType {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case string(ProfileTypeAlloc):
+		return ProfileTypeAlloc
+	case string(ProfileTypeWall):
+		return ProfileTypeWall
+	case string(ProfileTypeCPU), "":
+		return ProfileTypeCPU
+	default:
+		return ProfileTypeCPU
+	}
+}
+
+func buildFilterConditions(filters ProfileFilters, opts buildFilterOptions) []any {
+	conditions := make([]any, 0, 6)
+	if opts.includeProfileType {
+		profileType := filters.ProfileType
+		if profileType == "" {
+			profileType = DefaultProfileType
+		}
+		conditions = append(conditions, map[string]any{"$eq": []any{"ProfileType", string(profileType)}})
+	}
+	if filters.Service != "" {
+		conditions = append(conditions, map[string]any{"$eq": []any{"ServiceName", filters.Service}})
+	}
+	if filters.Env != "" {
+		conditions = append(conditions, map[string]any{"$eq": []any{ResourceEnv, filters.Env}})
+	}
+	if filters.Cluster != "" {
+		conditions = append(conditions, map[string]any{"$eq": []any{ResourceCluster, filters.Cluster}})
+	}
+	if filters.Namespace != "" {
+		conditions = append(conditions, map[string]any{"$eq": []any{ResourceNamespace, filters.Namespace}})
+	}
+	if filters.Runtime != "" {
+		conditions = append(conditions, map[string]any{"$eq": []any{ResourceRuntime, filters.Runtime}})
+	}
+	return conditions
+}
+
+func buildFilterStage(filters ProfileFilters, opts buildFilterOptions) map[string]any {
+	conditions := buildFilterConditions(filters, opts)
+	if len(conditions) == 0 {
+		return nil
+	}
+	if len(conditions) == 1 {
+		return map[string]any{"type": "filter", "query": conditions[0]}
+	}
+	return map[string]any{
+		"type":  "filter",
+		"query": map[string]any{"$and": conditions},
+	}
+}
+
+func withOptionalFilter(pipeline []any, filter map[string]any) []any {
+	if filter == nil {
+		return pipeline
+	}
+	return append([]any{filter}, pipeline...)
+}
+
+func flamegraphPipeline(filters ProfileFilters, limit int) []any {
+	if limit <= 0 {
+		limit = DefaultFlamegraphRowLimit
+	}
+	stages := []any{
+		map[string]any{
+			"type":     "aggregate",
+			"function": map[string]any{"$sum": []any{"Value"}},
+			"as":       "samples",
+			"groupby":  map[string]any{"StackHash": "StackHash", "Body": "Frames"},
+		},
+		map[string]any{
+			"type":   "select",
+			"labels": nil,
+			"order":  []any{"samples"},
+			"limit":  limit,
+		},
+	}
+	return withOptionalFilter(stages, buildFilterStage(filters, buildFilterOptions{includeProfileType: true}))
+}
+
+func serviceIndexSamplePipeline(filters ProfileFilters, limit int) []any {
+	if limit <= 0 {
+		limit = DefaultFlamegraphRowLimit
+	}
+	scope := ProfileFilters{
+		Env:         filters.Env,
+		Cluster:     filters.Cluster,
+		Namespace:   filters.Namespace,
+		Runtime:     filters.Runtime,
+		ProfileType: filters.ProfileType,
+	}
+	stages := []any{
+		map[string]any{
+			"type":     "aggregate",
+			"function": map[string]any{"$sum": []any{"Value"}},
+			"as":       "samples",
+			"groupby": map[string]any{
+				"ServiceName":   "name",
+				ResourceRuntime: "runtime",
+			},
+		},
+		map[string]any{
+			"type":   "select",
+			"labels": nil,
+			"order":  []any{"samples"},
+			"limit":  limit,
+		},
+	}
+	return withOptionalFilter(stages, buildFilterStage(scope, buildFilterOptions{includeProfileType: true}))
+}
+
+func serviceIndexLastPipeline(filters ProfileFilters, limit int) []any {
+	if limit <= 0 {
+		limit = DefaultFlamegraphRowLimit
+	}
+	scope := ProfileFilters{
+		Env:         filters.Env,
+		Cluster:     filters.Cluster,
+		Namespace:   filters.Namespace,
+		Runtime:     filters.Runtime,
+		ProfileType: filters.ProfileType,
+	}
+	stages := []any{
+		map[string]any{
+			"type":     "aggregate",
+			"function": map[string]any{"$max": []any{"Timestamp"}},
+			"as":       "last_profile",
+			"groupby":  map[string]any{"ServiceName": "name"},
+		},
+		map[string]any{
+			"type":   "select",
+			"labels": nil,
+			"order":  nil,
+			"limit":  limit,
+		},
+	}
+	return withOptionalFilter(stages, buildFilterStage(scope, buildFilterOptions{includeProfileType: true}))
+}

--- a/internal/telemetry/profiles/pipeline_test.go
+++ b/internal/telemetry/profiles/pipeline_test.go
@@ -22,14 +22,28 @@ func TestFlamegraphPipelinePinsCPUAndService(t *testing.T) {
 	}
 }
 
-func TestNormalizeProfileType(t *testing.T) {
-	if normalizeProfileType("") != ProfileTypeCPU {
-		t.Fatal("default cpu")
+func TestParseProfileType(t *testing.T) {
+	pt, err := parseProfileType("")
+	if err != nil || pt != ProfileTypeCPU {
+		t.Fatalf("default cpu: %v %v", pt, err)
 	}
-	if normalizeProfileType("ALLOC") != ProfileTypeAlloc {
-		t.Fatal("alloc")
+	pt, err = parseProfileType("ALLOC")
+	if err != nil || pt != ProfileTypeAlloc {
+		t.Fatalf("alloc: %v %v", pt, err)
 	}
-	if normalizeProfileType("nope") != ProfileTypeCPU {
-		t.Fatal("unknown falls back to cpu")
+	if _, err := parseProfileType("nope"); err == nil {
+		t.Fatal("expected error for unknown profile_type")
+	}
+}
+
+func TestClampFlamegraphLimit(t *testing.T) {
+	if clampFlamegraphLimit(0) != DefaultFlamegraphRowLimit {
+		t.Fatal("default")
+	}
+	if clampFlamegraphLimit(50000) != MaxFlamegraphRowLimit {
+		t.Fatal("cap")
+	}
+	if clampFlamegraphLimit(42) != 42 {
+		t.Fatal("passthrough")
 	}
 }

--- a/internal/telemetry/profiles/pipeline_test.go
+++ b/internal/telemetry/profiles/pipeline_test.go
@@ -1,0 +1,35 @@
+package profiles
+
+import "testing"
+
+func TestFlamegraphPipelinePinsCPUAndService(t *testing.T) {
+	pipeline := flamegraphPipeline(ProfileFilters{
+		Service:     "api",
+		Env:         "prod",
+		ProfileType: ProfileTypeCPU,
+	}, 100)
+	if len(pipeline) != 3 {
+		t.Fatalf("stages=%d want 3", len(pipeline))
+	}
+	filter, ok := pipeline[0].(map[string]any)
+	if !ok || filter["type"] != "filter" {
+		t.Fatalf("first stage=%v", pipeline[0])
+	}
+	query, _ := filter["query"].(map[string]any)
+	andClause, _ := query["$and"].([]any)
+	if len(andClause) != 3 {
+		t.Fatalf("and=%v", andClause)
+	}
+}
+
+func TestNormalizeProfileType(t *testing.T) {
+	if normalizeProfileType("") != ProfileTypeCPU {
+		t.Fatal("default cpu")
+	}
+	if normalizeProfileType("ALLOC") != ProfileTypeAlloc {
+		t.Fatal("alloc")
+	}
+	if normalizeProfileType("nope") != ProfileTypeCPU {
+		t.Fatal("unknown falls back to cpu")
+	}
+}

--- a/internal/telemetry/profiles/tree.go
+++ b/internal/telemetry/profiles/tree.go
@@ -1,0 +1,140 @@
+package profiles
+
+import (
+	"sort"
+	"strings"
+)
+
+type trieNode struct {
+	value    float64
+	self     float64
+	children map[string]*trieNode
+}
+
+func newTrieNode() *trieNode {
+	return &trieNode{children: make(map[string]*trieNode)}
+}
+
+// BuildFlameTree derives a nested flamegraph from flat stack rows.
+// Frames are stored leaf→root in Body; we reverse to root→leaf for the tree.
+func BuildFlameTree(rows []FlamegraphRow) FlameNode {
+	root := newTrieNode()
+	for _, row := range rows {
+		if row.Frames == "" || row.Samples == 0 {
+			continue
+		}
+		frames := strings.Split(row.Frames, FrameDelimiter)
+		// reverse leaf→root to root→leaf
+		for i, j := 0, len(frames)-1; i < j; i, j = i+1, j-1 {
+			frames[i], frames[j] = frames[j], frames[i]
+		}
+
+		root.value += row.Samples
+		node := root
+		for idx, frame := range frames {
+			child, ok := node.children[frame]
+			if !ok {
+				child = newTrieNode()
+				node.children[frame] = child
+			}
+			child.value += row.Samples
+			if idx == len(frames)-1 {
+				child.self += row.Samples
+			}
+			node = child
+		}
+	}
+	return toFlameNode("root", root)
+}
+
+func toFlameNode(name string, node *trieNode) FlameNode {
+	children := make([]FlameNode, 0, len(node.children))
+	for childName, child := range node.children {
+		children = append(children, toFlameNode(childName, child))
+	}
+	sort.Slice(children, func(i, j int) bool {
+		if children[i].Value != children[j].Value {
+			return children[i].Value > children[j].Value
+		}
+		return children[i].Name < children[j].Name
+	})
+	return FlameNode{
+		Name:     name,
+		Value:    node.value,
+		Self:     node.self,
+		Children: children,
+	}
+}
+
+// FoldToTopFunctions aggregates self/total samples per frame name.
+func FoldToTopFunctions(rows []FlamegraphRow) []TopFunction {
+	type counts struct {
+		total float64
+		self  float64
+	}
+	totals := make(map[string]*counts)
+
+	for _, row := range rows {
+		if row.Frames == "" || row.Samples == 0 {
+			continue
+		}
+		frames := strings.Split(row.Frames, FrameDelimiter)
+		leaf := frames[0]
+
+		seen := make(map[string]struct{}, len(frames))
+		for _, frame := range frames {
+			if _, ok := seen[frame]; ok {
+				continue
+			}
+			seen[frame] = struct{}{}
+			entry, ok := totals[frame]
+			if !ok {
+				entry = &counts{}
+				totals[frame] = entry
+			}
+			entry.total += row.Samples
+			if frame == leaf {
+				entry.self += row.Samples
+			}
+		}
+	}
+
+	out := make([]TopFunction, 0, len(totals))
+	var profileTotal float64
+	for name, c := range totals {
+		profileTotal += c.self
+		out = append(out, TopFunction{
+			Name:         name,
+			TotalSamples: c.total,
+			SelfSamples:  c.self,
+		})
+	}
+	for i := range out {
+		if profileTotal > 0 {
+			out[i].SelfPercent = (out[i].SelfSamples / profileTotal) * 100
+			out[i].TotalPercent = (out[i].TotalSamples / profileTotal) * 100
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].SelfSamples != out[j].SelfSamples {
+			return out[i].SelfSamples > out[j].SelfSamples
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func getProfileTotalSamples(functions []TopFunction) float64 {
+	var total float64
+	for _, fn := range functions {
+		total += fn.SelfSamples
+	}
+	return total
+}
+
+func limitTopFunctions(functions []TopFunction, limit int) []TopFunction {
+	if limit <= 0 || limit >= len(functions) {
+		return functions
+	}
+	return functions[:limit]
+}

--- a/internal/telemetry/profiles/tree_test.go
+++ b/internal/telemetry/profiles/tree_test.go
@@ -1,0 +1,82 @@
+package profiles
+
+import "testing"
+
+func TestBuildFlameTreeMergesCommonRoot(t *testing.T) {
+	rows := []FlamegraphRow{
+		{StackHash: "1", Frames: "leafA" + FrameDelimiter + "main", Samples: 10},
+		{StackHash: "2", Frames: "leafB" + FrameDelimiter + "main", Samples: 5},
+	}
+
+	tree := BuildFlameTree(rows)
+	if tree.Value != 15 {
+		t.Fatalf("root value=%v want 15", tree.Value)
+	}
+	if len(tree.Children) != 1 {
+		t.Fatalf("children=%d want 1", len(tree.Children))
+	}
+	mainNode := tree.Children[0]
+	if mainNode.Name != "main" || mainNode.Value != 15 {
+		t.Fatalf("main node=%+v", mainNode)
+	}
+	if len(mainNode.Children) != 2 {
+		t.Fatalf("main children=%d want 2", len(mainNode.Children))
+	}
+}
+
+func TestBuildFlameTreeSingleFrameSelf(t *testing.T) {
+	tree := BuildFlameTree([]FlamegraphRow{{StackHash: "1", Frames: "onlyFrame", Samples: 42}})
+	if len(tree.Children) != 1 {
+		t.Fatalf("children=%d", len(tree.Children))
+	}
+	node := tree.Children[0]
+	if node.Self != 42 || node.Value != 42 {
+		t.Fatalf("node=%+v", node)
+	}
+}
+
+func TestFoldToTopFunctionsSelfAndTotal(t *testing.T) {
+	rows := []FlamegraphRow{
+		{StackHash: "1", Frames: "frameA" + FrameDelimiter + "frameB", Samples: 10},
+		{StackHash: "2", Frames: "frameB" + FrameDelimiter + "frameA", Samples: 5},
+	}
+	result := FoldToTopFunctions(rows)
+	byName := map[string]TopFunction{}
+	for _, fn := range result {
+		byName[fn.Name] = fn
+	}
+	if byName["frameA"].SelfSamples != 10 || byName["frameA"].TotalSamples != 15 {
+		t.Fatalf("frameA=%+v", byName["frameA"])
+	}
+	if byName["frameB"].SelfSamples != 5 || byName["frameB"].TotalSamples != 15 {
+		t.Fatalf("frameB=%+v", byName["frameB"])
+	}
+}
+
+func TestFoldToTopFunctionsNoDoubleCountRecursive(t *testing.T) {
+	rows := []FlamegraphRow{
+		{StackHash: "1", Frames: "recurse" + FrameDelimiter + "recurse" + FrameDelimiter + "main", Samples: 7},
+	}
+	result := FoldToTopFunctions(rows)
+	var recurse TopFunction
+	for _, fn := range result {
+		if fn.Name == "recurse" {
+			recurse = fn
+		}
+	}
+	if recurse.TotalSamples != 7 || recurse.SelfSamples != 7 {
+		t.Fatalf("recurse=%+v", recurse)
+	}
+}
+
+func TestBuildProfileSummaryText(t *testing.T) {
+	summary := buildProfileSummaryText("api", "cpu", []TopFunction{
+		{Name: "hot.A", SelfSamples: 40},
+		{Name: "hot.B", SelfSamples: 30},
+		{Name: "hot.C", SelfSamples: 10},
+	}, 100)
+	want := "Top 3 CPU consumers for api are hot.A, hot.B, hot.C, accounting for 80.0% of total self samples."
+	if summary != want {
+		t.Fatalf("summary=%q want %q", summary, want)
+	}
+}

--- a/internal/telemetry/profiles/types.go
+++ b/internal/telemetry/profiles/types.go
@@ -16,6 +16,9 @@ const (
 	// DefaultFlamegraphRowLimit matches FLAMEGRAPH_ROW_LIMIT in the dashboard client.
 	DefaultFlamegraphRowLimit = 1000
 
+	// MaxFlamegraphRowLimit matches the PDE-718 query_range hard cap (~10000).
+	MaxFlamegraphRowLimit = 10000
+
 	// DefaultTopFunctionsLimit is the post-fold ranking cap for get_top_functions.
 	DefaultTopFunctionsLimit = 50
 

--- a/internal/telemetry/profiles/types.go
+++ b/internal/telemetry/profiles/types.go
@@ -1,6 +1,6 @@
 package profiles
 
-// ProfileType is the continuous-profiling sample kind (PDE-718 / ENG-1699).
+// ProfileType is the continuous-profiling sample kind.
 type ProfileType string
 
 const (
@@ -16,7 +16,7 @@ const (
 	// DefaultFlamegraphRowLimit matches FLAMEGRAPH_ROW_LIMIT in the dashboard client.
 	DefaultFlamegraphRowLimit = 1000
 
-	// MaxFlamegraphRowLimit matches the PDE-718 query_range hard cap (~10000).
+	// MaxFlamegraphRowLimit matches the query_range hard cap (~10000).
 	MaxFlamegraphRowLimit = 10000
 
 	// DefaultTopFunctionsLimit is the post-fold ranking cap for get_top_functions.

--- a/internal/telemetry/profiles/types.go
+++ b/internal/telemetry/profiles/types.go
@@ -1,0 +1,76 @@
+package profiles
+
+// ProfileType is the continuous-profiling sample kind (PDE-718 / ENG-1699).
+type ProfileType string
+
+const (
+	ProfileTypeCPU   ProfileType = "cpu"
+	ProfileTypeAlloc ProfileType = "alloc"
+	ProfileTypeWall  ProfileType = "wall"
+
+	DefaultProfileType = ProfileTypeCPU
+
+	// DefaultLookbackMinutes matches the Profiling UI default (1 hour).
+	DefaultLookbackMinutes = 60
+
+	// DefaultFlamegraphRowLimit matches FLAMEGRAPH_ROW_LIMIT in the dashboard client.
+	DefaultFlamegraphRowLimit = 1000
+
+	// DefaultTopFunctionsLimit is the post-fold ranking cap for get_top_functions.
+	DefaultTopFunctionsLimit = 50
+
+	// FrameDelimiter separates stack frames in Body / Frames (0x1f).
+	FrameDelimiter = "\x1f"
+)
+
+// Resource field paths used in filter/aggregate pipelines (ProfilesApis PROFILE_RESOURCE_FIELDS).
+const (
+	ResourceEnv       = "resources['deployment.environment.name']"
+	ResourceCluster   = "resources['k8s.cluster.name']"
+	ResourceNamespace = "resources['k8s.namespace.name']"
+	ResourceRuntime   = "resources['telemetry.sdk.language']"
+)
+
+// ProfileFilters scopes a profiles query_range/json pipeline.
+type ProfileFilters struct {
+	Service     string
+	Env         string
+	Cluster     string
+	Namespace   string
+	Runtime     string
+	ProfileType ProfileType
+}
+
+// FlamegraphRow is one aggregated stack from the flamegraph dataframe.
+type FlamegraphRow struct {
+	StackHash string  `json:"stack_hash"`
+	Frames    string  `json:"frames"`
+	Samples   float64 `json:"samples"`
+}
+
+// FlameNode is the nested flamegraph tree returned to agents.
+type FlameNode struct {
+	Name     string      `json:"name"`
+	Value    float64     `json:"value"`
+	Self     float64     `json:"self"`
+	Children []FlameNode `json:"children,omitempty"`
+}
+
+// TopFunction is a ranked function with self/total sample counts.
+type TopFunction struct {
+	Name         string  `json:"name"`
+	TotalSamples float64 `json:"total_samples"`
+	SelfSamples  float64 `json:"self_samples"`
+	SelfPercent  float64 `json:"self_percent"`
+	TotalPercent float64 `json:"total_percent"`
+}
+
+// ProfileServiceIndexRow is one landing-table service with relative sample share.
+type ProfileServiceIndexRow struct {
+	Name          string  `json:"name"`
+	Samples       float64 `json:"samples"`
+	Share         float64 `json:"share"`
+	SharePercent  float64 `json:"share_percent"`
+	Runtime       string  `json:"runtime,omitempty"`
+	LastProfileAt string  `json:"last_profile_at,omitempty"`
+}

--- a/internal/telemetry/profiles/unwrap.go
+++ b/internal/telemetry/profiles/unwrap.go
@@ -1,0 +1,238 @@
+package profiles
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func unwrapQueryRangeRows(body any) []map[string]any {
+	switch typed := body.(type) {
+	case []any:
+		return asRecordRows(typed)
+	case map[string]any:
+		data, ok := typed["data"]
+		if !ok || data == nil {
+			return nil
+		}
+		switch payload := data.(type) {
+		case []any:
+			return asRecordRows(payload)
+		case map[string]any:
+			if resultType, _ := payload["resultType"].(string); resultType == "dataframe" {
+				rawResult, _ := payload["result"].([]any)
+				out := make([]map[string]any, 0, len(rawResult))
+				for _, item := range rawResult {
+					row, ok := item.(map[string]any)
+					if !ok {
+						continue
+					}
+					metric, ok := row["metric"].(map[string]any)
+					if !ok || metric == nil {
+						continue
+					}
+					out = append(out, metric)
+				}
+				return out
+			}
+		}
+	}
+	return nil
+}
+
+func asRecordRows(rows []any) []map[string]any {
+	out := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		if m, ok := row.(map[string]any); ok && m != nil {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func getServiceNameFromRow(row map[string]any) string {
+	if name := strings.TrimSpace(asString(row["name"])); name != "" {
+		return name
+	}
+	return strings.TrimSpace(asString(row["ServiceName"]))
+}
+
+func getRowNumber(row map[string]any, keys ...string) float64 {
+	for _, key := range keys {
+		if n, ok := asFloat(row[key]); ok {
+			return n
+		}
+	}
+	return 0
+}
+
+func asString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case json.Number:
+		return t.String()
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(t)
+	case int64:
+		return strconv.FormatInt(t, 10)
+	default:
+		if v == nil {
+			return ""
+		}
+		return fmt.Sprint(v)
+	}
+}
+
+func asFloat(v any) (float64, bool) {
+	switch t := v.(type) {
+	case float64:
+		return t, true
+	case float32:
+		return float64(t), true
+	case int:
+		return float64(t), true
+	case int64:
+		return float64(t), true
+	case json.Number:
+		n, err := t.Float64()
+		return n, err == nil
+	case string:
+		if strings.TrimSpace(t) == "" {
+			return 0, false
+		}
+		n, err := strconv.ParseFloat(t, 64)
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func parseProfileTimestamp(value any) string {
+	if value == nil {
+		return ""
+	}
+	switch t := value.(type) {
+	case string:
+		trimmed := strings.TrimSpace(t)
+		if trimmed == "" {
+			return ""
+		}
+		if n, err := strconv.ParseFloat(trimmed, 64); err == nil {
+			return parseProfileTimestamp(n)
+		}
+		if parsed, err := time.Parse(time.RFC3339Nano, trimmed); err == nil {
+			return parsed.UTC().Format(time.RFC3339Nano)
+		}
+		if parsed, err := time.Parse(time.RFC3339, trimmed); err == nil {
+			return parsed.UTC().Format(time.RFC3339)
+		}
+		return ""
+	case float64:
+		ms := t
+		if t < 1e12 {
+			ms = t * 1000
+		}
+		return time.UnixMilli(int64(ms)).UTC().Format(time.RFC3339Nano)
+	case int64:
+		return parseProfileTimestamp(float64(t))
+	case int:
+		return parseProfileTimestamp(float64(t))
+	default:
+		return ""
+	}
+}
+
+func mapFlamegraphRows(rows []map[string]any) []FlamegraphRow {
+	out := make([]FlamegraphRow, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, FlamegraphRow{
+			StackHash: asString(row["StackHash"]),
+			Frames:    asString(row["Frames"]),
+			Samples:   getRowNumber(row, "samples", "Value", "value"),
+		})
+	}
+	return out
+}
+
+func buildProfileServiceIndex(sampleRows, lastProfileRows []map[string]any) []ProfileServiceIndexRow {
+	lastByName := make(map[string]string)
+	for _, row := range lastProfileRows {
+		name := getServiceNameFromRow(row)
+		if name == "" {
+			continue
+		}
+		lastByName[name] = parseProfileTimestamp(firstNonNil(row["last_profile"], row["Timestamp"], row["timestamp"]))
+	}
+
+	type acc struct {
+		samples       float64
+		runtime       string
+		runtimeSample float64
+	}
+	byName := make(map[string]*acc)
+	for _, row := range sampleRows {
+		name := getServiceNameFromRow(row)
+		samples := getRowNumber(row, "samples", "Value", "value")
+		if name == "" || samples <= 0 {
+			continue
+		}
+		runtime := strings.TrimSpace(asString(firstNonNil(row["runtime"], row[ResourceRuntime])))
+		existing, ok := byName[name]
+		if !ok {
+			byName[name] = &acc{samples: samples, runtime: runtime, runtimeSample: samples}
+			continue
+		}
+		existing.samples += samples
+		if runtime != "" && samples > existing.runtimeSample {
+			existing.runtime = runtime
+			existing.runtimeSample = samples
+		}
+	}
+
+	var total float64
+	for _, a := range byName {
+		total += a.samples
+	}
+
+	out := make([]ProfileServiceIndexRow, 0, len(byName))
+	for name, a := range byName {
+		share := 0.0
+		if total > 0 {
+			share = a.samples / total
+		}
+		row := ProfileServiceIndexRow{
+			Name:         name,
+			Samples:      a.samples,
+			Share:        share,
+			SharePercent: share * 100,
+			Runtime:      a.runtime,
+		}
+		if ts := lastByName[name]; ts != "" {
+			row.LastProfileAt = ts
+		}
+		out = append(out, row)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Samples != out[j].Samples {
+			return out[i].Samples > out[j].Samples
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func firstNonNil(values ...any) any {
+	for _, v := range values {
+		if v != nil {
+			return v
+		}
+	}
+	return nil
+}

--- a/internal/telemetry/profiles/unwrap_test.go
+++ b/internal/telemetry/profiles/unwrap_test.go
@@ -1,0 +1,60 @@
+package profiles
+
+import "testing"
+
+func TestUnwrapQueryRangeRowsDataframe(t *testing.T) {
+	body := map[string]any{
+		"status": "success",
+		"data": map[string]any{
+			"resultType": "dataframe",
+			"result": []any{
+				map[string]any{"metric": map[string]any{"name": "svc-a", "samples": float64(10)}},
+				map[string]any{"metric": map[string]any{"name": "svc-b", "samples": "5"}},
+			},
+		},
+	}
+	rows := unwrapQueryRangeRows(body)
+	if len(rows) != 2 {
+		t.Fatalf("rows=%d", len(rows))
+	}
+	if getServiceNameFromRow(rows[0]) != "svc-a" {
+		t.Fatalf("row0=%v", rows[0])
+	}
+	if getRowNumber(rows[1], "samples") != 5 {
+		t.Fatalf("samples=%v", rows[1]["samples"])
+	}
+}
+
+func TestUnwrapQueryRangeRowsPlainArray(t *testing.T) {
+	body := []any{
+		map[string]any{"ServiceName": "x", "samples": float64(1)},
+	}
+	rows := unwrapQueryRangeRows(body)
+	if len(rows) != 1 || getServiceNameFromRow(rows[0]) != "x" {
+		t.Fatalf("rows=%v", rows)
+	}
+}
+
+func TestBuildProfileServiceIndex(t *testing.T) {
+	sampleRows := []map[string]any{
+		{"name": "a", "samples": float64(70), "runtime": "go"},
+		{"name": "a", "samples": float64(10), "runtime": "java"},
+		{"name": "b", "samples": float64(20), "runtime": "go"},
+	}
+	lastRows := []map[string]any{
+		{"name": "a", "last_profile": "2026-08-13T10:00:00Z"},
+	}
+	out := buildProfileServiceIndex(sampleRows, lastRows)
+	if len(out) != 2 {
+		t.Fatalf("len=%d", len(out))
+	}
+	if out[0].Name != "a" || out[0].Samples != 80 || out[0].Runtime != "go" {
+		t.Fatalf("first=%+v", out[0])
+	}
+	if out[0].LastProfileAt == "" {
+		t.Fatal("expected last_profile_at")
+	}
+	if out[0].SharePercent <= out[1].SharePercent {
+		t.Fatalf("share order wrong: %+v", out)
+	}
+}

--- a/internal/toolsets/toolsets.go
+++ b/internal/toolsets/toolsets.go
@@ -64,6 +64,12 @@ var named = map[string][]string{
 		"get_dashboard_snapshot",
 		"delete_dashboard_snapshot",
 	},
+	"profiles": {
+		"get_profile_services",
+		"get_flamegraph",
+		"get_top_functions",
+		"get_profile_summary",
+	},
 }
 
 // discovery tools included in the investigate composite (R9a).
@@ -139,7 +145,7 @@ func Parse(spec string) (Set, error) {
 	for _, t := range tokens {
 		switch t {
 		case "investigate":
-			for _, domain := range []string{"logs", "traces", "metrics"} {
+			for _, domain := range []string{"logs", "traces", "metrics", "profiles"} {
 				for _, tool := range named[domain] {
 					out[tool] = struct{}{}
 				}

--- a/internal/toolsets/toolsets_test.go
+++ b/internal/toolsets/toolsets_test.go
@@ -52,7 +52,7 @@ func TestParseInvestigate(t *testing.T) {
 	if set == nil {
 		t.Fatal("investigate must not expand to nil/all")
 	}
-	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources", "get_apm_service_deviations"} {
+	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources", "get_apm_service_deviations", "get_flamegraph", "get_profile_services"} {
 		if !set.Allows(want) {
 			t.Errorf("investigate missing %q", want)
 		}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func SetupConfig(defaults models.Config) (models.Config, error) {
 	fs.BoolVar(&cfg.HTTPMode, "http", false, "Run as HTTP server instead of STDIO")
 	fs.StringVar(&cfg.Port, "port", "8080", "HTTP server port")
 	fs.StringVar(&cfg.Host, "host", "localhost", "HTTP server host")
-	fs.StringVar(&cfg.Toolsets, "toolsets", toolsets.SpecFromEnv(), "Comma-separated MCP toolsets to expose (logs,traces,metrics,alerts,dashboards,investigate,all). Empty or all = full surface")
+	fs.StringVar(&cfg.Toolsets, "toolsets", toolsets.SpecFromEnv(), "Comma-separated MCP toolsets to expose (logs,traces,metrics,alerts,dashboards,profiles,investigate,all). Empty or all = full surface")
 	versionFlag := fs.Bool("version", false, "Print version information")
 
 	var configFile string

--- a/tools.go
+++ b/tools.go
@@ -278,7 +278,7 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config) error 
 		Description: prompts.DidYouMeanDescription,
 	}, suggest.NewDidYouMeanHandler(client, cfg)))
 
-	// Continuous profiling tools (ENG-1067 / PDE-718 query_range/json)
+	// Continuous profiling tools (query_range/json)
 	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
 		Name:        "get_profile_services",
 		Description: prompts.GetProfileServicesDescription,

--- a/tools.go
+++ b/tools.go
@@ -12,6 +12,7 @@ import (
 	"last9-mcp/internal/prompts"
 	"last9-mcp/internal/suggest"
 	"last9-mcp/internal/telemetry/logs"
+	"last9-mcp/internal/telemetry/profiles"
 	"last9-mcp/internal/telemetry/traces"
 	"last9-mcp/internal/toolsets"
 
@@ -276,6 +277,27 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config) error 
 		Name:        "did_you_mean",
 		Description: prompts.DidYouMeanDescription,
 	}, suggest.NewDidYouMeanHandler(client, cfg)))
+
+	// Continuous profiling tools (ENG-1067 / PDE-718 query_range/json)
+	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
+		Name:        "get_profile_services",
+		Description: prompts.GetProfileServicesDescription,
+	}, profiles.NewGetProfileServicesHandler(client, cfg)))
+
+	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
+		Name:        "get_flamegraph",
+		Description: prompts.GetFlamegraphDescription,
+	}, profiles.NewGetFlamegraphHandler(client, cfg)))
+
+	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
+		Name:        "get_top_functions",
+		Description: prompts.GetTopFunctionsDescription,
+	}, profiles.NewGetTopFunctionsHandler(client, cfg)))
+
+	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
+		Name:        "get_profile_summary",
+		Description: prompts.GetProfileSummaryDescription,
+	}, profiles.NewGetProfileSummaryHandler(client, cfg)))
 
 	// Register dashboard tools
 	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{


### PR DESCRIPTION
## Summary
- Adds `get_profile_services`, `get_flamegraph`, `get_top_functions`, and `get_profile_summary` using the same PDE-718 `POST /profiles/api/v1/query_range/json` contract as the Profiling UI (last9#11392 / #11396 Tempo proxy).
- Registers a `profiles` toolset and includes it in `investigate`.
- Client-side flame tree + top-functions folding matches the dashboard ProfilesApis helpers (dataframe unwrap, CPU type pin, 0x1f frames).

## Test plan
- [x] `go test ./...`
- [x] `go run . dump-tools --toolsets=profiles` shows only the four tools
- [x] Live smoke on `app.last9.io` (`LAST9_LIVE_PROFILES=1`): services + flamegraph + top_functions + summary 200
- [ ] `go run . dump-tools --toolsets=logs` does not leak profiling tools

Linear: ENG-1067
Depends on: profiles Tempo proxy on app (last9#11396 / PDE-1117)


Made with [Cursor](https://cursor.com)