### PR TITLE
[FDE-166] Add get_infrastructure_context MCP tool

### DIFF
--- a/dump_test.go
+++ b/dump_test.go
@@ -44,7 +44,7 @@ func TestDumpTools(t *testing.T) {
 	for i, tool := range out.Tools {
 		byName[tool.Name] = i
 	}
-	for _, name := range []string{"get_traces", "get_service_summary", "prometheus_label_values", "get_logs", "get_infrastructure_context"} {
+	for _, name := range []string{"get_traces", "get_service_summary", "prometheus_label_values", "get_logs", "get_infrastructure_context", "search_infrastructure_entities"} {
 		i, ok := byName[name]
 		if !ok {
 			t.Fatalf("tool %q missing from dump", name)
@@ -298,7 +298,7 @@ func TestDumpToolsInvestigate(t *testing.T) {
 	for _, tool := range out.Tools {
 		byName[tool.Name] = true
 	}
-	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources", "get_infrastructure_context"} {
+	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources", "get_infrastructure_context", "search_infrastructure_entities"} {
 		if !byName[want] {
 			t.Errorf("investigate dump missing %q", want)
 		}

--- a/dump_test.go
+++ b/dump_test.go
@@ -44,7 +44,7 @@ func TestDumpTools(t *testing.T) {
 	for i, tool := range out.Tools {
 		byName[tool.Name] = i
 	}
-	for _, name := range []string{"get_traces", "get_service_summary", "prometheus_label_values", "get_logs"} {
+	for _, name := range []string{"get_traces", "get_service_summary", "prometheus_label_values", "get_logs", "get_infrastructure_context"} {
 		i, ok := byName[name]
 		if !ok {
 			t.Fatalf("tool %q missing from dump", name)
@@ -298,7 +298,7 @@ func TestDumpToolsInvestigate(t *testing.T) {
 	for _, tool := range out.Tools {
 		byName[tool.Name] = true
 	}
-	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources"} {
+	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources", "get_infrastructure_context"} {
 		if !byName[want] {
 			t.Errorf("investigate dump missing %q", want)
 		}

--- a/internal/constants/api.go
+++ b/internal/constants/api.go
@@ -37,6 +37,8 @@ const (
 	EndpointNotificationSettings = "/notification_settings"
 	// EndpointSuggest returns fuzzy entity-name suggestions for the did_you_mean tool.
 	EndpointSuggest = "/suggest"
+	// EndpointInfrastructureResolve returns host ↔ Kubernetes relationships.
+	EndpointInfrastructureResolve = "/infrastructure/resolve"
 
 	// Dashboard API endpoints (v4)
 	EndpointDashboards            = "/dashboards"
@@ -60,6 +62,7 @@ const (
 	HeaderUserAgent       = "User-Agent"
 	HeaderContentTypeJSON = "application/json"
 	HeaderAcceptJSON      = "application/json"
+	HeaderRegion          = "region"
 )
 
 // Bearer token prefix

--- a/internal/infrastructure/http.go
+++ b/internal/infrastructure/http.go
@@ -1,0 +1,74 @@
+package infrastructure
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"last9-mcp/internal/constants"
+	"last9-mcp/internal/models"
+)
+
+const (
+	maxAPIErrorBodyBytes   = 4096
+	maxAPISuccessBodyBytes = 256 * 1024
+)
+
+type jsonCall struct {
+	client *http.Client
+	cfg    models.Config
+	region string
+	body   []byte
+}
+
+func doJSONRequest(ctx context.Context, call jsonCall) ([]byte, error) {
+	if call.cfg.TokenManager == nil {
+		return nil, fmt.Errorf("token manager is not configured")
+	}
+
+	url := call.cfg.APIBaseURL + constants.EndpointInfrastructureResolve
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(call.body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set(constants.HeaderContentType, constants.HeaderContentTypeJSON)
+	req.Header.Set(constants.HeaderAccept, constants.HeaderAcceptJSON)
+	req.Header.Set(constants.HeaderXLast9APIToken, constants.BearerPrefix+call.cfg.TokenManager.GetAccessToken(ctx))
+	req.Header.Set(constants.HeaderRegion, call.region)
+
+	resp, err := call.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	return readAPIResponse(resp)
+}
+
+func readAPIResponse(resp *http.Response) ([]byte, error) {
+	limited := io.LimitReader(resp.Body, maxAPISuccessBodyBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if int64(len(body)) > maxAPISuccessBodyBytes {
+		return nil, fmt.Errorf("infrastructure API response exceeds %d bytes", maxAPISuccessBodyBytes)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("infrastructure API returned status %d: %s", resp.StatusCode, truncateAPIError(body, resp.StatusCode))
+	}
+	return body, nil
+}
+
+func truncateAPIError(body []byte, status int) string {
+	msg := strings.TrimSpace(string(body))
+	if msg == "" {
+		return http.StatusText(status)
+	}
+	if len(msg) > maxAPIErrorBodyBytes {
+		return msg[:maxAPIErrorBodyBytes] + "..."
+	}
+	return msg
+}

--- a/internal/infrastructure/resolve.go
+++ b/internal/infrastructure/resolve.go
@@ -1,0 +1,163 @@
+package infrastructure
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"last9-mcp/internal/deeplink"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// GetInfrastructureContextArgs are the input parameters for get_infrastructure_context.
+type GetInfrastructureContextArgs struct {
+	EntityType string                  `json:"entity_type" jsonschema:"(Required) Entity type: host, k8s_node, or k8s_pod. k8s_cluster is not valid input."`
+	Selectors  InfrastructureSelectors `json:"selectors" jsonschema:"(Required) Identity labels for the entity."`
+	Timestamp  int64                   `json:"timestamp,omitempty" jsonschema:"Unix seconds of the observation window. Defaults to now."`
+	ClusterID  string                  `json:"cluster_id,omitempty" jsonschema:"Levitate datasource UUID. Defaults to the configured datasource."`
+	Region     string                  `json:"region,omitempty" jsonschema:"AWS region sent as the region header. Defaults to the configured datasource region."`
+}
+
+// InfrastructureSelectors identify one host, node, or pod.
+type InfrastructureSelectors struct {
+	Cluster   string `json:"cluster,omitempty" jsonschema:"Kubernetes cluster name (k8s label). Required for k8s_node and k8s_pod."`
+	Node      string `json:"node,omitempty" jsonschema:"Kubernetes node name. Required for k8s_node."`
+	Namespace string `json:"namespace,omitempty" jsonschema:"Pod namespace. Required for k8s_pod when uid is omitted."`
+	Pod       string `json:"pod,omitempty" jsonschema:"Pod name. Required for k8s_pod when uid is omitted."`
+	UID       string `json:"uid,omitempty" jsonschema:"Pod UID. Accepted instead of namespace and pod."`
+	HostID    string `json:"host_id,omitempty" jsonschema:"Host instance id. One of instance, host_id, or host_name is required for host."`
+	HostName  string `json:"host_name,omitempty" jsonschema:"Host nodename / host_name."`
+	Instance  string `json:"instance,omitempty" jsonschema:"Prometheus instance label (host:port)."`
+	Job       string `json:"job,omitempty" jsonschema:"Optional Prometheus job label to disambiguate hosts."`
+}
+
+type resolvePayload struct {
+	ClusterID  string            `json:"cluster_id"`
+	EntityType string            `json:"entity_type"`
+	Timestamp  int64             `json:"timestamp"`
+	Selectors  map[string]string `json:"selectors"`
+}
+
+type resolveUI struct {
+	Href string `json:"href"`
+}
+
+type resolveAnchor struct {
+	UI resolveUI `json:"ui"`
+}
+
+type resolveResult struct {
+	Anchor resolveAnchor `json:"anchor"`
+}
+
+// NewGetInfrastructureContextHandler returns the handler for get_infrastructure_context.
+func NewGetInfrastructureContextHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, GetInfrastructureContextArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args GetInfrastructureContextArgs) (*mcp.CallToolResult, any, error) {
+		payload, region, err := buildResolveRequest(cfg, args)
+		if err != nil {
+			return nil, nil, err
+		}
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal request: %w", err)
+		}
+		respBody, err := doJSONRequest(ctx, jsonCall{client: client, cfg: cfg, region: region, body: body})
+		if err != nil {
+			return nil, nil, err
+		}
+		return resultFromAPI(respBody), nil, nil
+	}
+}
+
+func buildResolveRequest(cfg models.Config, args GetInfrastructureContextArgs) (resolvePayload, string, error) {
+	entityType := strings.TrimSpace(args.EntityType)
+	if err := validateEntityType(entityType); err != nil {
+		return resolvePayload{}, "", err
+	}
+	clusterID := strings.TrimSpace(args.ClusterID)
+	if clusterID == "" {
+		clusterID = strings.TrimSpace(cfg.ClusterID)
+	}
+	if clusterID == "" {
+		return resolvePayload{}, "", errors.New("cluster_id is required: pass cluster_id or configure LAST9_DATASOURCE")
+	}
+	region, err := resolveRegion(cfg, args.Region)
+	if err != nil {
+		return resolvePayload{}, "", err
+	}
+	ts := args.Timestamp
+	if ts <= 0 {
+		ts = time.Now().Unix()
+	}
+	return resolvePayload{
+		ClusterID:  clusterID,
+		EntityType: entityType,
+		Timestamp:  ts,
+		Selectors:  selectorMap(args.Selectors),
+	}, region, nil
+}
+
+func validateEntityType(entityType string) error {
+	switch entityType {
+	case "host", "k8s_node", "k8s_pod":
+		return nil
+	case "":
+		return errors.New("entity_type is required")
+	default:
+		return fmt.Errorf("unsupported entity_type %q; use host, k8s_node, or k8s_pod", entityType)
+	}
+}
+
+func resolveRegion(cfg models.Config, arg string) (string, error) {
+	if strings.TrimSpace(arg) != "" {
+		return strings.TrimSpace(arg), nil
+	}
+	if strings.TrimSpace(cfg.Region) != "" {
+		return strings.TrimSpace(cfg.Region), nil
+	}
+	return "", errors.New("region is required: pass region or configure LAST9_DATASOURCE with a region")
+}
+
+func selectorMap(sel InfrastructureSelectors) map[string]string {
+	out := map[string]string{}
+	putSelector(out, "cluster", sel.Cluster)
+	putSelector(out, "node", sel.Node)
+	putSelector(out, "namespace", sel.Namespace)
+	putSelector(out, "pod", sel.Pod)
+	putSelector(out, "uid", sel.UID)
+	putSelector(out, "host_id", sel.HostID)
+	putSelector(out, "host_name", sel.HostName)
+	putSelector(out, "instance", sel.Instance)
+	putSelector(out, "job", sel.Job)
+	return out
+}
+
+func putSelector(out map[string]string, key, value string) {
+	if v := strings.TrimSpace(value); v != "" {
+		out[key] = v
+	}
+}
+
+func resultFromAPI(body []byte) *mcp.CallToolResult {
+	result := &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(body)}},
+	}
+	if href := parseAnchorHref(body); href != "" {
+		result.Meta = deeplink.ToMeta(href)
+	}
+	return result
+}
+
+func parseAnchorHref(body []byte) string {
+	var parsed resolveResult
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	return parsed.Anchor.UI.Href
+}

--- a/internal/infrastructure/resolve_test.go
+++ b/internal/infrastructure/resolve_test.go
@@ -1,0 +1,241 @@
+package infrastructure
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func testResolveConfig(apiBase string) models.Config {
+	return models.Config{
+		APIBaseURL: apiBase,
+		OrgSlug:    "test-org",
+		Region:     "us-east-1",
+		ClusterID:  "cluster-uuid",
+		TokenManager: &auth.TokenManager{
+			AccessToken: "test-token",
+			ExpiresAt:   time.Now().Add(24 * time.Hour),
+		},
+	}
+}
+
+func TestGetInfrastructureContext_SendsRegionHeaderAndClusterID(t *testing.T) {
+	var gotRegion, gotPath, gotAuth, gotQuery string
+	var payload resolvePayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRegion = r.Header.Get("region")
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotAuth = r.Header.Get("X-LAST9-API-TOKEN")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &payload)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "matched",
+			"anchor": map[string]any{
+				"id": "host:i-abc",
+				"ui": map[string]any{"href": "/v2/organizations/test-org/host?host=i-abc"},
+			},
+			"relationships": []any{},
+		})
+	}))
+	defer srv.Close()
+
+	handler := NewGetInfrastructureContextHandler(srv.Client(), testResolveConfig(srv.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetInfrastructureContextArgs{
+		EntityType: "host",
+		Selectors:  InfrastructureSelectors{Instance: "10.0.0.1:9100"},
+		Timestamp:  1700000000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/infrastructure/resolve" {
+		t.Fatalf("path %q", gotPath)
+	}
+	if gotRegion != "us-east-1" {
+		t.Fatalf("region header %q", gotRegion)
+	}
+	if gotQuery != "" {
+		t.Fatalf("region must be a header, query was %q", gotQuery)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Fatalf("auth %q", gotAuth)
+	}
+	if payload.ClusterID != "cluster-uuid" || payload.EntityType != "host" || payload.Timestamp != 1700000000 {
+		t.Fatalf("payload %+v", payload)
+	}
+	if payload.Selectors["instance"] != "10.0.0.1:9100" {
+		t.Fatalf("selectors %+v", payload.Selectors)
+	}
+	href, _ := result.Meta["reference_url"].(string)
+	if href != "/v2/organizations/test-org/host?host=i-abc" {
+		t.Fatalf("meta href %q", href)
+	}
+}
+
+func TestGetInfrastructureContext_OverridesClusterAndRegion(t *testing.T) {
+	var gotRegion string
+	var payload resolvePayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRegion = r.Header.Get("region")
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"not_found","relationships":[]}`))
+	}))
+	defer srv.Close()
+
+	handler := NewGetInfrastructureContextHandler(srv.Client(), testResolveConfig(srv.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetInfrastructureContextArgs{
+		EntityType: "k8s_node",
+		Selectors:  InfrastructureSelectors{Cluster: "prod", Node: "ip-10-0-0-1"},
+		ClusterID:  "other-cluster",
+		Region:     "ap-south-1",
+		Timestamp:  1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRegion != "ap-south-1" {
+		t.Fatalf("region %q", gotRegion)
+	}
+	if payload.ClusterID != "other-cluster" {
+		t.Fatalf("cluster_id %q", payload.ClusterID)
+	}
+}
+
+func TestGetInfrastructureContext_RejectsK8sCluster(t *testing.T) {
+	handler := NewGetInfrastructureContextHandler(http.DefaultClient, testResolveConfig("http://example.invalid"))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetInfrastructureContextArgs{
+		EntityType: "k8s_cluster",
+		Selectors:  InfrastructureSelectors{Cluster: "prod"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported entity_type") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestGetInfrastructureContext_RequiresEntityType(t *testing.T) {
+	handler := NewGetInfrastructureContextHandler(http.DefaultClient, testResolveConfig("http://example.invalid"))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetInfrastructureContextArgs{})
+	if err == nil || !strings.Contains(err.Error(), "entity_type is required") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestGetInfrastructureContext_RequiresRegion(t *testing.T) {
+	cfg := testResolveConfig("http://example.invalid")
+	cfg.Region = ""
+	handler := NewGetInfrastructureContextHandler(http.DefaultClient, cfg)
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetInfrastructureContextArgs{
+		EntityType: "host",
+		Selectors:  InfrastructureSelectors{HostName: "web-01"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "region is required") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestGetInfrastructureContext_RequiresClusterID(t *testing.T) {
+	cfg := testResolveConfig("http://example.invalid")
+	cfg.ClusterID = ""
+	handler := NewGetInfrastructureContextHandler(http.DefaultClient, cfg)
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetInfrastructureContextArgs{
+		EntityType: "host",
+		Selectors:  InfrastructureSelectors{HostName: "web-01"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cluster_id is required") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestGetInfrastructureContext_DoesNotSendPromCredentials(t *testing.T) {
+	var raw map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		_, _ = w.Write([]byte(`{"status":"matched","relationships":[]}`))
+	}))
+	defer srv.Close()
+
+	cfg := testResolveConfig(srv.URL)
+	cfg.PrometheusReadURL = "https://prom.example/read"
+	cfg.PrometheusUsername = "user"
+	cfg.PrometheusPassword = "secret"
+	handler := NewGetInfrastructureContextHandler(srv.Client(), cfg)
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetInfrastructureContextArgs{
+		EntityType: "host",
+		Selectors:  InfrastructureSelectors{HostID: "i-abc"},
+		Timestamp:  1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"read_url", "username", "password"} {
+		if _, ok := raw[key]; ok {
+			t.Fatalf("must not send %s: %+v", key, raw)
+		}
+	}
+}
+
+func TestGetInfrastructureContext_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"cluster_id is required"}`, http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	handler := NewGetInfrastructureContextHandler(srv.Client(), testResolveConfig(srv.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetInfrastructureContextArgs{
+		EntityType: "host",
+		Selectors:  InfrastructureSelectors{Instance: "a:1"},
+		Timestamp:  1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "400") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestGetInfrastructureContext_MissingTokenManager(t *testing.T) {
+	cfg := testResolveConfig("http://example.invalid")
+	cfg.TokenManager = nil
+	handler := NewGetInfrastructureContextHandler(http.DefaultClient, cfg)
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetInfrastructureContextArgs{
+		EntityType: "host",
+		Selectors:  InfrastructureSelectors{Instance: "a:1"},
+		Timestamp:  1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "token manager is not configured") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestGetInfrastructureContext_DefaultsTimestamp(t *testing.T) {
+	var payload resolvePayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		_, _ = w.Write([]byte(`{"status":"matched","relationships":[]}`))
+	}))
+	defer srv.Close()
+
+	before := time.Now().Unix()
+	handler := NewGetInfrastructureContextHandler(srv.Client(), testResolveConfig(srv.URL))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, GetInfrastructureContextArgs{
+		EntityType: "k8s_pod",
+		Selectors:  InfrastructureSelectors{Cluster: "prod", UID: "uid-1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := time.Now().Unix()
+	if payload.Timestamp < before || payload.Timestamp > after {
+		t.Fatalf("timestamp %d not in [%d, %d]", payload.Timestamp, before, after)
+	}
+}

--- a/internal/infrastructure/search.go
+++ b/internal/infrastructure/search.go
@@ -1,0 +1,123 @@
+package infrastructure
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const (
+	defaultSearchLimit = 25
+	maxSearchLimit     = 100
+	maxSearchFetch     = 500
+)
+
+// SearchInfrastructureEntitiesArgs are the input parameters for search_infrastructure_entities.
+type SearchInfrastructureEntitiesArgs struct {
+	EntityType string `json:"entity_type" jsonschema:"(Required) Entity type: host, k8s_cluster, k8s_node, or k8s_pod."`
+	Query      string `json:"query,omitempty" jsonschema:"Optional substring filter on the entity name."`
+	Limit      int    `json:"limit,omitempty" jsonschema:"Page size (default 25, max 100)."`
+	Cursor     string `json:"cursor,omitempty" jsonschema:"Opaque cursor from the previous page's next_cursor."`
+	Timestamp  int64  `json:"timestamp,omitempty" jsonschema:"Unix seconds of the observation window. Defaults to now."`
+	ClusterID  string `json:"cluster_id,omitempty" jsonschema:"Levitate datasource UUID used in entity ids. Defaults to the configured datasource."`
+}
+
+type searchPage struct {
+	EntityType string         `json:"entity_type"`
+	Entities   []searchEntity `json:"entities"`
+	NextCursor string         `json:"next_cursor,omitempty"`
+	Truncated  bool           `json:"truncated,omitempty"`
+}
+
+type searchEntity struct {
+	ID         string            `json:"id"`
+	Type       string            `json:"type"`
+	Attributes map[string]string `json:"attributes"`
+	UI         searchUI          `json:"ui"`
+}
+
+type searchUI struct {
+	Href string `json:"href,omitempty"`
+}
+
+type searchQuery struct {
+	client *http.Client
+	cfg    models.Config
+	args   SearchInfrastructureEntitiesArgs
+}
+
+// NewSearchInfrastructureEntitiesHandler returns the handler for search_infrastructure_entities.
+func NewSearchInfrastructureEntitiesHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, SearchInfrastructureEntitiesArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args SearchInfrastructureEntitiesArgs) (*mcp.CallToolResult, any, error) {
+		page, err := runSearch(ctx, searchQuery{client: client, cfg: cfg, args: args})
+		if err != nil {
+			return nil, nil, err
+		}
+		body, err := json.Marshal(page)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to marshal search result: %w", err)
+		}
+		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(body)}}}, nil, nil
+	}
+}
+
+func runSearch(ctx context.Context, q searchQuery) (searchPage, error) {
+	entityType := strings.TrimSpace(q.args.EntityType)
+	if err := validateSearchType(entityType); err != nil {
+		return searchPage{}, err
+	}
+	if err := validateSearchConfig(q.cfg); err != nil {
+		return searchPage{}, err
+	}
+	ts := q.args.Timestamp
+	if ts <= 0 {
+		ts = time.Now().Unix()
+	}
+	metrics, truncated, err := fetchSearchMetrics(ctx, q, ts)
+	if err != nil {
+		return searchPage{}, err
+	}
+	clusterID := firstNonEmpty(q.args.ClusterID, q.cfg.ClusterID)
+	entities := entitiesFromMetrics(entityType, clusterID, q.cfg.OrgSlug, metrics)
+	entities = filterEntities(entities, q.args.Query)
+	return paginateEntities(entityType, entities, clampSearchLimit(q.args.Limit), q.args.Cursor, truncated)
+}
+
+func validateSearchConfig(cfg models.Config) error {
+	if cfg.TokenManager == nil {
+		return errors.New("token manager is not configured")
+	}
+	if strings.TrimSpace(cfg.PrometheusReadURL) == "" {
+		return errors.New("prometheus read URL is not configured")
+	}
+	return nil
+}
+
+func validateSearchType(entityType string) error {
+	switch entityType {
+	case "host", "k8s_cluster", "k8s_node", "k8s_pod":
+		return nil
+	case "":
+		return errors.New("entity_type is required")
+	default:
+		return fmt.Errorf("unsupported entity_type %q; use host, k8s_cluster, k8s_node, or k8s_pod", entityType)
+	}
+}
+
+func clampSearchLimit(n int) int {
+	if n <= 0 {
+		return defaultSearchLimit
+	}
+	if n > maxSearchLimit {
+		return maxSearchLimit
+	}
+	return n
+}

