### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-08-27
+
 ### Added
 
 - `get_logs` and `get_service_logs` can answer a search with one server-side call instead of the client-side chunk sweep. Set `LAST9_USE_LOG_SEARCH_API=true` (or `--use_log_search_api`); off by default. Output shapes are unchanged. `get_logs` gains `total_matching_lines`, `logs_truncated`, `search_stats` and `volume_summary` on raw searches (aggregates get `search_stats` only); `get_service_logs` gains `total_matching_lines` and `search_stats`. `total_matching_lines` counts all matching lines, not the returned sample — but it is a floor, not a total, when `logs_truncated` is true or `search_stats.chunks_failed` is above zero.
+
+## [0.15.2] - 2026-08-26
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@last9/mcp-server",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "Last9 MCP Server - Model Context Protocol server implementation for Last9",
   "bin": {
     "last9-mcp": "./bin/cli.js"


### PR DESCRIPTION
Bumps `package.json` to **0.16.0** — that field is the entire release trigger — and retroactively cuts the missing v0.15.2 changelog section.

**2 files, +5/−1.** No bullet text was edited; verified byte-identical, 8 bullets before and after.

## Why minor, not patch

`9a81bce` (#228) adds the server-side log search path for `get_logs` / `get_service_logs`: a new `--use_log_search_api` / `LAST9_USE_LOG_SEARCH_API` flag and new response fields (`total_matching_lines`, `logs_truncated`, `search_stats`, `volume_summary`). Additive surface, matching how every prior feature release here was cut.

**Off by default** — the client-side chunk sweep is still what runs unless the flag is set.

## CHANGELOG split

v0.15.2 shipped on 2026-08-26 but never got a section, so its four fixes were still sitting under `[Unreleased]` mixed in with #228's entry. Attribution verified with `git diff v0.15.1..v0.15.2 -- CHANGELOG.md`:

| section | contents |
|---|---|
| `[0.16.0] - 2026-08-27` | 1 Added — #228 |
| `[0.15.2] - 2026-08-26` | 5 Fixed + 2 Changed — #216, #218, #226, #227 |

## Contents

| commit | | ships in the binary? |
|---|---|---|
| `9a81bce` | `feat(logs)`: single server-side search call, flag-gated (#228) | yes |
| `a32fbe3` | `fix(ci)`: give `publish-npm` an npm that supports trusted publishing (#219) | no — CI only |

## Supersedes #223

#223 also bumped to 0.16.0, but from a branch 5 commits behind main that contains neither `a32fbe3` nor `9a81bce` — so it would have failed to publish to npm again and shipped without #226/#227/#228. Closed; its 4 genuinely unreleased commits (MCP 2026-07-28 / go-sdk v1.7.0) are preserved on `archive/mcp-2026-07-28` and need a fresh PR against main as 0.17.0.

## npm — first real test of #219

`publish-npm` has never once succeeded. Every one of the 22 published versions was hand-published, and npm `latest` is stuck at **0.10.0**. #219 fixed the cause (Node 20 bundles npm 10, which cannot perform the OIDC token exchange); the npm Trusted Publisher config was verified working independently (ENG-1745).

npm will jump **0.10.0 → 0.16.0**. Harmless: the package is a thin wrapper whose `postinstall` fetches the binary from GitHub Releases, and all of those releases exist. 0.15.2 stays absent from npm.

**Key check after merge:** 0.16.0 should be the first version ever to carry a **provenance attestation**. That is the proof the OIDC path actually ran, rather than the publish having succeeded some other way.

## Release checklist

- [ ] `tag-and-release` — tag `v0.16.0` + GoReleaser assets
- [ ] `build-docker` (amd64 + arm64) → `docker-manifest`
- [ ] `publish-npm` → `@last9/mcp-server@0.16.0` **with attestation**
- [ ] homebrew-tap formula PR auto-merged

Verified locally: `jq` parses `package.json`, `go build ./...` clean, `go test ./...` no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/last9/codesmith/last9-mcp-server/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790417783&installation_model_id=433497&pr_number=230&repository=last9%2Flast9-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Flast9%2Flast9-mcp-server%2Fpull%2F230&signature=58e9518121b1c17d62f0ced63c16af1b69400603d4161cf617790c323b2fc6a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->