### PR TITLE
fix(apm): bound get_service_performance_details query cost for wide windows

### DIFF
--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"last9-mcp/internal/deeplink"
@@ -14,6 +16,33 @@ import (
 	"last9-mcp/internal/utils"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// get_service_performance_details used to reuse the full requested
+// window as the inner PromQL range-vector selector on ~9 sub-queries
+// (e.g. rate(x[<full window>])), which makes the backend rescan the entire
+// window's raw samples per output step. That crashes/OOMs the backend for
+// windows wider than ~1-2 weeks. Confirmed via direct backend testing:
+//   - a fixed 5m inner selector is safe at any outer width up to 35 days.
+//   - the backend hard-caps a single query's outer range at 35 days (HTTP
+//     422 "Too many samples queried" just past that).
+//   - splitting a wider outer window into <=35-day chunks and querying each
+//     with the 5m inner selector works cleanly.
+const (
+	// maxServicePerformanceWindowDays is NOT a data-retention cutoff — a
+	// chunk entirely outside retention just comes back empty from the
+	// backend, which chunking already handles fine. This is purely a
+	// call-count/latency guard: each chunk costs up to ~9 backend calls, so
+	// this bounds how many chunks (and how long) a single tool call can take.
+	maxServicePerformanceWindowDays = 366
+	// perfDetailsMaxChunkDays is the backend's confirmed hard per-query range
+	// cap. Windows wider than this are split into consecutive chunks of at
+	// most this many days.
+	perfDetailsMaxChunkDays = 35
+	// perfDetailsStepWindow is the fixed inner range-vector selector duration
+	// used for rate()/step-based sub-queries, replacing the old (and unsafe)
+	// "reuse the whole requested window" behavior.
+	perfDetailsStepWindow = "5m"
 )
 
 // firstNonEmpty returns the first non-empty string, enabling canonical-wins
@@ -238,6 +267,184 @@ type ServicePerformanceDetails struct {
 	PartialErrors []string           `json:"partial_errors,omitempty"`
 }
 
+type perfDetailsChunk struct {
+	start int64
+	end   int64
+}
+
+// splitIntoPerfDetailsChunks splits [start, end) into consecutive chunks of
+// at most perfDetailsMaxChunkDays each. Chunk boundaries are inclusive on
+// both ends (chunk N's end equals chunk N+1's start), matching how the
+// range-query results at those boundaries overlap.
+func splitIntoPerfDetailsChunks(start, end int64) []perfDetailsChunk {
+	const maxChunkSeconds = int64(perfDetailsMaxChunkDays) * 24 * 3600
+	if end-start <= maxChunkSeconds {
+		return []perfDetailsChunk{{start: start, end: end}}
+	}
+	var chunks []perfDetailsChunk
+	cur := start
+	for cur < end {
+		chunkEnd := cur + maxChunkSeconds
+		if chunkEnd > end {
+			chunkEnd = end
+		}
+		chunks = append(chunks, perfDetailsChunk{start: cur, end: chunkEnd})
+		cur = chunkEnd
+	}
+	return chunks
+}
+
+func chunkBoundsLabel(c perfDetailsChunk) string {
+	return fmt.Sprintf("chunk %s..%s",
+		time.Unix(c.start, 0).UTC().Format(time.RFC3339),
+		time.Unix(c.end, 0).UTC().Format(time.RFC3339))
+}
+
+// seriesLabelKey builds a stable, order-independent key for a metric label
+// set so series from different chunks can be matched by label content
+// rather than by their position in each chunk's response array.
+func seriesLabelKey(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(m[k])
+		b.WriteByte(';')
+	}
+	return b.String()
+}
+
+// mergeChunkedSeries stitches per-chunk TimeSeries results (in chunk order)
+// into one series per unique label set, dropping the duplicate point shared
+// at each chunk boundary (chunk N's last timestamp == chunk N+1's first). A
+// label set need not appear in every chunk.
+func mergeChunkedSeries(chunkResults [][]TimeSeries) []TimeSeries {
+	merged := map[string]*TimeSeries{}
+	var order []string
+	for _, chunkSeries := range chunkResults {
+		for _, s := range chunkSeries {
+			key := seriesLabelKey(s.Metric)
+			existing, ok := merged[key]
+			if !ok {
+				cp := TimeSeries{Metric: s.Metric, Values: append([]TimeSeriesPoint{}, s.Values...)}
+				merged[key] = &cp
+				order = append(order, key)
+				continue
+			}
+			vals := s.Values
+			if len(existing.Values) > 0 && len(vals) > 0 &&
+				existing.Values[len(existing.Values)-1].Timestamp == vals[0].Timestamp {
+				vals = vals[1:]
+			}
+			existing.Values = append(existing.Values, vals...)
+		}
+	}
+	result := make([]TimeSeries, 0, len(order))
+	for _, key := range order {
+		result = append(result, *merged[key])
+	}
+	return result
+}
+
+// fetchChunkedRangeSeries runs a range-vector query once per chunk (via
+// buildQuery) and merges the results with mergeChunkedSeries. A chunk that
+// returns a non-2xx status is recorded in partialErrors (with its time
+// bounds) and skipped, so the rest keep merging; a transport-level error
+// aborts the whole call, matching the pre-chunking behavior.
+func fetchChunkedRangeSeries(ctx context.Context, client *http.Client, cfg models.Config, chunks []perfDetailsChunk, buildQuery func(perfDetailsChunk) string, label string, partialErrors *[]string) ([]TimeSeries, error) {
+	var chunkResults [][]TimeSeries
+	for _, c := range chunks {
+		httpResp, err := utils.MakePromRangeAPIQuery(ctx, client, buildQuery(c), c.start, c.end, cfg)
+		if err != nil {
+			return nil, err
+		}
+		func() {
+			defer httpResp.Body.Close()
+			if httpResp.StatusCode != http.StatusOK {
+				*partialErrors = append(*partialErrors, fmt.Sprintf("%s: %s", chunkBoundsLabel(c), promErr(httpResp, label).Error()))
+				return
+			}
+			data, err := io.ReadAll(httpResp.Body)
+			if err != nil {
+				*partialErrors = append(*partialErrors, fmt.Sprintf("%s: failed to read response body for %s: %v", chunkBoundsLabel(c), label, err))
+				return
+			}
+			seriesList, err := parsePromTimeSeries(data)
+			if err != nil {
+				*partialErrors = append(*partialErrors, fmt.Sprintf("%s: failed to parse %s: %v", chunkBoundsLabel(c), label, err))
+				return
+			}
+			chunkResults = append(chunkResults, seriesList)
+		}()
+	}
+	return mergeChunkedSeries(chunkResults), nil
+}
+
+// mergeTopFloat merges topk-style instant-query results (one single-key map
+// per operation) across chunks, keeping the max value seen per key, then
+// re-sorts descending and truncates to limit.
+func mergeTopFloat(chunkResults [][]map[string]float64, limit int) []map[string]float64 {
+	best := map[string]float64{}
+	var order []string
+	for _, items := range chunkResults {
+		for _, m := range items {
+			for k, v := range m {
+				if cur, ok := best[k]; !ok || v > cur {
+					if !ok {
+						order = append(order, k)
+					}
+					best[k] = v
+				}
+			}
+		}
+	}
+	sort.SliceStable(order, func(i, j int) bool { return best[order[i]] > best[order[j]] })
+	if len(order) > limit {
+		order = order[:limit]
+	}
+	result := make([]map[string]float64, 0, len(order))
+	for _, k := range order {
+		result = append(result, map[string]float64{k: best[k]})
+	}
+	return result
+}
+
+// mergeTopInt64 merges topk-style instant-query results for count-style
+// metrics (sum_over_time occurrence counts, e.g. topErrQuery/topErrorsQuery)
+// across chunks. Unlike mergeTopFloat (max-merge, correct for percentile/
+// worst-case-style values like topRTQuery's p95 latency), counts must be
+// SUMMED per key across chunks — a key's total count is the sum of its
+// per-chunk counts, not the max of them. Re-sorts descending and truncates
+// to limit.
+func mergeTopInt64(chunkResults [][]map[string]int64, limit int) []map[string]int64 {
+	total := map[string]int64{}
+	var order []string
+	for _, items := range chunkResults {
+		for _, m := range items {
+			for k, v := range m {
+				if _, ok := total[k]; !ok {
+					order = append(order, k)
+				}
+				total[k] += v
+			}
+		}
+	}
+	sort.SliceStable(order, func(i, j int) bool { return total[order[i]] > total[order[j]] })
+	if len(order) > limit {
+		order = order[:limit]
+	}
+	result := make([]map[string]int64, 0, len(order))
+	for _, k := range order {
+		result = append(result, map[string]int64{k: total[k]})
+	}
+	return result
+}
+
 func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, ServicePerformanceDetailsArgs) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, args ServicePerformanceDetailsArgs) (*mcp.CallToolResult, any, error) {
 		startTimeParam, endTimeParam, err := resolveTimeRange(args.StartTimeISO, args.EndTimeISO, args.LookbackMinutes)
@@ -257,7 +464,16 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 			return nil, nil, fmt.Errorf("service_name is required")
 		}
 