--- a/internal/infrastructure/search_entities.go
+++ b/internal/infrastructure/search_entities.go
@@ -1,0 +1,253 @@
+package infrastructure
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+func entitiesFromMetrics(entityType, clusterID, org string, metrics []map[string]string) []searchEntity {
+	seen := map[string]struct{}{}
+	out := make([]searchEntity, 0, len(metrics))
+	for _, metric := range metrics {
+		ent, ok := entityFromMetric(entityType, clusterID, org, metric)
+		if !ok {
+			continue
+		}
+		if _, dup := seen[ent.ID]; dup {
+			continue
+		}
+		seen[ent.ID] = struct{}{}
+		out = append(out, ent)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+func entityFromMetric(entityType, clusterID, org string, metric map[string]string) (searchEntity, bool) {
+	switch entityType {
+	case "host":
+		return hostSearchEntity(clusterID, org, metric)
+	case "k8s_cluster":
+		return clusterSearchEntity(clusterID, org, metric)
+	case "k8s_node":
+		return nodeSearchEntity(clusterID, org, metric)
+	default:
+		return podSearchEntity(clusterID, org, metric)
+	}
+}
+
+func hostSearchEntity(clusterID, org string, metric map[string]string) (searchEntity, bool) {
+	hostID := firstNonEmpty(metric["instance_id"], metric["nodename"], metric["instance_name"], metric["instance"])
+	if hostID == "" {
+		return searchEntity{}, false
+	}
+	attrs := omitEmptyAttrs(map[string]string{
+		"host_id":   hostID,
+		"host_name": firstNonEmpty(metric["nodename"], metric["instance_name"], hostID),
+		"instance":  metric["instance"],
+		"job":       metric["job"],
+	})
+	return searchEntity{
+		ID:         strings.Join([]string{"host", clusterID, hostID}, ":"),
+		Type:       "host",
+		Attributes: attrs,
+		UI:         searchUI{Href: hostSearchHref(org, clusterID, attrs)},
+	}, true
+}
+
+func nodeSearchEntity(clusterID, org string, metric map[string]string) (searchEntity, bool) {
+	node := strings.TrimSpace(metric["node"])
+	if node == "" {
+		return searchEntity{}, false
+	}
+	cluster := strings.TrimSpace(metric["cluster"])
+	attrs := omitEmptyAttrs(map[string]string{"cluster": cluster, "node": node})
+	return searchEntity{
+		ID:         strings.Join([]string{"k8s-node", clusterID, cluster, node}, ":"),
+		Type:       "k8s_node",
+		Attributes: attrs,
+		UI:         searchUI{Href: nodeSearchHref(org, clusterID, cluster, node)},
+	}, true
+}
+
+func clusterSearchEntity(clusterID, org string, metric map[string]string) (searchEntity, bool) {
+	cluster := strings.TrimSpace(metric["cluster"])
+	if cluster == "" {
+		return searchEntity{}, false
+	}
+	attrs := map[string]string{"cluster": cluster}
+	return searchEntity{
+		ID:         strings.Join([]string{"k8s-cluster", clusterID, cluster}, ":"),
+		Type:       "k8s_cluster",
+		Attributes: attrs,
+		UI:         searchUI{Href: clusterSearchHref(org, clusterID, cluster)},
+	}, true
+}
+
+func podSearchEntity(clusterID, org string, metric map[string]string) (searchEntity, bool) {
+	pod := strings.TrimSpace(metric["pod"])
+	namespace := strings.TrimSpace(metric["namespace"])
+	uid := strings.TrimSpace(metric["uid"])
+	if pod == "" && uid == "" {
+		return searchEntity{}, false
+	}
+	cluster := strings.TrimSpace(metric["cluster"])
+	idTail := uid
+	if idTail == "" {
+		idTail = pod
+	}
+	attrs := omitEmptyAttrs(map[string]string{
+		"cluster":   cluster,
+		"namespace": namespace,
+		"pod":       pod,
+		"uid":       uid,
+		"node":      metric["node"],
+	})
+	return searchEntity{
+		ID:         strings.Join([]string{"k8s-pod", clusterID, cluster, namespace, idTail}, ":"),
+		Type:       "k8s_pod",
+		Attributes: attrs,
+		UI:         searchUI{Href: podSearchHref(org, clusterID, attrs)},
+	}, true
+}
+
+func filterEntities(entities []searchEntity, query string) []searchEntity {
+	q := strings.ToLower(strings.TrimSpace(query))
+	if q == "" {
+		return entities
+	}
+	out := make([]searchEntity, 0, len(entities))
+	for _, ent := range entities {
+		if entityMatchesQuery(ent, q) {
+			out = append(out, ent)
+		}
+	}
+	return out
+}
+
+func entityMatchesQuery(ent searchEntity, query string) bool {
+	if strings.Contains(strings.ToLower(ent.ID), query) {
+		return true
+	}
+	for _, value := range ent.Attributes {
+		if strings.Contains(strings.ToLower(value), query) {
+			return true
+		}
+	}
+	return false
+}
+
+func paginateEntities(entityType string, entities []searchEntity, limit int, cursor string, truncated bool) (searchPage, error) {
+	offset, err := parseSearchCursor(cursor)
+	if err != nil {
+		return searchPage{}, err
+	}
+	if offset > len(entities) {
+		offset = len(entities)
+	}
+	end := offset + limit
+	if end > len(entities) {
+		end = len(entities)
+	}
+	page := searchPage{EntityType: entityType, Entities: entities[offset:end], Truncated: truncated}
+	if page.Entities == nil {
+		page.Entities = []searchEntity{}
+	}
+	if end < len(entities) {
+		page.NextCursor = strconv.Itoa(end)
+	}
+	return page, nil
+}
+
+func parseSearchCursor(cursor string) (int, error) {
+	if strings.TrimSpace(cursor) == "" {
+		return 0, nil
+	}
+	offset, err := strconv.Atoi(strings.TrimSpace(cursor))
+	if err != nil || offset < 0 {
+		return 0, fmt.Errorf("invalid cursor")
+	}
+	return offset, nil
+}
+
+func omitEmptyAttrs(in map[string]string) map[string]string {
+	out := map[string]string{}
+	for key, value := range in {
+		if strings.TrimSpace(value) != "" {
+			out[key] = strings.TrimSpace(value)
+		}
+	}
+	return out
+}
+
+func hostSearchHref(org, clusterID string, attrs map[string]string) string {
+	params := url.Values{}
+	params.Set("cluster", clusterID)
+	if attrs["instance"] != "" {
+		params.Set("hostIP", attrs["instance"])
+	}
+	if attrs["job"] != "" {
+		params.Set("job", attrs["job"])
+	}
+	if attrs["host_name"] != "" {
+		params.Set("host_name", attrs["host_name"])
+	}
+	return orgPrefixedSearch(org, "hosts/"+url.PathEscape(attrs["host_id"]), params)
+}
+
+func nodeSearchHref(org, clusterID, cluster, node string) string {
+	params := url.Values{}
+	params.Set("cluster", clusterID)
+	if cluster != "" {
+		params.Set("clusterName", cluster)
+	}
+	return orgPrefixedSearch(org, "k8s/nodes/"+url.PathEscape(node), params)
+}
+
+func clusterSearchHref(org, clusterID, cluster string) string {
+	params := url.Values{}
+	params.Set("cluster", clusterID)
+	if cluster != "" {
+		params.Set("clusterName", cluster)
+	}
+	return orgPrefixedSearch(org, "k8s", params)
+}
+
+func podSearchHref(org, clusterID string, attrs map[string]string) string {
+	params := url.Values{}
+	params.Set("cluster", clusterID)
+	if attrs["cluster"] != "" {
+		params.Set("clusterName", attrs["cluster"])
+	}
+	if attrs["namespace"] != "" {
+		params.Set("namespace", attrs["namespace"])
+	}
+	if attrs["pod"] != "" {
+		params.Set("pod", attrs["pod"])
+	}
+	return orgPrefixedSearch(org, "k8s/pod-details", params)
+}
+
+func orgPrefixedSearch(org, child string, params url.Values) string {
+	if org == "" {
+		return ""
+	}
+	path := "/v2/organizations/" + org + "/" + strings.TrimPrefix(child, "/")
+	encoded := params.Encode()
+	if encoded == "" {
+		return path
+	}
+	return path + "?" + encoded
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/infrastructure/search_entities.go
+++ b/internal/infrastructure/search_entities.go
@@ -40,13 +40,13 @@ func entityFromMetric(entityType, clusterID, org string, metric map[string]strin
 }
 
 func hostSearchEntity(clusterID, org string, metric map[string]string) (searchEntity, bool) {
-	hostID := firstNonEmpty(metric["instance_id"], metric["nodename"], metric["instance_name"], metric["instance"])
+	hostID := firstNonEmpty(metric["instance_id"], metric["nodename"], metric["instance_name"], metric["instance"], metric["host_name"])
 	if hostID == "" {
 		return searchEntity{}, false
 	}
 	attrs := omitEmptyAttrs(map[string]string{
 		"host_id":   hostID,
-		"host_name": firstNonEmpty(metric["nodename"], metric["instance_name"], hostID),
+		"host_name": firstNonEmpty(metric["host_name"], metric["nodename"], metric["instance_name"], hostID),
 		"instance":  metric["instance"],
 		"job":       metric["job"],
 	})

--- a/internal/infrastructure/search_query.go
+++ b/internal/infrastructure/search_query.go
@@ -1,0 +1,88 @@
+package infrastructure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"last9-mcp/internal/utils"
+)
+
+type instantPoint struct {
+	Metric map[string]string `json:"metric"`
+}
+
+func fetchSearchMetrics(ctx context.Context, q searchQuery, ts int64) ([]map[string]string, bool, error) {
+	promql := searchPromQL(q.args.EntityType, q.args.Query)
+	resp, err := utils.MakePromInstantAPIQuery(ctx, q.client, promql, ts, q.cfg)
+	if err != nil {
+		return nil, false, fmt.Errorf("infrastructure search query failed: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAPISuccessBodyBytes+1))
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to read search response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, false, fmt.Errorf("infrastructure search returned status %d: %s", resp.StatusCode, truncateAPIError(body, resp.StatusCode))
+	}
+	if int64(len(body)) > maxAPISuccessBodyBytes {
+		return nil, false, fmt.Errorf("infrastructure search response exceeds %d bytes", maxAPISuccessBodyBytes)
+	}
+	return parseInstantMetrics(body)
+}
+
+func parseInstantMetrics(body []byte) ([]map[string]string, bool, error) {
+	var points []instantPoint
+	if err := json.Unmarshal(body, &points); err != nil {
+		return nil, false, fmt.Errorf("failed to parse search response: %w", err)
+	}
+	truncated := len(points) > maxSearchFetch
+	if truncated {
+		points = points[:maxSearchFetch]
+	}
+	out := make([]map[string]string, 0, len(points))
+	for _, point := range points {
+		if len(point.Metric) == 0 {
+			continue
+		}
+		out = append(out, point.Metric)
+	}
+	return out, truncated, nil
+}
+
+func searchPromQL(entityType, query string) string {
+	switch entityType {
+	case "host":
+		return wrapMetric(`{__name__=~"node_uname_info|system_uname_info"}`, optionalRegexMatcher("nodename", query))
+	case "k8s_cluster":
+		return wrapMetric("kube_node_info", optionalRegexMatcher("cluster", query))
+	case "k8s_node":
+		return wrapMetric("kube_node_info", optionalRegexMatcher("node", query))
+	default:
+		return wrapMetric("kube_pod_info", optionalRegexMatcher("pod", query))
+	}
+}
+
+func wrapMetric(metric, matcher string) string {
+	if matcher == "" {
+		return metric
+	}
+	if strings.HasPrefix(metric, "{") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(metric, "{"), "}")
+		return "{" + inner + "," + matcher + "}"
+	}
+	return metric + "{" + matcher + "}"
+}
+
+func optionalRegexMatcher(label, query string) string {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return ""
+	}
+	return fmt.Sprintf(`%s=~".*%s.*"`, label, regexp.QuoteMeta(q))
+}

--- a/internal/infrastructure/search_query.go
+++ b/internal/infrastructure/search_query.go
@@ -12,26 +12,31 @@ import (
 	"last9-mcp/internal/utils"
 )
 
+const maxSearchBodyBytes = 4 * 1024 * 1024
+
 type instantPoint struct {
 	Metric map[string]string `json:"metric"`
 }
 
 func fetchSearchMetrics(ctx context.Context, q searchQuery, ts int64) ([]map[string]string, bool, error) {
-	promql := searchPromQL(q.args.EntityType, q.args.Query)
+	promql, err := searchPromQL(q.args.EntityType, q.args.Query)
+	if err != nil {
+		return nil, false, err
+	}
 	resp, err := utils.MakePromInstantAPIQuery(ctx, q.client, promql, ts, q.cfg)
 	if err != nil {
 		return nil, false, fmt.Errorf("infrastructure search query failed: %w", err)
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAPISuccessBodyBytes+1))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSearchBodyBytes+1))
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to read search response: %w", err)
 	}
 	if resp.StatusCode >= http.StatusBadRequest {
 		return nil, false, fmt.Errorf("infrastructure search returned status %d: %s", resp.StatusCode, truncateAPIError(body, resp.StatusCode))
 	}
