### PR TITLE
chore: release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-08-16
+
 ### Fixed
 
 - Log-query `400`/`422` responses now use the shared upstream sanitizer (URL/credential redaction, 512-byte truncation with `… (truncated)`) instead of echoing the raw body. `get_logs` / `get_service_logs` also append the pipeline schema hint pointing at `get_log_attributes_for_pipeline` (#213).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
Bumps `package.json` 0.15.0 → 0.15.1 and marks the `[Unreleased]` changelog entries as released.

## Changes since v0.15.0

- `fix(mcp)`: compile last9/api fetches and structured log search (#213)
- `fix(logs)`: align get_logs whale + fail-closed pipeline validation (#212)
- `fix(apm)`: rank get_service_summary by interval counts (#210)

All patch-level fixes — no breaking changes, no new tools.

## Release pipeline (auto-triggered on merge)

- [ ] `tag-and-release` — tag `v0.15.1` + GoReleaser artifacts
- [ ] `publish-docker` — `docker-registry.last9.io` + ECR (`v0.15.1`, `latest`)
- [ ] `publish-npm` — `@last9/mcp-server@0.15.1` via OIDC
- [ ] homebrew-tap dispatch — formula PR in `last9/homebrew-tap`

## Verification

`go build ./...` clean, `go test ./...` 998 passed across 17 packages.

Note: #210/#212/#213 changed tool descriptions and reference manuals. Recommend an agentic eval run (`last9-mcp-evals`, `--use-server`) against this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)