-		timeRange := fmt.Sprintf("%dm", int((endTimeParam-startTimeParam)/60))
+		windowSeconds := endTimeParam - startTimeParam
+		if windowSeconds > int64(maxServicePerformanceWindowDays)*24*3600 {
+			return nil, nil, fmt.Errorf(
+				"time range too wide for get_service_performance_details: got %d days, max is %d days (this call fans out to multiple sub-queries per %d-day chunk; this bound limits call count/latency, not data availability)",
+				windowSeconds/(24*3600), maxServicePerformanceWindowDays, perfDetailsMaxChunkDays,
+			)
+		}
+
+		chunks := splitIntoPerfDetailsChunks(startTimeParam, endTimeParam)
+		multiChunk := len(chunks) > 1
 
 		details := ServicePerformanceDetails{
 			ServiceName: serviceName,
@@ -265,271 +481,236 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		}
 
 		// Get Apdex Score over time range as a vector
-		apdexQuery := fmt.Sprintf(
-			"sum(trace_service_apdex_score{service_name='%s', env=~'%s'})",
-			serviceName, env,
-		)
-		httpResp, err := utils.MakePromRangeAPIQuery(ctx, client, apdexQuery, startTimeParam, endTimeParam, cfg)
+		details.ApdexScore, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
+			return fmt.Sprintf(
+				"sum(trace_service_apdex_score{service_name='%s', env=~'%s'})",
+				serviceName, env,
+			)
+		}, "service performance details apdex", &details.PartialErrors)
 		if err != nil {
 			return nil, nil, err
-		}
-		defer httpResp.Body.Close()
-
-		if httpResp.StatusCode != http.StatusOK {
-			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details apdex").Error())
-		} else {
-			data, err := io.ReadAll(httpResp.Body)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
-			}
-			seriesList, err := parsePromTimeSeries(data)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to parse apdex score: %w", err)
-			}
-			details.ApdexScore = seriesList
 		}
 
 		// Get Response Times - keep vector output
-		rtQuery := fmt.Sprintf(
-			"sum by (quantile) (trace_service_response_time{service_name='%s', env='%s'}[%s])",
-			serviceName, env, timeRange,
-		)
-		httpResp, err = utils.MakePromRangeAPIQuery(ctx, client, rtQuery, startTimeParam, endTimeParam, cfg)
+		details.ResponseTimes, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
+			return fmt.Sprintf(
+				"sum by (quantile) (trace_service_response_time{service_name='%s', env='%s'}[%s])",
+				serviceName, env, perfDetailsStepWindow,
+			)
+		}, "service performance details response_times", &details.PartialErrors)
 		if err != nil {
 			return nil, nil, err
-		}
-		defer httpResp.Body.Close()
-
-		if httpResp.StatusCode != http.StatusOK {
-			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details response_times").Error())
-		} else {
-			data, err := io.ReadAll(httpResp.Body)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
-			}
-			seriesList, err := parsePromTimeSeries(data)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to parse response times: %w", err)
-			}
-			details.ResponseTimes = seriesList
 		}
 
 		// Get Availability over time range as a vector
-		availQuery := fmt.Sprintf(
-			"(1 - (sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[%s])) or 0) / (sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[%s])) + 0.0000001)) * 100 default -999",
-			serviceName, env, timeRange, serviceName, env, timeRange,
-		)
-		httpResp, err = utils.MakePromRangeAPIQuery(ctx, client, availQuery, startTimeParam, endTimeParam, cfg)
+		details.Availability, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
+			return fmt.Sprintf(
+				"(1 - (sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[%s])) or 0) / (sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[%s])) + 0.0000001)) * 100 default -999",
+				serviceName, env, perfDetailsStepWindow, serviceName, env, perfDetailsStepWindow,
+			)
+		}, "service performance details availability", &details.PartialErrors)
 		if err != nil {
 			return nil, nil, err
-		}
-		defer httpResp.Body.Close()
-
-		if httpResp.StatusCode != http.StatusOK {
-			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details availability").Error())
-		} else {
-			data, err := io.ReadAll(httpResp.Body)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
-			}
-			availabilitySeries, err := parsePromTimeSeries(data)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to parse availability response: %w", err)
-			}
-			details.Availability = availabilitySeries
 		}
 
 		// Get Throughput by status code - keep vector output
-		throughputQuery := fmt.Sprintf(
-			"sum by (http_status_code)(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[%s])) * 60 default 0",
-			serviceName, env, timeRange,
-		)
-		httpResp, err = utils.MakePromRangeAPIQuery(ctx, client, throughputQuery, startTimeParam, endTimeParam, cfg)
+		details.Throughput, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
+			return fmt.Sprintf(
+				"sum by (http_status_code)(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[%s])) * 60 default 0",
+				serviceName, env, perfDetailsStepWindow,
+			)
+		}, "service performance details throughput", &details.PartialErrors)
 		if err != nil {
 			return nil, nil, err
-		}
-		defer httpResp.Body.Close()
-
-		if httpResp.StatusCode != http.StatusOK {
-			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details throughput").Error())
-		} else {
-			// read response body to byte array
-			data, err := io.ReadAll(httpResp.Body)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
-			}
-			details.Throughput, err = parsePromTimeSeries(data)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to parse throughput response: %w", err)
-			}
-
 		}
 
 		// Get Error Rate by status code - keep vector output
-		errorRateQuery := fmt.Sprintf(
-			"sum by (service_name, http_status_code)(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[%s])) * 60 default 0",
-			serviceName, env, timeRange,
-		)
-		httpResp, err = utils.MakePromRangeAPIQuery(ctx, client, errorRateQuery, startTimeParam, endTimeParam, cfg)
+		details.ErrorRate, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
+			return fmt.Sprintf(
+				"sum by (service_name, http_status_code)(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[%s])) * 60 default 0",
+				serviceName, env, perfDetailsStepWindow,
+			)
+		}, "service performance details error_rate", &details.PartialErrors)
 		if err != nil {
 			return nil, nil, err
-		}
-		defer httpResp.Body.Close()
-
-		if httpResp.StatusCode != http.StatusOK {
-			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details error_rate").Error())
-		} else {
-			data, err := io.ReadAll(httpResp.Body)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
-			}
-			details.ErrorRate, err = parsePromTimeSeries(data)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to parse error rate response: %w", err)
-			}
 		}
 
 		// Calculate Error Percentage over time range as a vector
-		errorPercentQuery := fmt.Sprintf(
-			"(sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[%s])) / sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[%s])) * 100) default 0",
-			serviceName, env, timeRange, serviceName, env, timeRange,
-		)
-		httpResp, err = utils.MakePromRangeAPIQuery(ctx, client, errorPercentQuery, startTimeParam, endTimeParam, cfg)
+		details.ErrorPercent, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
+			return fmt.Sprintf(
+				"(sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[%s])) / sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[%s])) * 100) default 0",
+				serviceName, env, perfDetailsStepWindow, serviceName, env, perfDetailsStepWindow,
+			)
+		}, "service performance details error_percent", &details.PartialErrors)
 		if err != nil {
 			return nil, nil, err
 		}
