### PR TITLE
fix: make metrics sample-limit errors actionable

### DIFF
--- a/internal/apm/apm_test.go
+++ b/internal/apm/apm_test.go
@@ -652,6 +652,13 @@ func TestPromqlRangeQueryRelays400AndDrains502(t *testing.T) {
 			wantSubstr: "parse error",
 		},
 		{
+			name:       "422 too many samples gives actionable metrics error",
+			status:     http.StatusUnprocessableEntity,
+			body:       `{"error":"Too many samples queried. Please try selecting a smaller time range."}`,
+			wantSubstr: "METRICS_QUERY_TOO_MANY_SAMPLES",
+			forbid:     "Upstream response",
+		},
+		{
 			name:       "502 omits body",
 			status:     http.StatusBadGateway,
 			body:       `{"error":"gateway SECRET"}`,
@@ -697,7 +704,7 @@ func TestPromqlRangeQueryRelays400AndDrains502(t *testing.T) {
 	}
 }
 
-func TestServicePerformanceDetailsPromFailureRecordsPartialErrors(t *testing.T) {
+func TestServicePerformanceDetailsTooManySamplesRecordsActionablePartialErrors(t *testing.T) {
 	var n atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if n.Add(1) == 1 {
@@ -705,8 +712,8 @@ func TestServicePerformanceDetailsPromFailureRecordsPartialErrors(t *testing.T) 
 			_, _ = io.WriteString(w, `[]`)
 			return
 		}
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = io.WriteString(w, `{"error":"bad selector"}`)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = io.WriteString(w, `{"error":"Too many samples queried. Please try selecting a smaller time range."}`)
 	}))
 	defer server.Close()
 
@@ -733,8 +740,14 @@ func TestServicePerformanceDetailsPromFailureRecordsPartialErrors(t *testing.T) 
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
 	joined := strings.Join(details.PartialErrors, "\n")
