### PR TITLE
fix(mcp): query get_change_events filters against stored metric labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `get_change_events` maps `service_name`/`env`/`event_name` onto stored labels (`service`/`deployment_environment`/`event_name`), using each alias only when the primary label is absent. `available_event_names` unions `event_name` and `event_type`.
 - Log-query `400`/`422` responses now use the shared upstream sanitizer (URL/credential redaction, 512-byte truncation with `… (truncated)`) instead of echoing the raw body. `get_logs` / `get_service_logs` also append the pipeline schema hint pointing at `get_log_attributes_for_pipeline` (#213).
 - `get_logs` fail-closed logjson validation with self-correcting tips (wrong keys/types, bare fields, NOT-SQL, bad parse/`window_aggregate` shapes); whale description aligned with API `window_aggregate`; missing parse `field` defaults to `Body`; `TraceId`/`SpanId`/`ParentSpanId` allowed for log↔trace correlation; dotted parse labels accepted; `tracejson.md` lookback default corrected to 60 (#212).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `get_change_events` maps `service_name`/`env`/`event_name` onto stored labels (`service`/`deployment_environment`/`event_name`), using each alias only when the primary label is absent. `available_event_names` unions `event_name` and `event_type`.
+- `get_change_events`: the `service_name`, `env`, and `event_name` filters now match the labels change events are actually stored with. A filtered call previously returned nothing while the same call without filters showed the events.
 - `get_log_attributes_for_pipeline` now reports a plain-text Body's shape. A Body that is neither JSON nor logfmt and carries no severity token previously produced no Body entry at all, so models guessed `parser:"json"` and got a silent zero, or wrote an unanchored regexp that captured the leading timestamp and returned a confidently wrong count. Such services now get a `Body` entry with `source:"body"`, up to three `sample_bodies` lines to anchor a pattern against, and a one-stage `$regex`-on-Body hint. `sample_bodies` redacts URLs and known credential values only — it is not PII-redacted, so treat it as untrusted log content.
 - `l9_sanity` is no longer suppressed when `matched_count` is 0 — previously the most suspicious outcome was the one case with no guardrail. A zero from a pipeline that parses or filters `Body` now carries a note pointing at `sample_bodies`, and a new `service_log_volume` key separates a genuine zero from a parse/filter mismatch. Zero counts from pipelines that never touch `Body`, and all non-zero paths, are unchanged.
 

--- a/internal/apm/databases.go
+++ b/internal/apm/databases.go
@@ -52,7 +52,7 @@ func NewGetDatabasesHandler(client *http.Client, cfg models.Config) func(context
 
 		envFilter := ""
 		if args.Env != "" {
-			envFilter = fmt.Sprintf(`, env=~"%s"`, escapePromQLLabel(args.Env))
+			envFilter = fmt.Sprintf(`, env=~"%s"`, utils.EscapePromQLLabel(args.Env))
 		}
 
 		baseFilter := fmt.Sprintf(
@@ -529,24 +529,15 @@ func NewGetDatabaseQueriesHandler(client *http.Client, cfg models.Config) func(c
 func buildDBBaseFilter(dbSystem, host, env string) string {
 	filter := fmt.Sprintf(
 		`span_kind=~"SPAN_KIND_CLIENT|SPAN_KIND_INTERNAL", db_system="%s"`,
-		escapePromQLLabel(dbSystem),
+		utils.EscapePromQLLabel(dbSystem),
 	)
 	if host != "" {
-		filter += fmt.Sprintf(`, net_peer_name="%s"`, escapePromQLLabel(host))
+		filter += fmt.Sprintf(`, net_peer_name="%s"`, utils.EscapePromQLLabel(host))
 	}
 	if env != "" {
-		filter += fmt.Sprintf(`, env=~"%s"`, escapePromQLLabel(env))
+		filter += fmt.Sprintf(`, env=~"%s"`, utils.EscapePromQLLabel(env))
 	}
 	return filter
-}
-
-// escapePromQLLabel escapes special characters in a PromQL label value
-// to prevent injection when interpolating into queries.
-func escapePromQLLabel(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `"`, `\"`)
-	s = strings.ReplaceAll(s, "\n", `\n`)
-	return s
 }
 
 func fetchPromBySpanName(ctx context.Context, client *http.Client, cfg models.Config, query string, endTime int64, patterns map[string]*QueryPattern, setter func(*QueryPattern, float64)) error {

--- a/internal/apm/deviations.go
+++ b/internal/apm/deviations.go
@@ -13,6 +13,7 @@ import (
 
 	"last9-mcp/internal/deeplink"
 	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -940,9 +941,9 @@ func uniqueSorted(values []string) []string {
 }
 
 func hasAnyAPMTelemetry(ctx context.Context, runner deviationQueryRunner, args DeviationArgs, windows DeviationWindows) (bool, error) {
-	matchers := []string{fmt.Sprintf(`service_name="%s"`, escapePromQLLabel(args.ServiceName))}
+	matchers := []string{fmt.Sprintf(`service_name="%s"`, utils.EscapePromQLLabel(args.ServiceName))}
 	if args.Env != "" {
-		matchers = append(matchers, fmt.Sprintf(`env="%s"`, escapePromQLLabel(args.Env)))
+		matchers = append(matchers, fmt.Sprintf(`env="%s"`, utils.EscapePromQLLabel(args.Env)))
 	}
 	selector := strings.Join(matchers, ",")
 	families := []string{"trace_endpoint_count", "trace_client_count", "domain_attributes_count"}

--- a/internal/apm/deviations_query.go
+++ b/internal/apm/deviations_query.go
@@ -206,10 +206,10 @@ func buildDeviationWindowQueries(scope deviationQueryScope, window TimeWindow, s
 	group := strings.Join(groupLabels, ", ")
 	baseMatchers := []string{`span_kind="SPAN_KIND_SERVER"`}
 	if scope.ServiceName != "" {
-		baseMatchers = append(baseMatchers, fmt.Sprintf(`service_name="%s"`, escapePromQLLabel(scope.ServiceName)))
+		baseMatchers = append(baseMatchers, fmt.Sprintf(`service_name="%s"`, utils.EscapePromQLLabel(scope.ServiceName)))
 	}
 	if scope.Env != "" {
-		baseMatchers = append(baseMatchers, fmt.Sprintf(`env="%s"`, escapePromQLLabel(scope.Env)))
+		baseMatchers = append(baseMatchers, fmt.Sprintf(`env="%s"`, utils.EscapePromQLLabel(scope.Env)))
 	}
 	requestSelector := fmt.Sprintf("trace_endpoint_count{%s}", strings.Join(baseMatchers, ","))
 	requestExpression := fmt.Sprintf("sum by (%s) (%s)", group, requestSelector)
@@ -305,10 +305,10 @@ func deviationGroupLabels(operations bool) []string {
 func deviationRequestExpression(scope deviationQueryScope, group string) string {
 	matchers := []string{`span_kind="SPAN_KIND_SERVER"`}
 	if scope.ServiceName != "" {
-		matchers = append(matchers, fmt.Sprintf(`service_name="%s"`, escapePromQLLabel(scope.ServiceName)))
+		matchers = append(matchers, fmt.Sprintf(`service_name="%s"`, utils.EscapePromQLLabel(scope.ServiceName)))
 	}
 	if scope.Env != "" {
-		matchers = append(matchers, fmt.Sprintf(`env="%s"`, escapePromQLLabel(scope.Env)))
+		matchers = append(matchers, fmt.Sprintf(`env="%s"`, utils.EscapePromQLLabel(scope.Env)))
 	}
 	return fmt.Sprintf("sum by (%s) (trace_endpoint_count{%s})", group, strings.Join(matchers, ","))
 }

--- a/internal/apm/service_summary.go
+++ b/internal/apm/service_summary.go
@@ -244,7 +244,7 @@ func serviceSummaryEnvMatcher(env string) (scope, matcher string, err error) {
 	if _, err := regexp.Compile(env); err != nil {
 		return "", "", fmt.Errorf("env %q is not a valid regular expression: %w", env, err)
 	}
-	return env, fmt.Sprintf(`env=~"%s"`, escapePromQLLabel(env)), nil
+	return env, fmt.Sprintf(`env=~"%s"`, utils.EscapePromQLLabel(env)), nil
 }
 
 func serviceSummaryCountQuery(envMatcher string, windowMin int, extraMatcher string) string {

--- a/internal/change_events/change_events.go
+++ b/internal/change_events/change_events.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -69,34 +70,7 @@ func NewGetChangeEventsHandler(client *http.Client, cfg models.Config) func(cont
 			return nil, nil, fmt.Errorf("failed to fetch available event names: %w", err)
 		}
 
-		// Build label filters for the Prometheus query
-		var labelFilters []string
-
-		if args.ServiceName != "" {
-			labelFilters = append(labelFilters, fmt.Sprintf(`service_name="%s"`, args.ServiceName))
-		}
-
-		if args.Env != "" {
-			labelFilters = append(labelFilters, fmt.Sprintf(`env="%s"`, args.Env))
-		}
-
-		// Use event_name parameter directly - the AI should provide the exact event type
-		if args.EventName != "" {
-			labelFilters = append(labelFilters, fmt.Sprintf(`event_type="%s"`, args.EventName))
-		}
-
-		// Add default filters to exclude backup and rehydration events
-		labelFilters = append(labelFilters, `event_name!~"cold_storage_logs_backup|cold_storage_logs_backup_endtime|cold_storage_logs_backup_time_taken_in_sec|manual_rehydration_event"`)
-		labelFilters = append(labelFilters, `l9_event_name!~"last9_scheduled_search"`)
-
-		// Build the filter string
-		var filterStr string
-		if len(labelFilters) > 0 {
-			filterStr = "{" + strings.Join(labelFilters, ",") + "}"
-		}
-
-		// Build PromQL query for change events
-		promql := fmt.Sprintf("last9_change_events%s", filterStr)
+		promql := buildChangeEventsPromQL(args.ServiceName, args.Env, args.EventName)
 
 		// Make range query to get change events over time
 		resp, err := utils.MakePromRangeAPIQuery(ctx, client, promql, startTimeParam, endTimeParam, cfg)
@@ -147,10 +121,71 @@ func NewGetChangeEventsHandler(client *http.Client, cfg models.Config) func(cont
 	}
 }
 
-// fetchAvailableEventNames fetches all available event_name values from the last9_change_events metric
+const (
+	changeEventsMetric     = "last9_change_events"
+	backupEventExclude     = `event_name!~"cold_storage_logs_backup|cold_storage_logs_backup_endtime|cold_storage_logs_backup_time_taken_in_sec|manual_rehydration_event"`
+	scheduledSearchExclude = `l9_event_name!~"last9_scheduled_search"`
+)
+
+// buildChangeEventsPromQL maps MCP-canonical params (service_name, env,
+// event_name) onto the labels last9_change_events actually stores.
+//
+// Stored series use service / deployment_environment / event_name. Some
+// tenants also copy the MCP names (service_name / env / event_type). Each
+// constraint matches the primary label, or the alias only when the primary
+// is absent — an unconditional OR would false-positive when both labels
+// exist with different values.
+func buildChangeEventsPromQL(serviceName, env, eventName string) string {
+	sels := [][]string{{backupEventExclude, scheduledSearchExclude}}
+	sels = expandPrimaryOrAlias(sels, "service", "service_name", serviceName)
+	sels = expandPrimaryOrAlias(sels, "deployment_environment", "env", env)
+	sels = expandPrimaryOrAlias(sels, "event_name", "event_type", eventName)
+
+	out := make([]string, 0, len(sels))
+	for _, f := range sels {
+		out = append(out, changeEventsMetric+"{"+strings.Join(f, ",")+"}")
+	}
+	return strings.Join(out, " or ")
+}
+
+func expandPrimaryOrAlias(sels [][]string, primary, alias, value string) [][]string {
+	if value == "" {
+		return sels
+	}
+	out := make([][]string, 0, len(sels)*2)
+	for _, s := range sels {
+		out = append(out, append(append([]string{}, s...), fmt.Sprintf(`%s="%s"`, primary, value)))
+		out = append(out, append(append([]string{}, s...), fmt.Sprintf(`%s=""`, primary), fmt.Sprintf(`%s="%s"`, alias, value)))
+	}
+	return out
+}
+
+// fetchAvailableEventNames unions event_name and event_type values so
+// discover-then-filter works for both stored shapes.
 func fetchAvailableEventNames(ctx context.Context, client *http.Client, startTime, endTime int64, cfg models.Config) ([]string, error) {
-	// Use the label values API to get all event_name values
-	resp, err := utils.MakePromLabelValuesAPIQuery(ctx, client, "event_type", "last9_change_events", startTime, endTime, cfg)
+	unique := make(map[string]struct{})
+	for _, label := range []string{"event_name", "event_type"} {
+		names, err := fetchEventNamesForLabel(ctx, client, label, startTime, endTime, cfg)
+		if err != nil {
+			return nil, err
+		}
+		for _, name := range names {
+			if name == "" {
+				continue
+			}
+			unique[name] = struct{}{}
+		}
+	}
+	eventNames := make([]string, 0, len(unique))
+	for name := range unique {
+		eventNames = append(eventNames, name)
+	}
+	sort.Strings(eventNames)
+	return eventNames, nil
+}
+
+func fetchEventNamesForLabel(ctx context.Context, client *http.Client, label string, startTime, endTime int64, cfg models.Config) ([]string, error) {
+	resp, err := utils.MakePromLabelValuesAPIQuery(ctx, client, label, "last9_change_events", startTime, endTime, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query event names: %w", err)
 	}
@@ -165,7 +200,6 @@ func fetchAvailableEventNames(ctx context.Context, client *http.Client, startTim
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	// Parse the response to extract event names
 	var eventNamesResp []string
 	if err := json.Unmarshal(body, &eventNamesResp); err != nil {
 		return nil, fmt.Errorf("failed to parse event names response: %w", err)

--- a/internal/change_events/change_events.go
+++ b/internal/change_events/change_events.go
@@ -122,70 +122,50 @@ func NewGetChangeEventsHandler(client *http.Client, cfg models.Config) func(cont
 }
 
 const (
-	changeEventsMetric     = "last9_change_events"
-	backupEventExclude     = `event_name!~"cold_storage_logs_backup|cold_storage_logs_backup_endtime|cold_storage_logs_backup_time_taken_in_sec|manual_rehydration_event"`
-	scheduledSearchExclude = `l9_event_name!~"last9_scheduled_search"`
+	changeEventsMetric           = "last9_change_events"
+	excludeBackupEvents          = `event_name!~"cold_storage_logs_backup|cold_storage_logs_backup_endtime|cold_storage_logs_backup_time_taken_in_sec|manual_rehydration_event"`
+	excludeScheduledSearchEvents = `l9_event_name!~"last9_scheduled_search"`
 )
 
-// buildChangeEventsPromQL maps MCP-canonical params (service_name, env,
-// event_name) onto the labels last9_change_events actually stores.
-//
-// Stored series use service / deployment_environment / event_name. Some
-// tenants also copy the MCP names (service_name / env / event_type). Each
-// constraint matches the primary label, or the alias only when the primary
-// is absent — an unconditional OR would false-positive when both labels
-// exist with different values.
+// Change events store service / deployment_environment / event_name; the MCP
+// param names are just a different spelling of the first two.
 func buildChangeEventsPromQL(serviceName, env, eventName string) string {
-	sels := [][]string{{backupEventExclude, scheduledSearchExclude}}
-	sels = expandPrimaryOrAlias(sels, "service", "service_name", serviceName)
-	sels = expandPrimaryOrAlias(sels, "deployment_environment", "env", env)
-	sels = expandPrimaryOrAlias(sels, "event_name", "event_type", eventName)
-
-	out := make([]string, 0, len(sels))
-	for _, f := range sels {
-		out = append(out, changeEventsMetric+"{"+strings.Join(f, ",")+"}")
-	}
-	return strings.Join(out, " or ")
+	matchers := []string{excludeBackupEvents, excludeScheduledSearchEvents}
+	matchers = addFilter(matchers, "service", serviceName)
+	matchers = addFilter(matchers, "deployment_environment", env)
+	matchers = addFilter(matchers, "event_name", eventName)
+	return changeEventsMetric + "{" + strings.Join(matchers, ",") + "}"
 }
 
-func expandPrimaryOrAlias(sels [][]string, primary, alias, value string) [][]string {
+func addFilter(matchers []string, label, value string) []string {
 	if value == "" {
-		return sels
+		return matchers
 	}
-	out := make([][]string, 0, len(sels)*2)
-	for _, s := range sels {
-		out = append(out, append(append([]string{}, s...), fmt.Sprintf(`%s="%s"`, primary, value)))
-		out = append(out, append(append([]string{}, s...), fmt.Sprintf(`%s=""`, primary), fmt.Sprintf(`%s="%s"`, alias, value)))
-	}
-	return out
+	return append(matchers, fmt.Sprintf(`%s="%s"`, label, utils.EscapePromQLLabel(value)))
 }
 
-// fetchAvailableEventNames unions event_name and event_type values so
-// discover-then-filter works for both stored shapes.
+// Same exclusions as the query: a name this list offers must be one a filter
+// can actually match. event_name only — no other label carries an event
+// identity a filter can match.
 func fetchAvailableEventNames(ctx context.Context, client *http.Client, startTime, endTime int64, cfg models.Config) ([]string, error) {
-	unique := make(map[string]struct{})
-	for _, label := range []string{"event_name", "event_type"} {
-		names, err := fetchEventNamesForLabel(ctx, client, label, startTime, endTime, cfg)
-		if err != nil {
-			return nil, err
-		}
-		for _, name := range names {
-			if name == "" {
-				continue
-			}
-			unique[name] = struct{}{}
-		}
+	selector := changeEventsMetric + "{" + excludeBackupEvents + "," + excludeScheduledSearchEvents + "}"
+	names, err := fetchEventNamesForLabel(ctx, client, "event_name", selector, startTime, endTime, cfg)
+	if err != nil {
+		return nil, err
 	}
-	eventNames := make([]string, 0, len(unique))
-	for name := range unique {
+	eventNames := make([]string, 0, len(names))
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
 		eventNames = append(eventNames, name)
 	}
 	sort.Strings(eventNames)
 	return eventNames, nil
 }
 
-func fetchEventNamesForLabel(ctx context.Context, client *http.Client, label string, startTime, endTime int64, cfg models.Config) ([]string, error) {
-	resp, err := utils.MakePromLabelValuesAPIQuery(ctx, client, label, "last9_change_events", startTime, endTime, cfg)
+func fetchEventNamesForLabel(ctx context.Context, client *http.Client, label, selector string, startTime, endTime int64, cfg models.Config) ([]string, error) {
+	resp, err := utils.MakePromLabelValuesAPIQuery(ctx, client, label, selector, startTime, endTime, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query event names: %w", err)
 	}

--- a/internal/change_events/change_events.go
+++ b/internal/change_events/change_events.go
@@ -41,7 +41,7 @@ type GetChangeEventsArgs struct {
 	LookbackMinutes int    `json:"lookback_minutes,omitempty" jsonschema:"Number of minutes to look back from now (default: 60, minimum: 1)"`
 	ServiceName     string `json:"service_name,omitempty" jsonschema:"Service name filter (optional)"`
 	Env             string `json:"env,omitempty" jsonschema:"Environment filter (optional)"`
-	EventName       string `json:"event_name,omitempty" jsonschema:"Exact event type filter (optional). Use available_event_names from a previous call."`
+	EventName       string `json:"event_name,omitempty" jsonschema:"Exact event name filter (optional). Use available_event_names from a previous call."`
 }
 
 func NewGetChangeEventsHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetChangeEventsArgs) (*mcp.CallToolResult, any, error) {

--- a/internal/change_events/change_events_test.go
+++ b/internal/change_events/change_events_test.go
@@ -99,3 +99,47 @@ func TestGetChangeEventsArgs_UsesCanonicalNames(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildChangeEventsPromQL(t *testing.T) {
+	excludes := backupEventExclude + "," + scheduledSearchExclude
+	metric := func(matchers string) string {
+		return `last9_change_events{` + matchers + `}`
+	}
+
+	unfiltered := buildChangeEventsPromQL("", "", "")
+	if unfiltered != metric(excludes) {
+		t.Fatalf("unfiltered:\n got %s\nwant %s", unfiltered, metric(excludes))
+	}
+
+	envOnly := buildChangeEventsPromQL("", "uat", "")
+	wantEnv := metric(excludes+`,deployment_environment="uat"`) + " or " +
+		metric(excludes+`,deployment_environment="",env="uat"`)
+	if envOnly != wantEnv {
+		t.Fatalf("env filter:\n got %s\nwant %s", envOnly, wantEnv)
+	}
+
+	svcOnly := buildChangeEventsPromQL("checkout", "", "")
+	wantSvc := metric(excludes+`,service="checkout"`) + " or " +
+		metric(excludes+`,service="",service_name="checkout"`)
+	if svcOnly != wantSvc {
+		t.Fatalf("service filter:\n got %s\nwant %s", svcOnly, wantSvc)
+	}
+
+	eventOnly := buildChangeEventsPromQL("", "", "deployment")
+	wantEvent := metric(excludes+`,event_name="deployment"`) + " or " +
+		metric(excludes+`,event_name="",event_type="deployment"`)
+	if eventOnly != wantEvent {
+		t.Fatalf("event filter:\n got %s\nwant %s", eventOnly, wantEvent)
+	}
+
+	both := buildChangeEventsPromQL("checkout", "uat", "")
+	wantBoth := strings.Join([]string{
+		metric(excludes + `,service="checkout",deployment_environment="uat"`),
+		metric(excludes + `,service="checkout",deployment_environment="",env="uat"`),
+		metric(excludes + `,service="",service_name="checkout",deployment_environment="uat"`),
+		metric(excludes + `,service="",service_name="checkout",deployment_environment="",env="uat"`),
+	}, " or ")
+	if both != wantBoth {
+		t.Fatalf("service+env:\n got %s\nwant %s", both, wantBoth)
+	}
+}

--- a/internal/change_events/change_events_test.go
+++ b/internal/change_events/change_events_test.go
@@ -101,45 +101,41 @@ func TestGetChangeEventsArgs_UsesCanonicalNames(t *testing.T) {
 }
 
 func TestBuildChangeEventsPromQL(t *testing.T) {
-	excludes := backupEventExclude + "," + scheduledSearchExclude
+	excludes := excludeBackupEvents + "," + excludeScheduledSearchEvents
 	metric := func(matchers string) string {
-		return `last9_change_events{` + matchers + `}`
+		return changeEventsMetric + `{` + matchers + `}`
 	}
 
-	unfiltered := buildChangeEventsPromQL("", "", "")
-	if unfiltered != metric(excludes) {
-		t.Fatalf("unfiltered:\n got %s\nwant %s", unfiltered, metric(excludes))
+	tests := []struct {
+		name                        string
+		serviceName, env, eventName string
+		want                        string
+	}{
+		{"unfiltered", "", "", "", metric(excludes)},
+		{"service", "checkout", "", "", metric(excludes + `,service="checkout"`)},
+		{"env", "", "uat", "", metric(excludes + `,deployment_environment="uat"`)},
+		{"event", "", "", "deployment", metric(excludes + `,event_name="deployment"`)},
+		{
+			"all three", "checkout", "uat", "deployment",
+			metric(excludes + `,service="checkout",deployment_environment="uat",event_name="deployment"`),
+		},
+		{
+			// A quote or backslash must not terminate the matcher.
+			"value needing escapes", `a"b\c`, "", "",
+			metric(excludes + `,service="a\"b\\c"`),
+		},
+		{
+			"injection attempt", `x"} or up{`, "", "",
+			metric(excludes + `,service="x\"} or up{"`),
+		},
 	}
 
-	envOnly := buildChangeEventsPromQL("", "uat", "")
-	wantEnv := metric(excludes+`,deployment_environment="uat"`) + " or " +
-		metric(excludes+`,deployment_environment="",env="uat"`)
-	if envOnly != wantEnv {
-		t.Fatalf("env filter:\n got %s\nwant %s", envOnly, wantEnv)
-	}
-
-	svcOnly := buildChangeEventsPromQL("checkout", "", "")
-	wantSvc := metric(excludes+`,service="checkout"`) + " or " +
-		metric(excludes+`,service="",service_name="checkout"`)
-	if svcOnly != wantSvc {
-		t.Fatalf("service filter:\n got %s\nwant %s", svcOnly, wantSvc)
-	}
-
-	eventOnly := buildChangeEventsPromQL("", "", "deployment")
-	wantEvent := metric(excludes+`,event_name="deployment"`) + " or " +
-		metric(excludes+`,event_name="",event_type="deployment"`)
-	if eventOnly != wantEvent {
-		t.Fatalf("event filter:\n got %s\nwant %s", eventOnly, wantEvent)
-	}
-
-	both := buildChangeEventsPromQL("checkout", "uat", "")
-	wantBoth := strings.Join([]string{
-		metric(excludes + `,service="checkout",deployment_environment="uat"`),
-		metric(excludes + `,service="checkout",deployment_environment="",env="uat"`),
-		metric(excludes + `,service="",service_name="checkout",deployment_environment="uat"`),
-		metric(excludes + `,service="",service_name="checkout",deployment_environment="",env="uat"`),
-	}, " or ")
-	if both != wantBoth {
-		t.Fatalf("service+env:\n got %s\nwant %s", both, wantBoth)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildChangeEventsPromQL(tt.serviceName, tt.env, tt.eventName)
+			if got != tt.want {
+				t.Fatalf("\n got %s\nwant %s", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/change_events/change_events_time_test.go
+++ b/internal/change_events/change_events_time_test.go
@@ -13,6 +13,7 @@ import (
 	"last9-mcp/internal/auth"
 	"last9-mcp/internal/constants"
 	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -94,8 +95,8 @@ func TestGetChangeEventsHandler_ExplicitRangePrecedence(t *testing.T) {
 		t.Fatalf("handler returned error: %v", err)
 	}
 
-	if len(captured) != 2 {
-		t.Fatalf("expected 2 upstream requests, got %d", len(captured))
+	if len(captured) != 3 {
+		t.Fatalf("expected 3 upstream requests (event_name + event_type discovery, then range), got %d", len(captured))
 	}
 
 	// endTimeParam = "2026-02-09T16:04:05Z" = 1770653045
@@ -110,20 +111,25 @@ func TestGetChangeEventsHandler_ExplicitRangePrecedence(t *testing.T) {
 	}
 }
 
-// Verifies the renamed input fields (service_name, env) actually reach the
-// backend PromQL as service_name="..."/env="..." — the rename is only correct
-// if the handler wires the new fields into the query, not just the schema.
-func TestGetChangeEventsHandler_FiltersUseCanonicalLabels(t *testing.T) {
+// last9_change_events stores service/deployment_environment/event_name (and
+// sometimes the MCP-canonical aliases). Filtering only on env/service_name/
+// event_type returns zero series even when matching events exist.
+func TestGetChangeEventsHandler_FiltersUseStoredMetricLabels(t *testing.T) {
 	var capturedQuery string
+	capturedLabels := map[string]bool{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		_ = r.Body.Close()
 		var req struct {
 			Query string `json:"query"`
+			Label string `json:"label"`
 		}
 		_ = json.Unmarshal(body, &req)
 		if req.Query != "" {
 			capturedQuery = req.Query
+		}
+		if req.Label != "" {
+			capturedLabels[req.Label] = true
 		}
 		w.Header().Set(constants.HeaderContentType, constants.HeaderContentTypeJSON)
 		_, _ = io.WriteString(w, `[]`)
@@ -142,15 +148,76 @@ func TestGetChangeEventsHandler_FiltersUseCanonicalLabels(t *testing.T) {
 	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetChangeEventsArgs{
 		ServiceName:     "checkout",
 		Env:             "prod",
+		EventName:       "deployment",
 		LookbackMinutes: 30,
 	})
 	if err != nil {
 		t.Fatalf("handler error: %v", err)
 	}
-	if !strings.Contains(capturedQuery, `service_name="checkout"`) {
-		t.Fatalf("expected service_name=\"checkout\" filter in query, got: %s", capturedQuery)
+	for _, want := range []string{"event_name", "event_type"} {
+		if !capturedLabels[want] {
+			t.Fatalf("available_event_names must read label %q, got %v", want, capturedLabels)
+		}
 	}
-	if !strings.Contains(capturedQuery, `env="prod"`) {
-		t.Fatalf("expected env=\"prod\" filter in query, got: %s", capturedQuery)
+	for _, want := range []string{
+		`service="checkout"`,
+		`deployment_environment="prod"`,
+		`event_name="deployment"`,
+	} {
+		if !strings.Contains(capturedQuery, want) {
+			t.Fatalf("expected %s in PromQL (stored metric labels), got: %s", want, capturedQuery)
+		}
+	}
+}
+
+func TestGetChangeEventsHandler_MergesEventNameAndEventTypeDiscovery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		w.Header().Set(constants.HeaderContentType, constants.HeaderContentTypeJSON)
+		if r.URL.Path != constants.EndpointPromLabelValues {
+			_, _ = io.WriteString(w, `[]`)
+			return
+		}
+		var req struct {
+			Label string `json:"label"`
+		}
+		_ = json.Unmarshal(body, &req)
+		switch req.Label {
+		case "event_name":
+			_, _ = io.WriteString(w, `["deployment"]`)
+		case "event_type":
+			_, _ = io.WriteString(w, `["rollback"]`)
+		default:
+			_, _ = io.WriteString(w, `[]`)
+		}
+	}))
+	defer server.Close()
+
+	cfg := models.Config{
+		APIBaseURL: server.URL,
+		TokenManager: &auth.TokenManager{
+			AccessToken: "test-token",
+			ExpiresAt:   time.Now().Add(24 * time.Hour),
+		},
+	}
+
+	handler := NewGetChangeEventsHandler(server.Client(), cfg)
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetChangeEventsArgs{
+		LookbackMinutes: 30,
+	})
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	text := utils.GetTextContent(t, result)
+	var response struct {
+		AvailableEventNames []string `json:"available_event_names"`
+	}
+	if err := json.Unmarshal([]byte(text), &response); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := strings.Join(response.AvailableEventNames, ",")
+	if got != "deployment,rollback" {
+		t.Fatalf("available_event_names = %q, want deployment,rollback", got)
 	}
 }

--- a/internal/change_events/change_events_time_test.go
+++ b/internal/change_events/change_events_time_test.go
@@ -95,8 +95,8 @@ func TestGetChangeEventsHandler_ExplicitRangePrecedence(t *testing.T) {
 		t.Fatalf("handler returned error: %v", err)
 	}
 
-	if len(captured) != 3 {
-		t.Fatalf("expected 3 upstream requests (event_name + event_type discovery, then range), got %d", len(captured))
+	if len(captured) != 2 {
+		t.Fatalf("expected 2 upstream requests (event_name discovery, then range), got %d", len(captured))
 	}
 
 	// endTimeParam = "2026-02-09T16:04:05Z" = 1770653045
@@ -111,9 +111,8 @@ func TestGetChangeEventsHandler_ExplicitRangePrecedence(t *testing.T) {
 	}
 }
 
-// last9_change_events stores service/deployment_environment/event_name (and
-// sometimes the MCP-canonical aliases). Filtering only on env/service_name/
-// event_type returns zero series even when matching events exist.
+// Filtering on the MCP spellings alone returns zero series even when matching
+// events exist.
 func TestGetChangeEventsHandler_FiltersUseStoredMetricLabels(t *testing.T) {
 	var capturedQuery string
 	capturedLabels := map[string]bool{}
@@ -154,10 +153,12 @@ func TestGetChangeEventsHandler_FiltersUseStoredMetricLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("handler error: %v", err)
 	}
-	for _, want := range []string{"event_name", "event_type"} {
-		if !capturedLabels[want] {
-			t.Fatalf("available_event_names must read label %q, got %v", want, capturedLabels)
-		}
+	if !capturedLabels["event_name"] {
+		t.Fatalf("available_event_names must read label \"event_name\", got %v", capturedLabels)
+	}
+	// event_type is never stamped, so reading it surfaces unmatchable names.
+	if capturedLabels["event_type"] {
+		t.Fatalf("available_event_names must not read label \"event_type\", got %v", capturedLabels)
 	}
 	for _, want := range []string{
 		`service="checkout"`,
@@ -170,7 +171,10 @@ func TestGetChangeEventsHandler_FiltersUseStoredMetricLabels(t *testing.T) {
 	}
 }
 
-func TestGetChangeEventsHandler_MergesEventNameAndEventTypeDiscovery(t *testing.T) {
+// event_name is stamped on every series, so an event_type value could never be
+// matched by a filter.
+func TestGetChangeEventsHandler_DiscoveryReadsEventNameOnly(t *testing.T) {
+	var capturedMatches []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		_ = r.Body.Close()
@@ -180,9 +184,11 @@ func TestGetChangeEventsHandler_MergesEventNameAndEventTypeDiscovery(t *testing.
 			return
 		}
 		var req struct {
-			Label string `json:"label"`
+			Label   string   `json:"label"`
+			Matches []string `json:"matches"`
 		}
 		_ = json.Unmarshal(body, &req)
+		capturedMatches = append(capturedMatches, req.Matches...)
 		switch req.Label {
 		case "event_name":
 			_, _ = io.WriteString(w, `["deployment"]`)
@@ -217,7 +223,16 @@ func TestGetChangeEventsHandler_MergesEventNameAndEventTypeDiscovery(t *testing.
 		t.Fatalf("unmarshal: %v", err)
 	}
 	got := strings.Join(response.AvailableEventNames, ",")
-	if got != "deployment,rollback" {
-		t.Fatalf("available_event_names = %q, want deployment,rollback", got)
+	if got != "deployment" {
+		t.Fatalf("available_event_names = %q, want deployment (event_type must not be unioned)", got)
+	}
+
+	// Discovery must carry the query's exclusions, or it offers names that
+	// every filtered call then rejects.
+	joined := strings.Join(capturedMatches, " ")
+	for _, want := range []string{excludeBackupEvents, excludeScheduledSearchEvents} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("event_name discovery must apply %s, got matches %v", want, capturedMatches)
+		}
 	}
 }

--- a/internal/prompts/descriptions/get_change_events.md
+++ b/internal/prompts/descriptions/get_change_events.md
@@ -2,7 +2,7 @@ Change events from the `last9_change_events` Prometheus metric (deployments, con
 
 Response: `available_event_names` (valid filter values), `change_events` (timeseries with metric labels + timestamp/value pairs), `count`, `time_range`.
 
-Each event has `metric` (labels: service, deployment_environment, event_name, message, …) and `values` (timestamp/value pairs). Pass tool params `service_name` and `env` — they map onto those stored labels (and `service_name`/`env` when present).
+Each event has `metric` (labels: service, deployment_environment, event_name, message, …) and `values` (timestamp/value pairs). Filter with the tool's own param names (`service_name`, `env`, `event_name`) — the server maps them onto the labels the events are stored with.
 
 Workflow: first call without `event_name` to read `available_event_names`, then filter with the exact name from that list. Combine with service_name, env, and time filters as needed.
 

--- a/internal/prompts/descriptions/get_change_events.md
+++ b/internal/prompts/descriptions/get_change_events.md
@@ -2,7 +2,7 @@ Change events from the `last9_change_events` Prometheus metric (deployments, con
 
 Response: `available_event_names` (valid filter values), `change_events` (timeseries with metric labels + timestamp/value pairs), `count`, `time_range`.
 
-Each event has `metric` (labels: service_name, env, event_type, message, …) and `values` (timestamp/value pairs).
+Each event has `metric` (labels: service, deployment_environment, event_name, message, …) and `values` (timestamp/value pairs). Pass tool params `service_name` and `env` — they map onto those stored labels (and `service_name`/`env` when present).
 
 Workflow: first call without `event_name` to read `available_event_names`, then filter with the exact name from that list. Combine with service_name, env, and time filters as needed.
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -471,3 +471,12 @@ func validatePopulatedDatasourceCfg(cfg *models.Config) error {
 	}
 	return nil
 }
+
+// EscapePromQLLabel escapes special characters in a PromQL label value so an
+// interpolated value cannot terminate the matcher and alter the selector.
+func EscapePromQLLabel(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	return s
+}


### PR DESCRIPTION
## Summary

`get_change_events` filtered on `service_name`, `env`, and `event_type` — none of which are the labels change events are stored with (`service`, `deployment_environment`, `event_name`). A filtered call returned nothing while the same call without filters returned the events.

The query is a single selector on the stored labels. Tool parameter names are unchanged. Filter values are escaped before interpolation, and `available_event_names` applies the query's exclusion matchers so every name it offers is one a filter can match.

## Test plan

- [x] `go test ./internal/change_events/`
- [x] `go test . -run TestDumpTools`
- [x] Verified against live data: filtered counts agree with unfiltered, and a value containing a quote produces a well-formed query instead of an upstream 400.