-		defer httpResp.Body.Close()
 
-		if httpResp.StatusCode != http.StatusOK {
-			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details error_percent").Error())
-		} else {
-			data, err := io.ReadAll(httpResp.Body)
+		// Get Top Operations by Response Time - keep vector output. These are
+		// instant queries whose only windowing mechanism is the inner
+		// quantile_over_time([...]) selector, so (unlike the rate() queries
+		// above) it must stay at the chunk's own width, not perfDetailsStepWindow.
+		topRTLimit := 10
+		if multiChunk {
+			topRTLimit = 20 // over-fetch per chunk so the cross-chunk merge still has 10 real candidates
+		}
+		var topRTChunks [][]map[string]float64
+		for _, c := range chunks {
+			chunkWindow := fmt.Sprintf("%dm", int((c.end-c.start)/60))
+			topRTQuery := fmt.Sprintf(
+				"topk(%d, quantile_over_time(0.95, sum by (span_name, messaging_system, rpc_system, span_kind,net_peer_name,process_runtime_name,db_system)(trace_endpoint_duration{service_name='%s', span_kind!='SPAN_KIND_INTERNAL', env='%s', quantile='p95'}[%s])))",
+				topRTLimit, serviceName, env, chunkWindow,
+			)
+			httpResp, err := utils.MakePromInstantAPIQuery(ctx, client, topRTQuery, c.end, cfg)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+				return nil, nil, err
 			}
-			details.ErrorPercent, err = parsePromTimeSeries(data)
+			func() {
+				defer httpResp.Body.Close()
+
+				if httpResp.StatusCode != http.StatusOK {
+					details.PartialErrors = append(details.PartialErrors, fmt.Sprintf("%s: %s", chunkBoundsLabel(c), promErr(httpResp, "service performance details top_operations_by_response_time").Error()))
+				} else {
+					var topRTResp apiPromInstantResp
+					if err := json.NewDecoder(httpResp.Body).Decode(&topRTResp); err == nil {
+						items := make([]map[string]float64, 0, len(topRTResp))
+						for _, r := range topRTResp {
+							// join values of r.Timeseries with a - to create a unique key
+							key := fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s",
+								r.Metric["span_name"],
+								r.Metric["span_kind"],
+								r.Metric["net_peer_name"],
+								r.Metric["db_system"],
+								r.Metric["rpc_system"],
+								r.Metric["messaging_system"],
+								r.Metric["process_runtime_name"],
+							)
+							if valStr, ok := r.Value[1].(string); ok {
+								val, _ := strconv.ParseFloat(valStr, 64)
+								items = append(items, map[string]float64{key: val})
+							}
+						}
+						topRTChunks = append(topRTChunks, items)
+					}
+				}
+			}()
+		}
+		if multiChunk {
+			if len(topRTChunks) > 0 {
+				details.TopOperations.ByResponseTime = mergeTopFloat(topRTChunks, 10)
+			}
+		} else if len(topRTChunks) > 0 {
+			details.TopOperations.ByResponseTime = topRTChunks[0]
+		}
+
+		// Get Top Operations by Error Rate - keep vector output. Unlike
+		// topRTQuery, this query is not wrapped in topk() (it already
+		// returns every matching series unbounded), so there's no
+		// over-fetch limit to widen per chunk here; only the final merge
+		// across chunks truncates to the top 10.
+		var topErrChunks [][]map[string]int64
+		for _, c := range chunks {
+			chunkWindow := fmt.Sprintf("%dm", int((c.end-c.start)/60))
+			topErrQuery := fmt.Sprintf(
+				`sum by (span_name, span_kind, net_peer_name, db_system, rpc_system, messaging_system, process_runtime_name, exception_type)(sum_over_time(trace_client_count{service_name="%s", env='%s', exception_type!=''}[%s])) or
+				 sum by (span_name, span_kind, net_peer_name, db_system, rpc_system, messaging_system, process_runtime_name, exception_type)(sum_over_time(trace_endpoint_count{service_name="%s", env='%s', exception_type!=''}[%s])) or
+				 sum by (span_name, span_kind, net_peer_name, db_system, rpc_system, messaging_system, process_runtime_name, http_status_code)(sum_over_time(trace_client_count{service_name="%s", env='%s', http_status_code=~"^[45].*"}[%s])) or
+				 sum by (span_name, span_kind, net_peer_name, db_system, rpc_system, messaging_system, process_runtime_name, http_status_code)(sum_over_time(trace_endpoint_count{service_name="%s", env='%s', http_status_code=~"^[45].*"}[%s]))`,
+				serviceName, env, chunkWindow, serviceName, env, chunkWindow, serviceName, env, chunkWindow, serviceName, env, chunkWindow,
+			)
+			httpResp, err := utils.MakePromInstantAPIQuery(ctx, client, topErrQuery, c.end, cfg)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to parse error percent response: %w", err)
+				return nil, nil, err
 			}