-	if int64(len(body)) > maxAPISuccessBodyBytes {
-		return nil, false, fmt.Errorf("infrastructure search response exceeds %d bytes", maxAPISuccessBodyBytes)
+	if int64(len(body)) > maxSearchBodyBytes {
+		return nil, false, fmt.Errorf("infrastructure search response exceeds %d bytes", maxSearchBodyBytes)
 	}
 	return parseInstantMetrics(body)
 }
@@ -55,17 +60,53 @@ func parseInstantMetrics(body []byte) ([]map[string]string, bool, error) {
 	return out, truncated, nil
 }
 
-func searchPromQL(entityType, query string) string {
+func searchPromQL(entityType, query string) (string, error) {
+	matcher, err := searchMatcher(entityType, query)
+	if err != nil {
+		return "", err
+	}
+	inner := wrapMetric(searchMetric(entityType), matcher)
+	return "count by (" + searchByLabels(entityType) + ") (" + inner + ")", nil
+}
+
+func searchMetric(entityType string) string {
 	switch entityType {
 	case "host":
-		return wrapMetric(`{__name__=~"node_uname_info|system_uname_info"}`, optionalRegexMatcher("nodename", query))
-	case "k8s_cluster":
-		return wrapMetric("kube_node_info", optionalRegexMatcher("cluster", query))
-	case "k8s_node":
-		return wrapMetric("kube_node_info", optionalRegexMatcher("node", query))
+		return `{__name__=~"node_uname_info|system_uname_info"}`
+	case "k8s_pod":
+		return "kube_pod_info"
 	default:
-		return wrapMetric("kube_pod_info", optionalRegexMatcher("pod", query))
+		return "kube_node_info"
 	}
+}
+
+func searchByLabels(entityType string) string {
+	switch entityType {
+	case "host":
+		return "instance_id,nodename,instance_name,instance,job,host_name"
+	case "k8s_cluster":
+		return "cluster"
+	case "k8s_node":
+		return "cluster,node"
+	default:
+		return "cluster,namespace,pod,uid,node"
+	}
+}
+
+func searchMatcher(entityType, query string) (string, error) {
+	// Host names live on several labels; Prom-side filter would miss instance_id /
+	// host_name. List all hosts and substring-filter in Go.
+	if entityType == "host" {
+		return "", nil
+	}
+	label := "node"
+	if entityType == "k8s_cluster" {
+		label = "cluster"
+	}
+	if entityType == "k8s_pod" {
+		label = "pod"
+	}
+	return optionalRegexMatcher(label, query)
 }
 
 func wrapMetric(metric, matcher string) string {
@@ -79,10 +120,23 @@ func wrapMetric(metric, matcher string) string {
 	return metric + "{" + matcher + "}"
 }
 
-func optionalRegexMatcher(label, query string) string {
+func optionalRegexMatcher(label, query string) (string, error) {
 	q := strings.TrimSpace(query)
 	if q == "" {
-		return ""
+		return "", nil
 	}
-	return fmt.Sprintf(`%s=~".*%s.*"`, label, regexp.QuoteMeta(q))
+	escaped, err := escapePromRegex(q)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`%s=~".*%s.*"`, label, escaped), nil
+}
+
+func escapePromRegex(value string) (string, error) {
+	if strings.ContainsAny(value, "\n\r}") {
+		return "", fmt.Errorf("query contains invalid characters")
+	}
+	quoted := regexp.QuoteMeta(value)
+	replacer := strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+	return replacer.Replace(quoted), nil
 }

--- a/internal/infrastructure/search_test.go
+++ b/internal/infrastructure/search_test.go
@@ -43,7 +43,7 @@ func TestSearchInfrastructureEntities_HostPage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gotQuery != `{__name__=~"node_uname_info|system_uname_info"}` {
+	if gotQuery != `count by (instance_id,nodename,instance_name,instance,job,host_name) ({__name__=~"node_uname_info|system_uname_info"})` {
 		t.Fatalf("promql %q", gotQuery)
 	}
 	if payload["read_url"] != "https://prom.example/read" {
@@ -85,7 +85,7 @@ func TestSearchInfrastructureEntities_FiltersAndEscapesQuery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gotQuery != `kube_node_info{node=~".*web.*"}` {
+	if gotQuery != `count by (cluster,node) (kube_node_info{node=~".*web.*"})` {
 		t.Fatalf("promql %q", gotQuery)
 	}
 	page := decodeSearchPage(t, result)
@@ -95,10 +95,26 @@ func TestSearchInfrastructureEntities_FiltersAndEscapesQuery(t *testing.T) {
 }
 
 func TestSearchPromQL_EscapesRegexMetacharacters(t *testing.T) {
-	got := searchPromQL("k8s_node", "web.01")
-	want := `kube_node_info{node=~".*web\.01.*"}`
+	got, err := searchPromQL("k8s_node", "web.01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `count by (cluster,node) (kube_node_info{node=~".*web\\.01.*"})`
 	if got != want {
 		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestSearchPromQL_RejectsQueryBreakout(t *testing.T) {
+	if _, err := searchPromQL("k8s_node", `foo"}`); err == nil {
+		t.Fatal("expected invalid query")
+	}
+}
+
+func TestHostSearchEntity_UsesHostNameFallback(t *testing.T) {
+	ent, ok := hostSearchEntity("cid", "org", map[string]string{"host_name": "otel-web"})
+	if !ok || ent.Attributes["host_id"] != "otel-web" {
+		t.Fatalf("got %+v ok=%v", ent, ok)
 	}
 }
 

--- a/internal/infrastructure/search_test.go
+++ b/internal/infrastructure/search_test.go
@@ -1,0 +1,204 @@
+package infrastructure
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"last9-mcp/internal/constants"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestSearchInfrastructureEntities_HostPage(t *testing.T) {
+	var gotQuery string
+	var payload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != constants.EndpointPromQueryInstant {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &payload)
+		gotQuery, _ = payload["query"].(string)
+		_ = json.NewEncoder(w).Encode([]instantPoint{
+			{Metric: map[string]string{"nodename": "ip-10-0-1-2", "instance": "10.0.1.2:9100", "job": "node"}},
+			{Metric: map[string]string{"nodename": "ip-10-0-1-3", "instance": "10.0.1.3:9100"}},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := testResolveConfig(srv.URL)
+	cfg.PrometheusReadURL = "https://prom.example/read"
+	handler := NewSearchInfrastructureEntitiesHandler(srv.Client(), cfg)
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchInfrastructureEntitiesArgs{
+		EntityType: "host",
+		Limit:      1,
+		Timestamp:  1700000000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotQuery != `{__name__=~"node_uname_info|system_uname_info"}` {
+		t.Fatalf("promql %q", gotQuery)
+	}
+	if payload["read_url"] != "https://prom.example/read" {
+		t.Fatalf("read_url %+v", payload)
+	}
+	page := decodeSearchPage(t, result)
+	if len(page.Entities) != 1 || page.NextCursor != "1" {
+		t.Fatalf("page %+v", page)
+	}
+	if page.Entities[0].Type != "host" || page.Entities[0].Attributes["host_id"] != "ip-10-0-1-2" {
+		t.Fatalf("entity %+v", page.Entities[0])
+	}
+	if !strings.Contains(page.Entities[0].UI.Href, "/hosts/ip-10-0-1-2") {
+		t.Fatalf("href %q", page.Entities[0].UI.Href)
+	}
+}
+
+func TestSearchInfrastructureEntities_FiltersAndEscapesQuery(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		gotQuery, _ = payload["query"].(string)
+		_ = json.NewEncoder(w).Encode([]instantPoint{
+			{Metric: map[string]string{"cluster": "prod", "node": "web-01"}},
+			{Metric: map[string]string{"cluster": "prod", "node": "db-01"}},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := testResolveConfig(srv.URL)
+	cfg.PrometheusReadURL = "https://prom.example/read"
+	handler := NewSearchInfrastructureEntitiesHandler(srv.Client(), cfg)
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchInfrastructureEntitiesArgs{
+		EntityType: "k8s_node",
+		Query:      "web",
+		Timestamp:  1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotQuery != `kube_node_info{node=~".*web.*"}` {
+		t.Fatalf("promql %q", gotQuery)
+	}
+	page := decodeSearchPage(t, result)
+	if len(page.Entities) != 1 || page.Entities[0].Attributes["node"] != "web-01" {
+		t.Fatalf("page %+v", page)
+	}
+}
+
+func TestSearchPromQL_EscapesRegexMetacharacters(t *testing.T) {
+	got := searchPromQL("k8s_node", "web.01")
+	want := `kube_node_info{node=~".*web\.01.*"}`
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestSearchInfrastructureEntities_DedupesClusters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]instantPoint{
+			{Metric: map[string]string{"cluster": "prod", "node": "a"}},
+			{Metric: map[string]string{"cluster": "prod", "node": "b"}},
+			{Metric: map[string]string{"cluster": "stage", "node": "c"}},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := testResolveConfig(srv.URL)
+	cfg.PrometheusReadURL = "https://prom.example/read"
+	handler := NewSearchInfrastructureEntitiesHandler(srv.Client(), cfg)
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchInfrastructureEntitiesArgs{
+		EntityType: "k8s_cluster",
+		Timestamp:  1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	page := decodeSearchPage(t, result)
+	if len(page.Entities) != 2 {
+		t.Fatalf("want 2 clusters, got %+v", page.Entities)
+	}
+}
+
+func TestSearchInfrastructureEntities_PodAttributes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]instantPoint{
+			{Metric: map[string]string{"cluster": "prod", "namespace": "default", "pod": "api-1", "uid": "uid-1", "node": "n1"}},
+		})
+	}))
+	defer srv.Close()
+
+	cfg := testResolveConfig(srv.URL)
+	cfg.PrometheusReadURL = "https://prom.example/read"
+	handler := NewSearchInfrastructureEntitiesHandler(srv.Client(), cfg)
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchInfrastructureEntitiesArgs{
+		EntityType: "k8s_pod",
+		Timestamp:  1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	page := decodeSearchPage(t, result)
+	if len(page.Entities) != 1 {
+		t.Fatalf("page %+v", page)
+	}
+	ent := page.Entities[0]
+	if ent.ID != "k8s-pod:cluster-uuid:prod:default:uid-1" {
+		t.Fatalf("id %q", ent.ID)
+	}
+	if ent.Attributes["namespace"] != "default" || ent.Attributes["pod"] != "api-1" {
+		t.Fatalf("attrs %+v", ent.Attributes)
+	}
+}
+
+func TestSearchInfrastructureEntities_RejectsUnknownType(t *testing.T) {
+	handler := NewSearchInfrastructureEntitiesHandler(http.DefaultClient, testResolveConfig("http://example.invalid"))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchInfrastructureEntitiesArgs{EntityType: "service"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported entity_type") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestSearchInfrastructureEntities_InvalidCursor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]instantPoint{})
+	}))
+	defer srv.Close()
+	cfg := testResolveConfig(srv.URL)
+	cfg.PrometheusReadURL = "https://prom.example/read"
+	handler := NewSearchInfrastructureEntitiesHandler(srv.Client(), cfg)
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchInfrastructureEntitiesArgs{
+		EntityType: "host",
+		Cursor:     "nope",
+		Timestamp:  1,
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid cursor") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestSearchInfrastructureEntities_RequiresPromURL(t *testing.T) {
+	handler := NewSearchInfrastructureEntitiesHandler(http.DefaultClient, testResolveConfig("http://example.invalid"))
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, SearchInfrastructureEntitiesArgs{EntityType: "host"})
+	if err == nil || !strings.Contains(err.Error(), "prometheus read URL") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func decodeSearchPage(t *testing.T, result *mcp.CallToolResult) searchPage {
+	t.Helper()
+	text := result.Content[0].(*mcp.TextContent).Text
+	var page searchPage
+	if err := json.Unmarshal([]byte(text), &page); err != nil {
+		t.Fatalf("decode %q: %v", text, err)
+	}
+	return page
+}

--- a/internal/prompts/descriptions/did_you_mean.md
+++ b/internal/prompts/descriptions/did_you_mean.md
@@ -5,7 +5,7 @@ when the user types something that looks like a typo, abbreviation, or partial n
 
 Returns up to 3 closest matches with similarity scores (0–100%) from the Last9 catalog,
 covering all entity types: services, environments, hosts, databases, k8s deployments,
-k8s namespaces, jobs, and more.
+k8s namespaces, k8s nodes, jobs, and more.
 
 When to use:
 - Before calling get_service_logs, get_service_traces, get_service_performance_details, etc.
@@ -16,7 +16,7 @@ When to use:
 Parameters:
 - query: (Required) The name to search for — can be a partial name, misspelling, or abbreviation
 - type: (Optional) Restrict suggestions to a specific entity type (e.g. "service", "environment",
-  "host", "k8s_deployment", "k8s_namespace", "database", "job")
+  "host", "k8s_deployment", "k8s_namespace", "k8s_node", "database", "job")
 
 Examples:
 - query="paymnt-svc"  → "payment-service (92%, service)"

--- a/internal/prompts/descriptions/get_infrastructure_context.md
+++ b/internal/prompts/descriptions/get_infrastructure_context.md
@@ -20,5 +20,5 @@ Parameters:
 - cluster_id: (Optional) Levitate datasource UUID. Defaults to the configured datasource.
 - region: (Optional) AWS region header. Defaults to the configured datasource region.
 
-Do not send Prometheus credentials. Call did_you_mean with type=host or type=k8s_node
-when the name may be misspelled.
+Do not send Prometheus credentials. Call search_infrastructure_entities to find a typed
+id, or did_you_mean with type=host or type=k8s_node when the name may be misspelled.

--- a/internal/prompts/descriptions/get_infrastructure_context.md
+++ b/internal/prompts/descriptions/get_infrastructure_context.md
@@ -1,0 +1,24 @@
+Resolves one host, Kubernetes node, or Kubernetes pod to its depth-one infrastructure neighbors.
+
+Use this instead of writing PromQL that joins node_uname_info to kube_node_info.
+Returns the same identity the Last9 Host / Node / Pod UI uses: typed entity id, match
+status (matched, not_found, stale, ambiguous), observed edges (scheduled_on, member_of,
+same_machine), evidence labels, and a dashboard href.
+
+When to use:
+- A host page question needs the Kubernetes node or cluster it maps to
+- A node or pod question needs the underlying host
+- Ambiguous matches: present candidates; never pick the first silently
+
+Parameters:
+- entity_type: (Required) host, k8s_node, or k8s_pod. k8s_cluster is not valid input.
+- selectors: (Required) Identity fields for that type:
+  - host: instance, host_id, or host_name (optional job)
+  - k8s_node: cluster and node
+  - k8s_pod: cluster plus uid, or cluster plus namespace and pod
+- timestamp: (Optional) Unix seconds. Defaults to now.
+- cluster_id: (Optional) Levitate datasource UUID. Defaults to the configured datasource.
+- region: (Optional) AWS region header. Defaults to the configured datasource region.
+
+Do not send Prometheus credentials. Call did_you_mean with type=host or type=k8s_node
+when the name may be misspelled.

--- a/internal/prompts/descriptions/search_infrastructure_entities.md
+++ b/internal/prompts/descriptions/search_infrastructure_entities.md
@@ -1,0 +1,17 @@
+Lists hosts, Kubernetes clusters, nodes, or pods from live inventory.
+
+Use this to find a typed entity id before calling get_infrastructure_context.
+Does not join Host to Node — that is get_infrastructure_context. Does not require
+writing PromQL.
+
+Parameters:
+- entity_type: (Required) host, k8s_cluster, k8s_node, or k8s_pod.
+- query: (Optional) Substring filter on the entity name. Regex metacharacters are literal.
+- limit: (Optional) Page size (default 25, max 100).
+- cursor: (Optional) next_cursor from the previous page.
+- timestamp: (Optional) Unix seconds. Defaults to now.
+- cluster_id: (Optional) Levitate datasource UUID used in returned ids. Defaults to the configured datasource.
+
+Returns typed ids (host:..., k8s-node:..., k8s-cluster:..., k8s-pod:...), key attributes,
+dashboard hrefs, and next_cursor when more pages exist. Then call get_infrastructure_context
+with those selectors.

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -107,6 +107,9 @@ var GetDatabaseServerMetricsDescription string
 //go:embed descriptions/get_infrastructure_context.md
 var GetInfrastructureContextDescription string
 
+//go:embed descriptions/search_infrastructure_entities.md
+var SearchInfrastructureEntitiesDescription string
+
 //go:embed descriptions/did_you_mean.md
 var DidYouMeanDescription string
 

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -104,6 +104,9 @@ var GetDatabaseQueriesDescription string
 //go:embed descriptions/get_database_server_metrics.md
 var GetDatabaseServerMetricsDescription string
 
+//go:embed descriptions/get_infrastructure_context.md
+var GetInfrastructureContextDescription string
+
 //go:embed descriptions/did_you_mean.md
 var DidYouMeanDescription string
 

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -23,7 +23,7 @@ const (
 // DidYouMeanArgs are the input parameters for the did_you_mean tool.
 type DidYouMeanArgs struct {
 	Query string `json:"query" jsonschema:"The misspelled or uncertain entity name to find suggestions for (required)"`
-	Type  string `json:"type,omitempty" jsonschema:"Optional entity type filter: service, environment, host, database, k8s_deployment, k8s_namespace, job"`
+	Type  string `json:"type,omitempty" jsonschema:"Optional entity type filter: service, environment, host, database, k8s_deployment, k8s_namespace, k8s_node, job"`
 }
 
 type suggestionItem struct {

--- a/internal/toolsets/toolsets.go
+++ b/internal/toolsets/toolsets.go
@@ -45,6 +45,7 @@ var named = map[string][]string{
 		"get_database_queries",
 		"get_database_server_metrics",
 		"get_infrastructure_context",
+		"search_infrastructure_entities",
 	},
 	"alerts": {
 		"get_alerts",

--- a/internal/toolsets/toolsets.go
+++ b/internal/toolsets/toolsets.go
@@ -44,6 +44,7 @@ var named = map[string][]string{
 		"get_database_slow_queries",
 		"get_database_queries",
 		"get_database_server_metrics",
+		"get_infrastructure_context",
 	},
 	"alerts": {
 		"get_alerts",

--- a/internal/toolsets/toolsets_test.go
+++ b/internal/toolsets/toolsets_test.go
@@ -52,7 +52,7 @@ func TestParseInvestigate(t *testing.T) {
 	if set == nil {
 		t.Fatal("investigate must not expand to nil/all")
 	}
-	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources", "get_apm_service_deviations", "get_infrastructure_context"} {
+	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources", "get_apm_service_deviations", "get_infrastructure_context", "search_infrastructure_entities"} {
 		if !set.Allows(want) {
 			t.Errorf("investigate missing %q", want)
 		}

--- a/internal/toolsets/toolsets_test.go
+++ b/internal/toolsets/toolsets_test.go
@@ -52,7 +52,7 @@ func TestParseInvestigate(t *testing.T) {
 	if set == nil {
 		t.Fatal("investigate must not expand to nil/all")
 	}
-	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources", "get_apm_service_deviations"} {
+	for _, want := range []string{"get_logs", "get_traces", "prometheus_instant_query", "did_you_mean", "list_datasources", "get_apm_service_deviations", "get_infrastructure_context"} {
 		if !set.Allows(want) {
 			t.Errorf("investigate missing %q", want)
 		}

--- a/tools.go
+++ b/tools.go
@@ -8,6 +8,7 @@ import (
 	"last9-mcp/internal/auth"
 	"last9-mcp/internal/change_events"
 	"last9-mcp/internal/dashboards"
+	"last9-mcp/internal/infrastructure"
 	"last9-mcp/internal/models"
 	"last9-mcp/internal/prompts"
 	"last9-mcp/internal/suggest"
@@ -272,6 +273,11 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config) error 
 		Name:        "get_database_server_metrics",
 		Description: prompts.GetDatabaseServerMetricsDescription,
 	}, apm.NewGetDatabaseServerMetricsHandler(client, cfg)))
+
+	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
+		Name:        "get_infrastructure_context",
+		Description: prompts.GetInfrastructureContextDescription,
+	}, infrastructure.NewGetInfrastructureContextHandler(client, cfg)))
 
 	// Register did_you_mean tool
 	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{

--- a/tools.go
+++ b/tools.go
@@ -279,6 +279,11 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config) error 
 		Description: prompts.GetInfrastructureContextDescription,
 	}, infrastructure.NewGetInfrastructureContextHandler(client, cfg)))
 
+	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
+		Name:        "search_infrastructure_entities",
+		Description: prompts.SearchInfrastructureEntitiesDescription,
+	}, infrastructure.NewSearchInfrastructureEntitiesHandler(client, cfg)))
+
 	// Register did_you_mean tool
 	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
 		Name:        "did_you_mean",


### PR DESCRIPTION
## Summary
- Adds `get_infrastructure_context` as a thin client of `POST /v4/organizations/{org}/infrastructure/resolve` (region header, `cluster_id` from the datasource, no Prometheus credentials).
- Adds `search_infrastructure_entities` in this MCP PR only: bounded Prom inventory (`node_uname_info` / `kube_node_info` / `kube_pod_info`) with limit + cursor. Last9 stays resolve-only per the FDE-166 split.
- Registers both tools on the `metrics` toolset (and therefore `investigate`).
- Documents `k8s_node` on `did_you_mean`. Last9 suggest inventory for that type is in https://github.com/last9/last9/pull/11442.

Depends on Last9 #11442 being deployed for `get_infrastructure_context`. Search uses the existing `/prom_query_instant` path with datasource Prometheus credentials (same as `get_databases`).

Linear: https://linear.app/last9/issue/FDE-166/support-host-to-kubernetes-cluster-correlation

## Test plan
- [x] `go test ./internal/infrastructure ./internal/toolsets .`
- [x] `go run . dump-tools --toolsets=metrics` lists `get_infrastructure_context` and `search_infrastructure_entities`
- [x] `go run . dump-tools --toolsets=investigate` includes both and still excludes dashboards/alerts
- [ ] After Last9 #11442 is on a live env: resolve a spiderSilk host and confirm the MCP JSON matches Host Detail related-strip identities