-	if !strings.Contains(joined, "bad selector") {
-		t.Fatalf("expected sanitized 400 body in partial_errors, got %#v", details.PartialErrors)
+	for _, want := range []string{
+		"METRICS_QUERY_TOO_MANY_SAMPLES",
+		"shorter time range",
+		"narrower filters",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("actionable partial_errors %q missing %q", joined, want)
+		}
 	}
 	if details.ServiceName != "checkout" {
 		t.Fatalf("surviving payload missing service_name, got %#v", details)

--- a/internal/apm/apm_test.go
+++ b/internal/apm/apm_test.go
@@ -742,8 +742,10 @@ func TestServicePerformanceDetailsTooManySamplesRecordsActionablePartialErrors(t
 	joined := strings.Join(details.PartialErrors, "\n")
 	for _, want := range []string{
 		"METRICS_QUERY_TOO_MANY_SAMPLES",
-		"shorter time range",
 		"narrower filters",
+		"do not ask the user to edit PromQL",
+		"preserve the requested coverage",
+		"Never average percentile values",
 	} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("actionable partial_errors %q missing %q", joined, want)

--- a/internal/utils/upstream_http.go
+++ b/internal/utils/upstream_http.go
@@ -60,7 +60,7 @@ func NewUpstreamHTTPError(resp *http.Response, op string, hint ...string) error 
 		body := ReadLimitedResponseBody(resp.Body, 4<<10)
 		if status == http.StatusUnprocessableEntity && strings.Contains(strings.ToLower(body), "too many samples") {
 			return fmt.Errorf(
-				"%s failed with HTTP %d (%s). The metrics backend rejected the query because it would scan too many samples. Retry with a shorter time range or narrower filters (for example, a specific service, environment, operation, or label). Do not retry the same query unchanged.",
+				"%s failed with HTTP %d (%s). The generated metrics query would scan too many samples. Agent action required: do not ask the user to edit PromQL. Retry with narrower filters already known from the request (for example, service, environment, operation, or label). If the full time range is still required, split it into smaller subranges only when the results can be combined correctly; preserve the requested coverage and disclose any limitations. Never average percentile values across subranges. Ask the user to narrow the scope only when the requested result cannot be computed correctly. Do not retry the same query unchanged.",
 				op,
 				status,
 				MetricsTooManySamplesErrorCode,

--- a/internal/utils/upstream_http.go
+++ b/internal/utils/upstream_http.go
@@ -10,7 +10,10 @@ import (
 	"unicode"
 )
 
-const UpstreamBodyLimit = 512
+const (
+	UpstreamBodyLimit              = 512
+	MetricsTooManySamplesErrorCode = "METRICS_QUERY_TOO_MANY_SAMPLES"
+)
 
 var (
 	upstreamBodyURLPattern    = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.-]*://[^\s"'<>,}\]]+`)
@@ -55,6 +58,14 @@ func NewUpstreamHTTPError(resp *http.Response, op string, hint ...string) error 
 	status := resp.StatusCode
 	if status == http.StatusBadRequest || status == http.StatusUnprocessableEntity {
 		body := ReadLimitedResponseBody(resp.Body, 4<<10)
+		if status == http.StatusUnprocessableEntity && strings.Contains(strings.ToLower(body), "too many samples") {
+			return fmt.Errorf(
+				"%s failed with HTTP %d (%s). The metrics backend rejected the query because it would scan too many samples. Retry with a shorter time range or narrower filters (for example, a specific service, environment, operation, or label). Do not retry the same query unchanged.",
+				op,
+				status,
+				MetricsTooManySamplesErrorCode,
+			)
+		}
 		msg := fmt.Sprintf("%s failed with HTTP %d. Review the tool arguments and retry. Upstream response: %s", op, status, body)
 		if len(hint) > 0 && strings.TrimSpace(hint[0]) != "" {
 			msg += "\n\n" + hint[0]

--- a/internal/utils/upstream_http_test.go
+++ b/internal/utils/upstream_http_test.go
@@ -50,6 +50,39 @@ func TestNewUpstreamHTTPErrorTruncatesAndHints(t *testing.T) {
 	}
 }
 
+func TestNewUpstreamHTTPErrorMapsTooManySamplesToActionableMetricsError(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusUnprocessableEntity,
+		Body: io.NopCloser(strings.NewReader(
+			`{"error":"Too many samples queried. Please try selecting a smaller time range."}`,
+		)),
+	}
+	err := NewUpstreamHTTPError(resp, "Prometheus range query")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	got := err.Error()
+	for _, want := range []string{
+		"HTTP 422",
+		"METRICS_QUERY_TOO_MANY_SAMPLES",
+		"shorter time range",
+		"narrower filters",
+		"service",
+		"environment",
+		"operation",
+		"label",
+		"Do not retry the same query unchanged",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("custom metrics error %q missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "Upstream response") {
+		t.Fatalf("custom metrics error should replace the raw upstream response: %s", got)
+	}
+}
+
 func TestNewUpstreamHTTPErrorDrains502Body(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: http.StatusBadGateway,

--- a/internal/utils/upstream_http_test.go
+++ b/internal/utils/upstream_http_test.go
@@ -66,12 +66,16 @@ func TestNewUpstreamHTTPErrorMapsTooManySamplesToActionableMetricsError(t *testi
 	for _, want := range []string{
 		"HTTP 422",
 		"METRICS_QUERY_TOO_MANY_SAMPLES",
-		"shorter time range",
 		"narrower filters",
 		"service",
 		"environment",
 		"operation",
 		"label",
+		"do not ask the user to edit PromQL",
+		"split it into smaller subranges",
+		"preserve the requested coverage",
+		"Never average percentile values",
+		"Ask the user to narrow the scope only when",
 		"Do not retry the same query unchanged",
 	} {
 		if !strings.Contains(got, want) {


### PR DESCRIPTION
## Summary
- recognize upstream HTTP 422 responses containing too many samples
- return the stable error code METRICS_QUERY_TOO_MANY_SAMPLES
- direct the AI agent, not the customer, to adapt generated metric queries
- reuse filters already known from the request and preserve requested coverage
- split ranges only when results can be combined correctly; never average percentiles across chunks
- ask the user to narrow scope only when the requested result cannot be computed correctly
- preserve existing sanitized handling for other 400/422 responses

## Agent behavior
The tool explicitly says not to ask users to edit PromQL. The agent should retry with known service, environment, operation, or label filters. If the full range is required, it may split the range only when aggregation remains mathematically valid. It must preserve coverage, disclose limitations, and never average percentile values.

## Verification
- go test ./... — 996 passed
- go vet ./... — clean