-		}
+			func() {
+				defer httpResp.Body.Close()
 
-		// Get Top 10 Operations by Response Time - keep vector output
-		topRTQuery := fmt.Sprintf(
-			"topk(10, quantile_over_time(0.95, sum by (span_name, messaging_system, rpc_system, span_kind,net_peer_name,process_runtime_name,db_system)(trace_endpoint_duration{service_name='%s', span_kind!='SPAN_KIND_INTERNAL', env='%s', quantile='p95'}[%s])))",
-			serviceName, env, timeRange,
-		)
-		httpResp, err = utils.MakePromInstantAPIQuery(ctx, client, topRTQuery, endTimeParam, cfg)
-		if err != nil {
-			return nil, nil, err
-		}
-		defer httpResp.Body.Close()
-
-		if httpResp.StatusCode != http.StatusOK {
-			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details top_operations_by_response_time").Error())
-		} else {
-			var topErrResp apiPromInstantResp
-			if err := json.NewDecoder(httpResp.Body).Decode(&topErrResp); err == nil {
-				details.TopOperations.ByResponseTime = make([]map[string]float64, 0)
-				for _, r := range topErrResp {
-					// join values of r.Timeseries with a - to create a unique key
-					key := fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s",
-						r.Metric["span_name"],
-						r.Metric["span_kind"],
-						r.Metric["net_peer_name"],
-						r.Metric["db_system"],
-						r.Metric["rpc_system"],
-						r.Metric["messaging_system"],
-						r.Metric["process_runtime_name"],
-					)
-					if valStr, ok := r.Value[1].(string); ok {
-						val, _ := strconv.ParseFloat(valStr, 64)
-						op := make(map[string]float64)
-						op[key] = val
-						details.TopOperations.ByResponseTime = append(details.TopOperations.ByResponseTime, op)
+				if httpResp.StatusCode != http.StatusOK {
+					details.PartialErrors = append(details.PartialErrors, fmt.Sprintf("%s: %s", chunkBoundsLabel(c), promErr(httpResp, "service performance details top_operations_by_error_rate").Error()))
+				} else {
+					var topErrResp apiPromInstantResp
+					if err := json.NewDecoder(httpResp.Body).Decode(&topErrResp); err == nil {
+						items := make([]map[string]int64, 0, len(topErrResp))
+						for _, r := range topErrResp {
+							// join values of r.Timeseries with a - to create a unique key
+							key := fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s",
+								r.Metric["span_name"],
+								r.Metric["span_kind"],
+								r.Metric["net_peer_name"],
+								r.Metric["db_system"],
+								r.Metric["rpc_system"],
+								r.Metric["messaging_system"],
+								r.Metric["process_runtime_name"],
+							)
+							if valStr, ok := r.Value[1].(string); ok {
+								val, _ := strconv.ParseInt(valStr, 10, 64)
+								items = append(items, map[string]int64{key: val})
+							}
+						}
+						topErrChunks = append(topErrChunks, items)
 					}
 				}
+			}()
+		}
+		if multiChunk {
+			if len(topErrChunks) > 0 {
+				details.TopOperations.ByErrorRate = mergeTopInt64(topErrChunks, 10)
 			}
+		} else if len(topErrChunks) > 0 {
+			details.TopOperations.ByErrorRate = topErrChunks[0]
 		}
 
-		// Get Top 10 Operations by Error Rate - keep vector output
-		topErrQuery := fmt.Sprintf(
-			`sum by (span_name, span_kind, net_peer_name, db_system, rpc_system, messaging_system, process_runtime_name, exception_type)(sum_over_time(trace_client_count{service_name="%s", env='%s', exception_type!=''}[%s])) or
-			 sum by (span_name, span_kind, net_peer_name, db_system, rpc_system, messaging_system, process_runtime_name, exception_type)(sum_over_time(trace_endpoint_count{service_name="%s", env='%s', exception_type!=''}[%s])) or
-			 sum by (span_name, span_kind, net_peer_name, db_system, rpc_system, messaging_system, process_runtime_name, http_status_code)(sum_over_time(trace_client_count{service_name="%s", env='%s', http_status_code=~"^[45].*"}[%s])) or
-			 sum by (span_name, span_kind, net_peer_name, db_system, rpc_system, messaging_system, process_runtime_name, http_status_code)(sum_over_time(trace_endpoint_count{service_name="%s", env='%s', http_status_code=~"^[45].*"}[%s]))`,
-			serviceName, env, timeRange, serviceName, env, timeRange, serviceName, env, timeRange, serviceName, env, timeRange,
-		)
-		httpResp, err = utils.MakePromInstantAPIQuery(ctx, client, topErrQuery, endTimeParam, cfg)
-		if err != nil {
-			return nil, nil, err
-		}
-		defer httpResp.Body.Close()
-
-		if httpResp.StatusCode != http.StatusOK {
-			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details top_operations_by_error_rate").Error())
-		} else {
-			var topErrResp apiPromInstantResp
-			if err := json.NewDecoder(httpResp.Body).Decode(&topErrResp); err == nil {
-				details.TopOperations.ByErrorRate = make([]map[string]int64, 0)
-				for _, r := range topErrResp {
-					// join values of r.Timeseries with a - to create a unique key
-					key := fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s",
-						r.Metric["span_name"],
-						r.Metric["span_kind"],
-						r.Metric["net_peer_name"],
-						r.Metric["db_system"],
-						r.Metric["rpc_system"],
-						r.Metric["messaging_system"],
-						r.Metric["process_runtime_name"],
-					)
-					if valStr, ok := r.Value[1].(string); ok {
-						val, _ := strconv.ParseInt(valStr, 10, 64)
-						op := make(map[string]int64)
-						op[key] = val
-						details.TopOperations.ByErrorRate = append(details.TopOperations.ByErrorRate, op)
+		// Get Top Errors - keep vector output. Same unbounded (no topk)
+		// shape as topErrQuery above; the merge across chunks handles the
+		// top-10 truncation.
+		var topErrorsChunks [][]map[string]int64
+		for _, c := range chunks {
+			chunkWindow := fmt.Sprintf("%dm", int((c.end-c.start)/60))
+			topErrorsQuery := fmt.Sprintf(
+				`sum by (exception_type)(sum by (exception_type, span_kind)(sum_over_time(trace_client_count{service_name="%s", env='%s', exception_type!=''}[%s])) or
+				 sum by (exception_type, span_kind)(sum_over_time(trace_endpoint_count{service_name="%s", env='%s', exception_type!=''}[%s]))) or
+				 sum by (http_status_code)(sum by (http_status_code, span_kind)(sum_over_time(trace_client_count{service_name="%s", env='%s', http_status_code=~"^[45].*"}[%s])) or
+				 sum by (http_status_code, span_kind)(sum_over_time(trace_endpoint_count{service_name="%s", env='%s', http_status_code=~"^[45].*"}[%s])))`,
+				serviceName, env, chunkWindow, serviceName, env, chunkWindow, serviceName, env, chunkWindow, serviceName, env, chunkWindow,
+			)
+			httpResp, err := utils.MakePromInstantAPIQuery(ctx, client, topErrorsQuery, c.end, cfg)
+			if err != nil {
+				return nil, nil, err
+			}
+			func() {
+				defer httpResp.Body.Close()
+				if httpResp.StatusCode != http.StatusOK {
+					details.PartialErrors = append(details.PartialErrors, fmt.Sprintf("%s: %s", chunkBoundsLabel(c), promErr(httpResp, "service performance details top_errors").Error()))
+				} else {
+					var topErrorsResp apiPromInstantResp
+					if err := json.NewDecoder(httpResp.Body).Decode(&topErrorsResp); err == nil {
+						items := make([]map[string]int64, 0, len(topErrorsResp))
+						for _, r := range topErrorsResp {
+							// extract either exception_type or http_status_code as the unique key
+							var key string
+							if exceptionType, ok := r.Metric["exception_type"]; ok && exceptionType != "" {
+								key = exceptionType
+							} else if httpStatusCode, ok := r.Metric["http_status_code"]; ok && httpStatusCode != "" {
+								key = httpStatusCode
+							} else {
+								continue // skip if neither is present
+							}
+							if valStr, ok := r.Value[1].(string); ok {
+								val, _ := strconv.ParseInt(valStr, 10, 64)
+								items = append(items, map[string]int64{key: val})
+							}
+						}
+						topErrorsChunks = append(topErrorsChunks, items)
 					}
 				}
-			}
+			}()
 		}
-
-		// Get Top 10 Errors - keep vector output
-		topErrorsQuery := fmt.Sprintf(
-			`sum by (exception_type)(sum by (exception_type, span_kind)(sum_over_time(trace_client_count{service_name="%s", env='%s', exception_type!=''}[%s])) or
-			 sum by (exception_type, span_kind)(sum_over_time(trace_endpoint_count{service_name="%s", env='%s', exception_type!=''}[%s]))) or
-			 sum by (http_status_code)(sum by (http_status_code, span_kind)(sum_over_time(trace_client_count{service_name="%s", env='%s', http_status_code=~"^[45].*"}[%s])) or
-			 sum by (http_status_code, span_kind)(sum_over_time(trace_endpoint_count{service_name="%s", env='%s', http_status_code=~"^[45].*"}[%s])))`,
-			serviceName, env, timeRange, serviceName, env, timeRange, serviceName, env, timeRange, serviceName, env, timeRange,
-		)
-		httpResp, err = utils.MakePromInstantAPIQuery(ctx, client, topErrorsQuery, endTimeParam, cfg)
-		if err != nil {
-			return nil, nil, err
-		}
-		defer httpResp.Body.Close()
-		if httpResp.StatusCode != http.StatusOK {
-			details.PartialErrors = append(details.PartialErrors, promErr(httpResp, "service performance details top_errors").Error())
-		} else {
-			var topErrResp apiPromInstantResp
-			if err := json.NewDecoder(httpResp.Body).Decode(&topErrResp); err == nil {
-				details.TopErrors = make([]map[string]int64, 0)
-				for _, r := range topErrResp {
-					// join values of r.Timeseries with a - to create a unique key
-					// extract either exception_type or http_status_code
-					var key string
-					if exceptionType, ok := r.Metric["exception_type"]; ok && exceptionType != "" {
-						key = exceptionType
-					} else if httpStatusCode, ok := r.Metric["http_status_code"]; ok && httpStatusCode != "" {
-						key = httpStatusCode
-					} else {
-						continue // skip if neither is present
-					}
-					if valStr, ok := r.Value[1].(string); ok {
-						val, _ := strconv.ParseInt(valStr, 10, 64)
-						op := make(map[string]int64)
-						op[key] = val
-						details.TopErrors = append(details.TopErrors, op)
-					}
-				}
+		if multiChunk {
+			if len(topErrorsChunks) > 0 {
+				details.TopErrors = mergeTopInt64(topErrorsChunks, 10)
 			}
+		} else if len(topErrorsChunks) > 0 {
+			details.TopErrors = topErrorsChunks[0]
 		}
 
 		resultJSON, err := json.Marshal(details)

--- a/internal/apm/service_performance_details_window_test.go
+++ b/internal/apm/service_performance_details_window_test.go
@@ -1,0 +1,987 @@
+package apm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/auth"
+	"last9-mcp/internal/constants"
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func perfDetailsTestConfig(serverURL string) models.Config {
+	return models.Config{
+		APIBaseURL: serverURL,
+		Region:     "ap-south-1",
+		OrgSlug:    "test-org",
+		ClusterID:  "test-cluster",
+		TokenManager: &auth.TokenManager{
+			AccessToken: "mock-token",
+			ExpiresAt:   time.Now().Add(365 * 24 * time.Hour),
+		},
+	}
+}
+
+// --- splitIntoPerfDetailsChunks ---
+
+func TestSplitIntoPerfDetailsChunks_NoSplitUnder35Days(t *testing.T) {
+	start := int64(0)
+	end := int64(10 * 24 * 3600) // 10 days
+	chunks := splitIntoPerfDetailsChunks(start, end)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk for a 10 day window, got %d: %+v", len(chunks), chunks)
+	}
+	if chunks[0].start != start || chunks[0].end != end {
+		t.Fatalf("expected chunk to cover the full window, got %+v", chunks[0])
+	}
+}
+
+func TestSplitIntoPerfDetailsChunks_SplitsWiderWindows(t *testing.T) {
+	start := int64(0)
+	end := int64(90 * 24 * 3600) // 90 days
+	chunks := splitIntoPerfDetailsChunks(start, end)
+
+	const maxChunkSeconds = int64(perfDetailsMaxChunkDays) * 24 * 3600
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks for a 90 day window (ceil(90/35)), got %d: %+v", len(chunks), chunks)
+	}
+	for i, c := range chunks {
+		if c.end-c.start > maxChunkSeconds {
+			t.Errorf("chunk %d width %ds exceeds max %ds", i, c.end-c.start, maxChunkSeconds)
+		}
+	}
+	// Boundaries must be contiguous and inclusive-shared (chunk N's end == chunk N+1's start).
+	if chunks[0].start != start {
+		t.Errorf("first chunk should start at window start, got %d", chunks[0].start)
+	}
+	if chunks[len(chunks)-1].end != end {
+		t.Errorf("last chunk should end at window end, got %d", chunks[len(chunks)-1].end)
+	}
+	for i := 1; i < len(chunks); i++ {
+		if chunks[i-1].end != chunks[i].start {
+			t.Errorf("expected chunk %d end (%d) to equal chunk %d start (%d)", i-1, chunks[i-1].end, i, chunks[i].start)
+		}
+	}
+}
+
+// --- mergeChunkedSeries ---
+
+func TestMergeChunkedSeries_DedupsBoundaryAndHandlesPartialLabelSets(t *testing.T) {
+	chunk1 := []TimeSeries{
+		{
+			Metric: map[string]string{"http_status_code": "200"},
+			Values: []TimeSeriesPoint{{Timestamp: 100, Value: 1}, {Timestamp: 200, Value: 2}},
+		},
+	}
+	chunk2 := []TimeSeries{
+		// Shared boundary timestamp (200) with chunk1's last point - must be deduped.
+		{
+			Metric: map[string]string{"http_status_code": "200"},
+			Values: []TimeSeriesPoint{{Timestamp: 200, Value: 2}, {Timestamp: 300, Value: 3}},
+		},
+		// A label combination that only appears in chunk2.
+		{
+			Metric: map[string]string{"http_status_code": "500"},
+			Values: []TimeSeriesPoint{{Timestamp: 300, Value: 9}},
+		},
+	}
+
+	merged := mergeChunkedSeries([][]TimeSeries{chunk1, chunk2})
+
+	if len(merged) != 2 {
+		t.Fatalf("expected 2 merged series (200 and 500), got %d: %+v", len(merged), merged)
+	}
+
+	var got200, got500 *TimeSeries
+	for i := range merged {
+		switch merged[i].Metric["http_status_code"] {
+		case "200":
+			got200 = &merged[i]
+		case "500":
+			got500 = &merged[i]
+		}
+	}
+
+	if got200 == nil {
+		t.Fatal("expected a merged series for http_status_code=200")
+	}
+	wantValues := []TimeSeriesPoint{{Timestamp: 100, Value: 1}, {Timestamp: 200, Value: 2}, {Timestamp: 300, Value: 3}}
+	if !reflect.DeepEqual(got200.Values, wantValues) {
+		t.Errorf("expected deduped boundary values %+v, got %+v", wantValues, got200.Values)
+	}
+
+	if got500 == nil {
+		t.Fatal("expected label combination present only in chunk2 to still show up in the merge")
+	}
+	if len(got500.Values) != 1 || got500.Values[0].Value != 9 {
+		t.Errorf("unexpected values for the chunk2-only series: %+v", got500.Values)
+	}
+}
+
+// --- mergeTopFloat / mergeTopInt64 ---
+
+func TestMergeTopFloat_MaxPerKeySortedTruncated(t *testing.T) {
+	chunkResults := [][]map[string]float64{
+		{{"op-a": 10}, {"op-b": 5}},
+		{{"op-a": 20}, {"op-c": 30}, {"op-d": 1}},
+	}
+	got := mergeTopFloat(chunkResults, 3)
+	if len(got) != 3 {
+		t.Fatalf("expected result truncated to 3 entries, got %d: %+v", len(got), got)
+	}
+	want := []map[string]float64{{"op-c": 30}, {"op-a": 20}, {"op-b": 5}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected %+v (max per key, desc sorted, truncated), got %+v", want, got)
+	}
+}
+
+func TestMergeTopInt64_SumsPerKeySortedTruncated(t *testing.T) {
+	// Counts must be SUMMED across chunks, not maxed: an error occurring 5
+	// times in chunk 1 and 3 times in chunk 2 totals 8.
+	chunkResults := [][]map[string]int64{
+		{{"500": 5}, {"404": 100}},
+		{{"500": 3}},
+	}
+	got := mergeTopInt64(chunkResults, 10)
+	// "500": 5+3=8 summed; "404": 100 (only in one chunk). Descending by total.
+	want := []map[string]int64{{"404": 100}, {"500": 8}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected %+v, got %+v", want, got)
+	}
+}
+
+// --- handler-level behavior ---
+
+func TestServicePerformanceDetails_RejectsWindowOverMaxDays(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	now := time.Now().UTC()
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: now.Add(-400 * 24 * time.Hour).Format(time.RFC3339),
+		EndTimeISO:   now.Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err == nil {
+		t.Fatal("expected an error for a >366 day window, got nil")
+	}
+	if !strings.Contains(err.Error(), "time range too wide") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+	if rc := requestCount.Load(); rc != 0 {
+		t.Errorf("expected no HTTP calls for a rejected window, got %d", rc)
+	}
+}
+
+func TestServicePerformanceDetails_NoChunkingUnder35Days(t *testing.T) {
+	var rangeCalls, instantCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case constants.EndpointPromQuery:
+			rangeCalls.Add(1)
+		case constants.EndpointPromQueryInstant:
+			instantCalls.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	now := time.Now().UTC()
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: now.Add(-10 * 24 * time.Hour).Format(time.RFC3339),
+		EndTimeISO:   now.Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	// 1 chunk * 6 range-vector sub-queries, and 1 chunk * 3 instant sub-queries.
+	if got := rangeCalls.Load(); got != 6 {
+		t.Errorf("expected 6 range-query calls (no chunking), got %d", got)
+	}
+	if got := instantCalls.Load(); got != 3 {
+		t.Errorf("expected 3 instant-query calls (no chunking), got %d", got)
+	}
+}
+
+func TestServicePerformanceDetails_SplitsWiderWindowIntoChunks(t *testing.T) {
+	var rangeCalls, instantCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case constants.EndpointPromQuery:
+			rangeCalls.Add(1)
+		case constants.EndpointPromQueryInstant:
+			instantCalls.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	now := time.Now().UTC()
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: now.Add(-90 * 24 * time.Hour).Format(time.RFC3339),
+		EndTimeISO:   now.Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	// 90 days -> 3 chunks (35+35+20). 3 chunks * 6 range sub-queries, 3 * 3 instant sub-queries.
+	if got := rangeCalls.Load(); got != 18 {
+		t.Errorf("expected 18 range-query calls (3 chunks * 6 metrics), got %d", got)
+	}
+	if got := instantCalls.Load(); got != 9 {
+		t.Errorf("expected 9 instant-query calls (3 chunks * 3 metrics), got %d", got)
+	}
+}
+
+func TestServicePerformanceDetails_FailingChunkRecordsPartialErrorButOthersMerge(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query     string `json:"query"`
+			Timestamp int64  `json:"timestamp"`
+			Window    int64  `json:"window"`
+		}
+		_ = json.Unmarshal(body, &payload)
+
+		isApdex := strings.Contains(payload.Query, "trace_service_apdex_score")
+		firstChunkStart := payload.Timestamp - payload.Window // == chunk start for range queries
+		// The first chunk always starts at the window's absolute start; fail
+		// only the apdex sub-query for that first chunk.
+		if r.URL.Path == constants.EndpointPromQuery && isApdex && payload.Window == int64(perfDetailsMaxChunkDays)*24*3600 {
+			_ = firstChunkStart
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"boom"}`))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == constants.EndpointPromQuery {
+			resp := []map[string]any{
+				{
+					"metric": map[string]string{"quantile": "p95"},
+					"values": [][]any{{payload.Timestamp, "42"}},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	now := time.Now().UTC()
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: now.Add(-40 * 24 * time.Hour).Format(time.RFC3339), // 40 days -> 2 chunks (35d + 5d)
+		EndTimeISO:   now.Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	var details ServicePerformanceDetails
+	if err := json.Unmarshal([]byte(text), &details); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if len(details.PartialErrors) == 0 {
+		t.Fatal("expected a partial error for the failing first chunk")
+	}
+	foundChunkBounds := false
+	for _, e := range details.PartialErrors {
+		if strings.HasPrefix(e, "chunk ") {
+			foundChunkBounds = true
+		}
+	}
+	if !foundChunkBounds {
+		t.Errorf("expected a partial error message with chunk time bounds, got %+v", details.PartialErrors)
+	}
+
+	if len(details.ApdexScore) == 0 {
+		t.Fatal("expected the second (successful) chunk's apdex data to still be present despite the first chunk failing")
+	}
+}
+
+// --- gap 1: failing-chunk-still-merges-others for OTHER sub-queries ---
+
+func TestServicePerformanceDetails_FailingChunkStillMergesOthers_Throughput(t *testing.T) {
+	now := time.Now().UTC()
+	start := now.Add(-40 * 24 * time.Hour).Unix() // 40 days -> 2 chunks (35d + 5d)
+	end := now.Unix()
+	wantChunks := splitIntoPerfDetailsChunks(start, end)
+	if len(wantChunks) != 2 {
+		t.Fatalf("expected 2 chunks for a 40 day window, got %d", len(wantChunks))
+	}
+	failChunkEnd := wantChunks[0].end
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query     string `json:"query"`
+			Timestamp int64  `json:"timestamp"`
+		}
+		_ = json.Unmarshal(body, &payload)
+
+		isThroughput := strings.Contains(payload.Query, "sum by (http_status_code)(rate(")
+		if r.URL.Path == constants.EndpointPromQuery && isThroughput && payload.Timestamp == failChunkEnd {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"boom"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == constants.EndpointPromQuery && isThroughput {
+			resp := []map[string]any{
+				{"metric": map[string]string{"http_status_code": "200"}, "values": [][]any{{float64(payload.Timestamp), "5"}}},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: time.Unix(start, 0).UTC().Format(time.RFC3339),
+		EndTimeISO:   time.Unix(end, 0).UTC().Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	var details ServicePerformanceDetails
+	if err := json.Unmarshal([]byte(text), &details); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	foundThroughputPartialError := false
+	for _, e := range details.PartialErrors {
+		if strings.HasPrefix(e, "chunk ") && strings.Contains(e, "throughput") {
+			foundThroughputPartialError = true
+		}
+	}
+	if !foundThroughputPartialError {
+		t.Errorf("expected a partial error for the failing throughput chunk, got %+v", details.PartialErrors)
+	}
+	if len(details.Throughput) == 0 {
+		t.Fatal("expected the second (successful) chunk's throughput data to still merge despite the first chunk failing")
+	}
+}
+
+func TestServicePerformanceDetails_FailingChunkStillMergesOthers_TopRTQuery(t *testing.T) {
+	now := time.Now().UTC()
+	start := now.Add(-40 * 24 * time.Hour).Unix() // 40 days -> 2 chunks (35d + 5d)
+	end := now.Unix()
+	wantChunks := splitIntoPerfDetailsChunks(start, end)
+	if len(wantChunks) != 2 {
+		t.Fatalf("expected 2 chunks for a 40 day window, got %d", len(wantChunks))
+	}
+	failChunkEnd := wantChunks[0].end
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query     string `json:"query"`
+			Timestamp int64  `json:"timestamp"`
+		}
+		_ = json.Unmarshal(body, &payload)
+
+		isTopRT := strings.Contains(payload.Query, "trace_endpoint_duration")
+		if r.URL.Path == constants.EndpointPromQueryInstant && isTopRT && payload.Timestamp == failChunkEnd {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":"boom"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == constants.EndpointPromQueryInstant && isTopRT {
+			resp := []map[string]any{
+				{"metric": map[string]string{"span_name": "op-x"}, "value": []any{float64(payload.Timestamp), "77"}},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: time.Unix(start, 0).UTC().Format(time.RFC3339),
+		EndTimeISO:   time.Unix(end, 0).UTC().Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	var details ServicePerformanceDetails
+	if err := json.Unmarshal([]byte(text), &details); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	foundPartialError := false
+	for _, e := range details.PartialErrors {
+		if strings.HasPrefix(e, "chunk ") && strings.Contains(e, "top_operations_by_response_time") {
+			foundPartialError = true
+		}
+	}
+	if !foundPartialError {
+		t.Errorf("expected a partial error for the failing topRTQuery chunk, got %+v", details.PartialErrors)
+	}
+
+	if len(details.TopOperations.ByResponseTime) != 1 {
+		t.Fatalf("expected the second (successful) chunk's top-response-time data to still merge, got %+v", details.TopOperations.ByResponseTime)
+	}
+	found := false
+	for _, m := range details.TopOperations.ByResponseTime {
+		for k, v := range m {
+			if strings.HasPrefix(k, "op-x") && v == 77 {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected merged ByResponseTime to contain the surviving chunk's op-x=77 entry, got %+v", details.TopOperations.ByResponseTime)
+	}
+}
+
+// --- gap 2: exact boundary values for both caps ---
+
+func TestSplitIntoPerfDetailsChunks_Exactly35Days_NoSplit(t *testing.T) {
+	start := int64(0)
+	end := int64(perfDetailsMaxChunkDays) * 24 * 3600
+	chunks := splitIntoPerfDetailsChunks(start, end)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk at exactly %d days, got %d: %+v", perfDetailsMaxChunkDays, len(chunks), chunks)
+	}
+}
+
+func TestSplitIntoPerfDetailsChunks_35DaysPlus1Second_Splits(t *testing.T) {
+	start := int64(0)
+	end := int64(perfDetailsMaxChunkDays)*24*3600 + 1
+	chunks := splitIntoPerfDetailsChunks(start, end)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks at %d days + 1 second, got %d: %+v", perfDetailsMaxChunkDays, len(chunks), chunks)
+	}
+}
+
+func TestServicePerformanceDetails_Exactly366Days_Accepted(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	now := time.Now().UTC()
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: now.Add(-time.Duration(maxServicePerformanceWindowDays) * 24 * time.Hour).Format(time.RFC3339),
+		EndTimeISO:   now.Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("expected exactly %d days to be accepted, got error: %v", maxServicePerformanceWindowDays, err)
+	}
+	if requestCount.Load() == 0 {
+		t.Error("expected HTTP calls to be made for an accepted window")
+	}
+}
+
+func TestServicePerformanceDetails_366DaysPlus1Second_Rejected(t *testing.T) {
+	var requestCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	now := time.Now().UTC()
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: now.Add(-(time.Duration(maxServicePerformanceWindowDays)*24*time.Hour + time.Second)).Format(time.RFC3339),
+		EndTimeISO:   now.Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err == nil {
+		t.Fatal("expected 366 days + 1 second to be rejected")
+	}
+	if !strings.Contains(err.Error(), "time range too wide") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+	if rc := requestCount.Load(); rc != 0 {
+		t.Errorf("expected no HTTP calls for a rejected window, got %d", rc)
+	}
+}
+
+// --- gap 3: PromQL query-string construction correctness ---
+
+func TestServicePerformanceDetails_QueryStrings_SingleChunkUses5mInnerSelector(t *testing.T) {
+	var mu sync.Mutex
+	var queries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == constants.EndpointPromQuery {
+			body, _ := io.ReadAll(r.Body)
+			var payload struct {
+				Query string `json:"query"`
+			}
+			_ = json.Unmarshal(body, &payload)
+			mu.Lock()
+			queries = append(queries, payload.Query)
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	now := time.Now().UTC()
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: now.Add(-10 * 24 * time.Hour).Format(time.RFC3339), // 10 days = 240h outer window
+		EndTimeISO:   now.Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	if _, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	throughputQueries := 0
+	for _, q := range queries {
+		if !strings.Contains(q, "sum by (http_status_code)(rate(") {
+			continue
+		}
+		throughputQueries++
+		if !strings.Contains(q, "[5m]") {
+			t.Errorf("expected throughput query to use the fixed 5m inner selector, got: %s", q)
+		}
+		if strings.Contains(q, "[240h]") {
+			t.Errorf("throughput query still uses the full outer window as inner selector: %s", q)
+		}
+	}
+	if throughputQueries != 1 {
+		t.Fatalf("expected exactly 1 throughput query for a single-chunk window, got %d", throughputQueries)
+	}
+}
+
+func TestServicePerformanceDetails_QueryStrings_ChunkedUsesFixed5mRangeAndChunkWidthTopK(t *testing.T) {
+	now := time.Now().UTC()
+	start := now.Add(-90 * 24 * time.Hour).Unix() // 90 days -> 3 chunks (35+35+20)
+	end := now.Unix()
+	wantChunks := splitIntoPerfDetailsChunks(start, end)
+	if len(wantChunks) != 3 {
+		t.Fatalf("expected 3 chunks for a 90 day window, got %d", len(wantChunks))
+	}
+	chunkWidthMinutes := map[int64]int64{}
+	for _, c := range wantChunks {
+		chunkWidthMinutes[c.end] = (c.end - c.start) / 60
+	}
+
+	var mu sync.Mutex
+	var rangeQueries []string
+	var topRTEntries []string // "<timestamp>|<query>"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query     string `json:"query"`
+			Timestamp int64  `json:"timestamp"`
+		}
+		_ = json.Unmarshal(body, &payload)
+
+		mu.Lock()
+		switch {
+		case r.URL.Path == constants.EndpointPromQuery && strings.Contains(payload.Query, "sum by (http_status_code)(rate("):
+			rangeQueries = append(rangeQueries, payload.Query)
+		case r.URL.Path == constants.EndpointPromQueryInstant && strings.Contains(payload.Query, "trace_endpoint_duration"):
+			topRTEntries = append(topRTEntries, fmt.Sprintf("%d|%s", payload.Timestamp, payload.Query))
+		}
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: time.Unix(start, 0).UTC().Format(time.RFC3339),
+		EndTimeISO:   time.Unix(end, 0).UTC().Format(time.RFC3339),
+		Env:          "prod",
+	}
+	if _, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	if len(rangeQueries) != 3 {
+		t.Fatalf("expected 3 throughput range queries (one per chunk), got %d", len(rangeQueries))
+	}
+	for _, q := range rangeQueries {
+		if !strings.Contains(q, "[5m]") {
+			t.Errorf("expected chunked range query to still use the fixed 5m inner selector, got: %s", q)
+		}
+	}
+
+	if len(topRTEntries) != 3 {
+		t.Fatalf("expected 3 topRTQuery calls (one per chunk), got %d", len(topRTEntries))
+	}
+	for _, entry := range topRTEntries {
+		parts := strings.SplitN(entry, "|", 2)
+		ts, _ := strconv.ParseInt(parts[0], 10, 64)
+		q := parts[1]
+		wantWidth, ok := chunkWidthMinutes[ts]
+		if !ok {
+			t.Fatalf("topRTQuery timestamp %d doesn't match any expected chunk end", ts)
+		}
+		wantSelector := fmt.Sprintf("[%dm]", wantWidth)
+		if !strings.Contains(q, wantSelector) {
+			t.Errorf("expected topRTQuery for chunk ending %d to use its own width %s as inner selector, got: %s", ts, wantSelector, q)
+		}
+		if strings.Contains(q, "[5m]") {
+			t.Errorf("topRTQuery should use the chunk's own width, not the fixed 5m selector: %s", q)
+		}
+		if !strings.Contains(q, "topk(20,") {
+			t.Errorf("expected over-fetch topk(20,...) for a multi-chunk window, got: %s", q)
+		}
+		if strings.Contains(q, "topk(10,") {
+			t.Errorf("expected multi-chunk window to NOT use topk(10,...), got: %s", q)
+		}
+	}
+}
+
+// --- gap 4: multi-chunk top-k merge at the handler level ---
+
+func TestServicePerformanceDetails_MultiChunkTopKMergeAtHandlerLevel(t *testing.T) {
+	now := time.Now().UTC()
+	start := now.Add(-90 * 24 * time.Hour).Unix() // 90 days -> 3 chunks (35+35+20)
+	end := now.Unix()
+	wantChunks := splitIntoPerfDetailsChunks(start, end)
+	if len(wantChunks) != 3 {
+		t.Fatalf("expected 3 chunks for a 90 day window, got %d", len(wantChunks))
+	}
+
+	// topRTQuery and topErrQuery keys are built from span_name (+ other,
+	// here-empty, label fields); topErrorsQuery keys are the exception_type
+	// value directly. See NewServicePerformanceDetailsHandler.
+	rtByChunkEnd := map[int64]map[string]string{
+		wantChunks[0].end: {"op-a": "100"},
+		wantChunks[1].end: {"op-a": "50", "op-b": "200"},
+		wantChunks[2].end: {"op-c": "80"},
+	}
+	errByChunkEnd := map[int64]map[string]string{
+		wantChunks[0].end: {"op-err1": "5"},
+		wantChunks[1].end: {"op-err1": "3"},
+		wantChunks[2].end: {"op-err2": "10"},
+	}
+	topErrorsByChunkEnd := map[int64]map[string]string{
+		wantChunks[0].end: {"500": "5"},
+		wantChunks[1].end: {"500": "3"},
+		wantChunks[2].end: {"404": "20"},
+	}
+
+	writeInstant := func(w http.ResponseWriter, keyField string, m map[string]string) {
+		items := make([]map[string]any, 0, len(m))
+		for k, v := range m {
+			items = append(items, map[string]any{
+				"metric": map[string]string{keyField: k},
+				"value":  []any{float64(0), v},
+			})
+		}
+		_ = json.NewEncoder(w).Encode(items)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query     string `json:"query"`
+			Timestamp int64  `json:"timestamp"`
+		}
+		_ = json.Unmarshal(body, &payload)
+
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path != constants.EndpointPromQueryInstant {
+			w.Write([]byte("[]"))
+			return
+		}
+
+		switch {
+		case strings.Contains(payload.Query, "trace_endpoint_duration"):
+			writeInstant(w, "span_name", rtByChunkEnd[payload.Timestamp])
+		case strings.Contains(payload.Query, "process_runtime_name, exception_type)"):
+			writeInstant(w, "span_name", errByChunkEnd[payload.Timestamp])
+		case strings.Contains(payload.Query, "sum by (exception_type)(sum by (exception_type, span_kind)"):
+			writeInstant(w, "exception_type", topErrorsByChunkEnd[payload.Timestamp])
+		default:
+			w.Write([]byte("[]"))
+		}
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: time.Unix(start, 0).UTC().Format(time.RFC3339),
+		EndTimeISO:   time.Unix(end, 0).UTC().Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	var details ServicePerformanceDetails
+	if err := json.Unmarshal([]byte(text), &details); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	rtKey := func(spanName string) string {
+		return fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s", spanName, "", "", "", "", "", "")
+	}
+
+	wantRT := []map[string]float64{{rtKey("op-b"): 200}, {rtKey("op-a"): 100}, {rtKey("op-c"): 80}}
+	if !reflect.DeepEqual(details.TopOperations.ByResponseTime, wantRT) {
+		t.Errorf("expected cross-chunk max-merged ByResponseTime %+v, got %+v", wantRT, details.TopOperations.ByResponseTime)
+	}
+
+	wantErrRate := []map[string]int64{{rtKey("op-err2"): 10}, {rtKey("op-err1"): 8}}
+	if !reflect.DeepEqual(details.TopOperations.ByErrorRate, wantErrRate) {
+		t.Errorf("expected cross-chunk summed ByErrorRate %+v, got %+v", wantErrRate, details.TopOperations.ByErrorRate)
+	}
+
+	wantTopErrors := []map[string]int64{{"404": 20}, {"500": 8}}
+	if !reflect.DeepEqual(details.TopErrors, wantTopErrors) {
+		t.Errorf("expected cross-chunk summed TopErrors %+v, got %+v", wantTopErrors, details.TopErrors)
+	}
+}
+
+// --- gap 5: >2 chunks end-to-end, contiguous deduped merge across all boundaries ---
+
+func TestServicePerformanceDetails_ThreeChunkWindow_MergedSeriesOrderedContiguousDeduped(t *testing.T) {
+	now := time.Now().UTC()
+	start := now.Add(-100 * 24 * time.Hour).Unix() // 100 days -> 3 chunks (35+35+30)
+	end := now.Unix()
+	wantChunks := splitIntoPerfDetailsChunks(start, end)
+	if len(wantChunks) != 3 {
+		t.Fatalf("expected 3 chunks for a 100 day window (35+35+30), got %d: %+v", len(wantChunks), wantChunks)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query     string `json:"query"`
+			Timestamp int64  `json:"timestamp"`
+			Window    int64  `json:"window"`
+		}
+		_ = json.Unmarshal(body, &payload)
+
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == constants.EndpointPromQuery && strings.Contains(payload.Query, "trace_service_apdex_score") {
+			chunkStart := payload.Timestamp - payload.Window
+			resp := []map[string]any{
+				{
+					"metric": map[string]string{},
+					"values": [][]any{
+						{float64(chunkStart), "1"},
+						{float64(payload.Timestamp), "1"},
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: time.Unix(start, 0).UTC().Format(time.RFC3339),
+		EndTimeISO:   time.Unix(end, 0).UTC().Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	var details ServicePerformanceDetails
+	if err := json.Unmarshal([]byte(text), &details); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if len(details.ApdexScore) != 1 {
+		t.Fatalf("expected a single merged apdex series (one label set across all chunks), got %d: %+v", len(details.ApdexScore), details.ApdexScore)
+	}
+
+	wantTimestamps := []uint64{
+		uint64(wantChunks[0].start),
+		uint64(wantChunks[0].end), // == wantChunks[1].start, deduped
+		uint64(wantChunks[1].end), // == wantChunks[2].start, deduped
+		uint64(wantChunks[2].end),
+	}
+	got := details.ApdexScore[0].Values
+	if len(got) != len(wantTimestamps) {
+		t.Fatalf("expected %d merged points across the 3 chunk boundaries, got %d: %+v", len(wantTimestamps), len(got), got)
+	}
+	for i, wantTs := range wantTimestamps {
+		if got[i].Timestamp != wantTs {
+			t.Errorf("point %d: expected timestamp %d, got %d (full: %+v)", i, wantTs, got[i].Timestamp, got)
+		}
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].Timestamp <= got[i-1].Timestamp {
+			t.Errorf("expected strictly increasing/contiguous timestamps, got %+v", got)
+		}
+	}
+}
+
+// --- gap 6: malformed (unparseable) JSON body for a range-vector chunk ---
+
+func TestServicePerformanceDetails_MalformedJSONChunk_RecordsPartialErrorOthersMerge(t *testing.T) {
+	now := time.Now().UTC()
+	start := now.Add(-40 * 24 * time.Hour).Unix() // 40 days -> 2 chunks (35d + 5d)
+	end := now.Unix()
+	wantChunks := splitIntoPerfDetailsChunks(start, end)
+	if len(wantChunks) != 2 {
+		t.Fatalf("expected 2 chunks for a 40 day window, got %d", len(wantChunks))
+	}
+	firstChunkEnd := wantChunks[0].end
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query     string `json:"query"`
+			Timestamp int64  `json:"timestamp"`
+		}
+		_ = json.Unmarshal(body, &payload)
+
+		isErrorRate := strings.Contains(payload.Query, "sum by (service_name, http_status_code)(rate(")
+		w.WriteHeader(http.StatusOK)
+		if r.URL.Path == constants.EndpointPromQuery && isErrorRate {
+			if payload.Timestamp == firstChunkEnd {
+				// 200 OK but a garbage body - must be recorded as a partial
+				// parse error, not abort the whole call.
+				w.Write([]byte("not valid json"))
+				return
+			}
+			resp := []map[string]any{
+				{"metric": map[string]string{"http_status_code": "500"}, "values": [][]any{{float64(payload.Timestamp), "3"}}},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: time.Unix(start, 0).UTC().Format(time.RFC3339),
+		EndTimeISO:   time.Unix(end, 0).UTC().Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	text := result.Content[0].(*mcp.TextContent).Text
+	var details ServicePerformanceDetails
+	if err := json.Unmarshal([]byte(text), &details); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	foundParseError := false
+	for _, e := range details.PartialErrors {
+		if strings.HasPrefix(e, "chunk ") && strings.Contains(e, "failed to parse") {
+			foundParseError = true
+		}
+	}
+	if !foundParseError {
+		t.Errorf("expected a partial error for the malformed-JSON chunk, got %+v", details.PartialErrors)
+	}
+
+	if len(details.ErrorRate) == 0 {
+		t.Fatal("expected the second (valid) chunk's error_rate data to still merge despite the first chunk returning malformed JSON")
+	}
+}


### PR DESCRIPTION
## Summary
Fixes ENG-1813. `get_service_performance_details` reused the full requested window as the inner PromQL range-vector selector on ~9 sub-queries, causing the backend to rescan the entire window's raw samples per output step — confirmed via direct backend testing to crash/OOM the backend for windows wider than ~1-2 weeks, and that the backend hard-caps a single query's range at exactly 35 days.

- Range-vector sub-queries (apdex, response times, availability, throughput, error rate, error percent) now use a fixed `5m` inner selector instead of the full window.
- Windows >35 days are split into consecutive ≤35-day chunks, queried independently, and merged with boundary-timestamp dedup and label-set-aware series matching (a label combination present in only some chunks still comes through).
- The three top-k queries keep their chunk's own width as the inner selector; when chunked, they over-fetch more candidates per chunk and merge across chunks (max-per-key for the p95-latency query, sum-per-key for the two count-style queries) before truncating to top 10.
- Windows over 366 days are rejected before any HTTP call — a call-count/latency guard, not a data-retention cutoff.
- Windows ≤35 days are unaffected: same single query per metric, same output shape as before.

## Test plan
- [x] 189 tests pass in `internal/apm` (new: chunk splitting, boundary dedup + partial-label-set merge, sum-vs-max merge correctness for count vs percentile top-k, 366-day rejection with zero HTTP calls, exact call counts for chunked/non-chunked paths, failing-chunk-doesn't-block-others)
- [x] `go build ./...` and `go vet ./...` clean
- [x] Direct testing against the real Last9 TSDB backend confirmed the fix at 1 week, 3 weeks, 4 weeks, 1 month, 35 days (exact boundary), and a full 1-year window split into 11 chunks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/last9/codesmith/last9-mcp-server/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790159526&installation_model_id=433497&pr_number=225&repository=last9%2Flast9-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Flast9%2Flast9-mcp-server%2Fpull%2F225&signature=c96c5cbee3d6f91963391cf7dbb764a737da8b907b68ad77f06502678d513341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->