### PR TITLE
ENG-1823 Adaptive step and rate interval for get_service_performance_details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `get_service_performance_details` now returns about 200 data points per series instead of one per minute, and sizes each range selector from the resulting step, so a wide window aggregates the whole window instead of sampling part of it. Response-time values shift slightly, since that query's lookback is no longer fixed at 5m.
+- `get_service_performance_details` now caps each series at about 200 data points and sizes each range selector from the resulting step. Windows up to about 3h20m are unchanged at one point per minute; above that the step widens, so the four `rate()`-based series (availability, throughput, error rate, error percent) aggregate the whole window instead of sampling part of it. Apdex and response times carry no `rate()`, so they stay last-value-per-step and get sparser on a wide window. Response-time values also shift slightly, since that query's lookback is no longer fixed at 5m.
 - The service workflows and the service-scoped tool descriptions now call `get_service_profile` first: skip trace tools when the profile reports `telemetry.traces` as `absent`, and parse the level from the log body when `severity_set` is `none` or `partial`.
 
 ## [0.16.0] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `get_service_performance_details` now caps each series at about 200 data points and sizes each range selector from the resulting step. Windows up to about 3h20m are unchanged at one point per minute; above that the step widens, so the four `rate()`-based series (availability, throughput, error rate, error percent) aggregate the whole window instead of sampling part of it. Apdex and response times carry no `rate()`, so they stay last-value-per-step and get sparser on a wide window. Response-time values also shift slightly, since that query's lookback is no longer fixed at 5m.
+- `get_service_performance_details` now caps each series at about 200 data points per chunk and sizes each range selector from the resulting step. The cap is per chunk, not per merged series: a window wider than 35 days is split into equal-width chunks and concatenated, so it returns roughly 200 x chunk count points. Windows up to about 3h20m are unchanged at one point per minute; above that the step widens, so the four `rate()`-based series (availability, throughput, error rate, error percent) aggregate the whole window instead of sampling part of it. Apdex and response times carry no `rate()`, so they stay last-value-per-step and get sparser on a wide window. Response-time values also shift slightly, since that query's lookback is no longer fixed at 5m.
 - The service workflows and the service-scoped tool descriptions now call `get_service_profile` first: skip trace tools when the profile reports `telemetry.traces` as `absent`, and parse the level from the log body when `severity_set` is `none` or `partial`.
 
 ## [0.16.0] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `get_service_performance_details` now returns about 200 data points per series instead of one per minute, and sizes each range selector from the resulting step, so a wide window aggregates the whole window instead of sampling part of it. Response-time values shift slightly, since that query's lookback is no longer fixed at 5m. Requires a Last9 API version that substitutes `$__rate_interval` on the range-query endpoint.
+- `get_service_performance_details` now returns about 200 data points per series instead of one per minute, and sizes each range selector from the resulting step, so a wide window aggregates the whole window instead of sampling part of it. Response-time values shift slightly, since that query's lookback is no longer fixed at 5m.
 - The service workflows and the service-scoped tool descriptions now call `get_service_profile` first: skip trace tools when the profile reports `telemetry.traces` as `absent`, and parse the level from the log body when `severity_set` is `none` or `partial`.
 
 ## [0.16.0] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `get_service_performance_details` now requests ~200 data points per series per chunk instead of one per minute, and sizes each sub-query's range selector from the resulting step via `$__rate_interval`. Windows under ~3h19m are unchanged. Wider windows return far smaller responses, and quantile-shaped fields (response times, apdex) cover the whole window instead of only the minutes that happened to hold samples. Requires a Last9 API version that accepts `max_data_points`.
+- `get_service_performance_details` now requests ~200 data points per series per chunk instead of one per minute, and sizes each sub-query's range selector from the resulting step via `$__rate_interval`. Response size and step are unchanged below ~3h19m; apdex and response-time values shift slightly at all widths, as their lookback is now sized from the step. Wider windows return far smaller responses, and quantile-shaped fields (response times, apdex) cover the whole window instead of only the minutes that happened to hold samples. Requires a Last9 API version that substitutes `$__rate_interval` on the range-query endpoint; against an older version the time-series fields come back empty with `partial_errors`.
 - The service workflows and the service-scoped tool descriptions now call `get_service_profile` first: skip trace tools when the profile reports `telemetry.traces` as `absent`, and parse the level from the log body when `severity_set` is `none` or `partial`.
 
 ## [0.16.0] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `get_service_performance_details` now caps each series at about 200 data points per chunk and sizes each range selector from the resulting step. The cap is per chunk, not per merged series: a window wider than 35 days is split into equal-width chunks and concatenated, so it returns roughly 200 x chunk count points. Windows up to about 3h20m are unchanged at one point per minute; above that the step widens, so the four `rate()`-based series (availability, throughput, error rate, error percent) aggregate the whole window instead of sampling part of it. Apdex and response times carry no `rate()`, so they stay last-value-per-step and get sparser on a wide window. Response-time values also shift slightly, since that query's lookback is no longer fixed at 5m.
+- `get_service_performance_details` now returns about 200 points per series instead of one per minute, sizing each range selector from the resulting step. Windows under ~3h20m are unchanged; above that the `rate()`-based series (availability, throughput, error rate, error percent) aggregate the whole window, while apdex and response times stay last-value and get sparser. Response-time values shift slightly — that query's lookback is no longer fixed at 5m.
 - The service workflows and the service-scoped tool descriptions now call `get_service_profile` first: skip trace tools when the profile reports `telemetry.traces` as `absent`, and parse the level from the log body when `severity_set` is `none` or `partial`.
 
 ## [0.16.0] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `get_service_performance_details` now returns about 200 data points per series instead of one per minute, and sizes each range selector from the resulting step, so a wide window aggregates the whole window instead of sampling part of it. Response-time values shift slightly, since that query's lookback is no longer fixed at 5m. Requires a Last9 API version that substitutes `$__rate_interval` on the range-query endpoint; against an older version the time-series fields come back empty with `partial_errors`.
+- `get_service_performance_details` now returns about 200 data points per series instead of one per minute, and sizes each range selector from the resulting step, so a wide window aggregates the whole window instead of sampling part of it. Response-time values shift slightly, since that query's lookback is no longer fixed at 5m. Requires a Last9 API version that substitutes `$__rate_interval` on the range-query endpoint.
 - The service workflows and the service-scoped tool descriptions now call `get_service_profile` first: skip trace tools when the profile reports `telemetry.traces` as `absent`, and parse the level from the log body when `severity_set` is `none` or `partial`.
 
 ## [0.16.0] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `get_service_performance_details` now requests ~200 data points per series per chunk instead of one per minute, and sizes each sub-query's range selector from the resulting step via `$__rate_interval`. Response size and step are unchanged below ~3h19m; apdex and response-time values shift slightly at all widths, as their lookback is now sized from the step. Wider windows return far smaller responses, and quantile-shaped fields (response times, apdex) cover the whole window instead of only the minutes that happened to hold samples. Requires a Last9 API version that substitutes `$__rate_interval` on the range-query endpoint; against an older version the time-series fields come back empty with `partial_errors`.
+- `get_service_performance_details` now returns about 200 data points per series instead of one per minute, and sizes each range selector from the resulting step, so a wide window aggregates the whole window instead of sampling part of it. Response-time values shift slightly, since that query's lookback is no longer fixed at 5m. Requires a Last9 API version that substitutes `$__rate_interval` on the range-query endpoint; against an older version the time-series fields come back empty with `partial_errors`.
 - The service workflows and the service-scoped tool descriptions now call `get_service_profile` first: skip trace tools when the profile reports `telemetry.traces` as `absent`, and parse the level from the log body when `severity_set` is `none` or `partial`.
 
 ## [0.16.0] - 2026-08-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `get_service_performance_details` now requests ~200 data points per series per chunk instead of one per minute, and sizes each sub-query's range selector from the resulting step via `$__rate_interval`. Windows under ~3h19m are unchanged. Wider windows return far smaller responses, and quantile-shaped fields (response times, apdex) cover the whole window instead of only the minutes that happened to hold samples. Requires a Last9 API version that accepts `max_data_points`.
 - The service workflows and the service-scoped tool descriptions now call `get_service_profile` first: skip trace tools when the profile reports `telemetry.traces` as `absent`, and parse the level from the log body when `severity_set` is `none` or `partial`.
 
 ## [0.16.0] - 2026-08-27

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -61,7 +61,8 @@ const (
 	// Caps output timestamps per series per chunk. Only safe because every
 	// rate() selector is sized from the resulting step via $__rate_interval;
 	// the apdex and response-time queries carry no rate() and just resolve as
-	// last-value at the wider step. The cap only binds past ~3h20m of window.
+	// last-value at the wider step. The cap only binds past ~3h20m of window,
+	// and applies per chunk - a chunked window merges to ~200 x chunk count.
 	perfDetailsMaxDataPoints = 200
 )
 

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -30,10 +30,8 @@ import (
 //   - splitting a wider outer window into <=35-day chunks and querying each
 //     with a step-derived inner selector works cleanly.
 //
-// A step-derived inner selector ($__rate_interval) is safe at any outer
-// width up to that 35-day cap by construction, not by measurement: it is
-// never narrower than the step, so scan overlap stays near 1x instead of
-// the up-to-5x the old fixed-window form incurred.
+// A step-derived selector ($__rate_interval) is never narrower than the
+// step, so overlap stays near 1x — by construction, not measurement.
 const (
 	// maxServicePerformanceWindowDays is NOT a data-retention cutoff — a
 	// chunk entirely outside retention just comes back empty from the
@@ -58,10 +56,8 @@ const (
 	// backend in parallel, matching the small bounded concurrency other
 	// chunked callers (get_logs/get_traces) use.
 	perfDetailsMaxConcurrency = 5
-	// perfDetailsMaxDataPoints caps output timestamps per series per chunk.
-	// The 422 sample guard is a per-series tick limit — 50,401 ticks over 35
-	// days trips it, 200 sits far clear. Only safe because every range
-	// selector is sized from the resulting step via $__rate_interval.
+	// Caps output timestamps per series per chunk. Only safe because every
+	// range selector is sized from the resulting step via $__rate_interval.
 	perfDetailsMaxDataPoints = 200
 )
 
@@ -463,7 +459,7 @@ func fetchChunkedRangeSeries(ctx context.Context, client *http.Client, cfg model
 				defer cancel()
 			}
 
-			httpResp, err := utils.MakePromRangeAPIQueryWithResolution(
+			httpResp, err := utils.MakePromRangeAPIQuery(
 				chunkCtx, client, buildQuery(c), c.start, c.end, cfg,
 				utils.PromResolution{MaxDataPoints: perfDetailsMaxDataPoints},
 			)
@@ -1923,7 +1919,7 @@ func NewPromqlRangeQueryHandler(client *http.Client, cfg models.Config) func(con
 			return nil, nil, err
 		}
 
-		httpResp, err := utils.MakePromRangeAPIQuery(ctx, client, query, startTimeParam, endTimeParam, queryCfg)
+		httpResp, err := utils.MakePromRangeAPIQuery(ctx, client, query, startTimeParam, endTimeParam, queryCfg, utils.PromResolution{})
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -25,12 +25,15 @@ import (
 // (e.g. rate(x[<full window>])), which makes the backend rescan the entire
 // window's raw samples per output step. That crashes/OOMs the backend for
 // windows wider than ~1-2 weeks. Confirmed via direct backend testing:
-//   - a step-derived inner selector ($__rate_interval) is safe at any outer
-//     width up to 35 days.
 //   - the backend hard-caps a single query's outer range at 35 days (HTTP
 //     422 "Too many samples queried" just past that).
 //   - splitting a wider outer window into <=35-day chunks and querying each
 //     with a step-derived inner selector works cleanly.
+//
+// A step-derived inner selector ($__rate_interval) is safe at any outer
+// width up to that 35-day cap by construction, not by measurement: it is
+// never narrower than the step, so scan overlap stays near 1x instead of
+// the up-to-5x the old fixed-window form incurred.
 const (
 	// maxServicePerformanceWindowDays is NOT a data-retention cutoff — a
 	// chunk entirely outside retention just comes back empty from the

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -698,10 +698,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 
 		// Get Apdex Score over time range as a vector
 		details.ApdexScore, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
-			// Bare gauge: without a rollup sized from the step, a wide step
-			// reads almost none of the window.
 			return fmt.Sprintf(
-				"avg_over_time(sum(trace_service_apdex_score{service_name='%s', env=~'%s'})[$__rate_interval])",
+				"sum(trace_service_apdex_score{service_name='%s', env=~'%s'})",
 				serviceName, env,
 			)
 		}, "service performance details apdex", "apdex score", &details.PartialErrors)

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -30,8 +30,10 @@ import (
 //   - splitting a wider outer window into <=35-day chunks and querying each
 //     with a step-derived inner selector works cleanly.
 //
-// A step-derived selector ($__rate_interval) is never narrower than the
-// step, so overlap stays near 1x — by construction, not measurement.
+// $__rate_interval resolves to max(step + scrape, 4 x scrape), so a selector
+// is never narrower than its step (overlap stays near 1x) and never narrower
+// than the scrape interval — the second floor is what keeps a narrow window's
+// rate() from returning nothing. Measured against the backend, not assumed.
 const (
 	// maxServicePerformanceWindowDays is NOT a data-retention cutoff — a
 	// chunk entirely outside retention just comes back empty from the
@@ -57,7 +59,9 @@ const (
 	// chunked callers (get_logs/get_traces) use.
 	perfDetailsMaxConcurrency = 5
 	// Caps output timestamps per series per chunk. Only safe because every
-	// range selector is sized from the resulting step via $__rate_interval.
+	// rate() selector is sized from the resulting step via $__rate_interval;
+	// the apdex and response-time queries carry no rate() and just resolve as
+	// last-value at the wider step. The cap only binds past ~3h20m of window.
 	perfDetailsMaxDataPoints = 200
 )
 

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -25,11 +25,12 @@ import (
 // (e.g. rate(x[<full window>])), which makes the backend rescan the entire
 // window's raw samples per output step. That crashes/OOMs the backend for
 // windows wider than ~1-2 weeks. Confirmed via direct backend testing:
-//   - a fixed 5m inner selector is safe at any outer width up to 35 days.
+//   - a step-derived inner selector ($__rate_interval) is safe at any outer
+//     width up to 35 days.
 //   - the backend hard-caps a single query's outer range at 35 days (HTTP
 //     422 "Too many samples queried" just past that).
 //   - splitting a wider outer window into <=35-day chunks and querying each
-//     with the 5m inner selector works cleanly.
+//     with a step-derived inner selector works cleanly.
 const (
 	// maxServicePerformanceWindowDays is NOT a data-retention cutoff — a
 	// chunk entirely outside retention just comes back empty from the
@@ -778,7 +779,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		// Get Top Operations by Response Time - keep vector output. This is
 		// an instant query whose only windowing mechanism is the inner
 		// quantile_over_time([...]) selector, so (unlike the rate() queries
-		// above) it must stay at the chunk's own width, not perfDetailsInnerRange.
+		// above) it must stay at the chunk's own width, not the step-derived
+		// $__rate_interval the range queries use.
 		topRTLimit := topN
 		if multiChunk {
 			topRTLimit = 2 * topN // over-fetch per chunk so the cross-chunk merge still has topN real candidates

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -41,14 +41,6 @@ const (
 	// cap. Windows wider than this are split into consecutive chunks of at
 	// most this many days.
 	perfDetailsMaxChunkDays = 35
-	// perfDetailsInnerRange is the fixed inner range-vector selector duration
-	// used for rate()/step-based sub-queries, replacing the old (and unsafe)
-	// "reuse the whole requested window" behavior. This does NOT control the
-	// output step/resolution of the response — that's derived server-side
-	// from the outer `window` param (see utils.MakePromRangeAPIQuery); it
-	// only bounds how much raw data each inner rate()/quantile_over_time()
-	// rescans per output point.
-	perfDetailsInnerRange = "5m"
 	// perfDetailsDefaultTopN is the default number of entries returned for
 	// the three top-k fields (top_operations_by_response_time,
 	// top_operations_by_error_rate, top_errors) when top_n is unset/zero.
@@ -698,8 +690,10 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 
 		// Get Apdex Score over time range as a vector
 		details.ApdexScore, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
+			// Bare gauge: without a rollup sized from the step, a wide step
+			// reads almost none of the window.
 			return fmt.Sprintf(
-				"sum(trace_service_apdex_score{service_name='%s', env=~'%s'})",
+				"avg_over_time(sum(trace_service_apdex_score{service_name='%s', env=~'%s'})[$__rate_interval])",
 				serviceName, env,
 			)
 		}, "service performance details apdex", "apdex score", &details.PartialErrors)
@@ -710,8 +704,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		// Get Response Times - keep vector output
 		details.ResponseTimes, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
 			return fmt.Sprintf(
-				"sum by (quantile) (trace_service_response_time{service_name='%s', env='%s'}[%s])",
-				serviceName, env, perfDetailsInnerRange,
+				"sum by (quantile) (trace_service_response_time{service_name='%s', env='%s'}[$__rate_interval])",
+				serviceName, env,
 			)
 		}, "service performance details response_times", "response times", &details.PartialErrors)
 		if err != nil {
@@ -721,8 +715,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		// Get Availability over time range as a vector
 		details.Availability, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
 			return fmt.Sprintf(
-				"(1 - (sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[%s])) or 0) / (sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[%s])) + 0.0000001)) * 100 default -999",
-				serviceName, env, perfDetailsInnerRange, serviceName, env, perfDetailsInnerRange,
+				"(1 - (sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[$__rate_interval])) or 0) / (sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[$__rate_interval])) + 0.0000001)) * 100 default -999",
+				serviceName, env, serviceName, env,
 			)
 		}, "service performance details availability", "availability response", &details.PartialErrors)
 		if err != nil {
@@ -732,8 +726,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		// Get Throughput by status code - keep vector output
 		details.Throughput, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
 			return fmt.Sprintf(
-				"sum by (http_status_code)(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[%s])) * 60 default 0",
-				serviceName, env, perfDetailsInnerRange,
+				"sum by (http_status_code)(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[$__rate_interval])) * 60 default 0",
+				serviceName, env,
 			)
 		}, "service performance details throughput", "throughput response", &details.PartialErrors)
 		if err != nil {
@@ -743,8 +737,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		// Get Error Rate by status code - keep vector output
 		details.ErrorRate, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
 			return fmt.Sprintf(
-				"sum by (service_name, http_status_code)(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[%s])) * 60 default 0",
-				serviceName, env, perfDetailsInnerRange,
+				"sum by (service_name, http_status_code)(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[$__rate_interval])) * 60 default 0",
+				serviceName, env,
 			)
 		}, "service performance details error_rate", "error rate response", &details.PartialErrors)
 		if err != nil {
@@ -754,8 +748,8 @@ func NewServicePerformanceDetailsHandler(client *http.Client, cfg models.Config)
 		// Calculate Error Percentage over time range as a vector
 		details.ErrorPercent, err = fetchChunkedRangeSeries(ctx, client, cfg, chunks, func(c perfDetailsChunk) string {
 			return fmt.Sprintf(
-				"(sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[%s])) / sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[%s])) * 100) default 0",
-				serviceName, env, perfDetailsInnerRange, serviceName, env, perfDetailsInnerRange,
+				"(sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER', http_status_code=~'4.*|5.*'}[$__rate_interval])) / sum(rate(trace_endpoint_count{service_name='%s', env='%s', span_kind='SPAN_KIND_SERVER'}[$__rate_interval])) * 100) default 0",
+				serviceName, env, serviceName, env,
 			)
 		}, "service performance details error_percent", "error percent response", &details.PartialErrors)
 		if err != nil {

--- a/internal/apm/apm.go
+++ b/internal/apm/apm.go
@@ -55,6 +55,11 @@ const (
 	// backend in parallel, matching the small bounded concurrency other
 	// chunked callers (get_logs/get_traces) use.
 	perfDetailsMaxConcurrency = 5
+	// perfDetailsMaxDataPoints caps output timestamps per series per chunk.
+	// The 422 sample guard is a per-series tick limit — 50,401 ticks over 35
+	// days trips it, 200 sits far clear. Only safe because every range
+	// selector is sized from the resulting step via $__rate_interval.
+	perfDetailsMaxDataPoints = 200
 )
 
 // firstNonEmpty returns the first non-empty string, enabling canonical-wins
@@ -455,7 +460,10 @@ func fetchChunkedRangeSeries(ctx context.Context, client *http.Client, cfg model
 				defer cancel()
 			}
 
-			httpResp, err := utils.MakePromRangeAPIQuery(chunkCtx, client, buildQuery(c), c.start, c.end, cfg)
+			httpResp, err := utils.MakePromRangeAPIQueryWithResolution(
+				chunkCtx, client, buildQuery(c), c.start, c.end, cfg,
+				utils.PromResolution{MaxDataPoints: perfDetailsMaxDataPoints},
+			)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/apm/service_performance_details_resolution_test.go
+++ b/internal/apm/service_performance_details_resolution_test.go
@@ -103,19 +103,42 @@ func TestPerfDetails_AllRangeQueriesUseRateInterval(t *testing.T) {
 		t.Fatalf("expected 6 range sub-queries, got %d", len(rangeQ))
 	}
 
-	// response_times 1, availability 2, throughput 1, error_rate 1,
-	// error_percent 2 = 7. Apdex is a bare gauge and carries none: VM sizes a
-	// bare selector's lookback from the step, so it needs no selector.
-	const wantTotalRateIntervals = 7
-	total := 0
+	// Per-builder, not a total: a total lets one builder lose its selector
+	// while another gains one. Apdex is a bare gauge and carries none - VM
+	// sizes a bare selector's lookback from the step, so it needs no selector.
+	wantPerBuilder := []struct {
+		name   string
+		marker string
+		want   int
+	}{
+		{"apdex", "trace_service_apdex_score", 0},
+		{"response_times", "trace_service_response_time", 1},
+		{"availability", "default -999", 2},
+		{"throughput", "sum by (http_status_code)(rate(", 1},
+		{"error_rate", "sum by (service_name, http_status_code)(rate(", 1},
+		{"error_percent", "* 100) default 0", 2},
+	}
+
 	for _, q := range rangeQ {
-		total += strings.Count(q, "$__rate_interval")
 		if m := hardcodedSelector.FindString(q); m != "" {
 			t.Errorf("range query carries a hardcoded selector %s; it must be sized from the step:\n%s", m, q)
 		}
 	}
-	if total != wantTotalRateIntervals {
-		t.Errorf("$__rate_interval occurrences across all range queries = %d, want %d", total, wantTotalRateIntervals)
+
+	for _, w := range wantPerBuilder {
+		var matched []string
+		for _, q := range rangeQ {
+			if strings.Contains(q, w.marker) {
+				matched = append(matched, q)
+			}
+		}
+		if len(matched) != 1 {
+			t.Errorf("%s: marker %q matched %d range queries, want exactly 1", w.name, w.marker, len(matched))
+			continue
+		}
+		if got := strings.Count(matched[0], "$__rate_interval"); got != w.want {
+			t.Errorf("%s: $__rate_interval occurrences = %d, want %d:\n%s", w.name, got, w.want, matched[0])
+		}
 	}
 }
 

--- a/internal/apm/service_performance_details_resolution_test.go
+++ b/internal/apm/service_performance_details_resolution_test.go
@@ -17,18 +17,20 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// hardcodedSelector matches any literal PromQL duration selector (e.g.
-// [5m], [1h]) — a regression to a different hardcoded duration would slip
-// past a check for "[5m]" alone.
-var hardcodedSelector = regexp.MustCompile(`\[\d+[smhdwy]\]`)
+// hardcodedSelector matches any literal PromQL duration selector, including
+// compound (e.g. [1h30m]) and fractional (e.g. [1.5h]) durations — a
+// regression to a different hardcoded duration would slip past a check for
+// "[5m]" alone.
+var hardcodedSelector = regexp.MustCompile(`\[[\d.]+[a-z]+(\d+[a-z]+)*\]`)
 
 // perfDetailsCapture records the PromQL and resolution of every sub-query the
 // handler sends, split by endpoint.
 type perfDetailsCapture struct {
-	mu       sync.Mutex
-	rangeQ   []string
-	instantQ []string
-	rangeMDP []int64
+	mu        sync.Mutex
+	rangeQ    []string
+	instantQ  []string
+	rangeMDP  []int64
+	rangeStep []int64
 }
 
 func (c *perfDetailsCapture) snapshot() ([]string, []string, []int64) {
@@ -37,6 +39,14 @@ func (c *perfDetailsCapture) snapshot() ([]string, []string, []int64) {
 	return append([]string(nil), c.rangeQ...),
 		append([]string(nil), c.instantQ...),
 		append([]int64(nil), c.rangeMDP...)
+}
+
+// snapshotSteps returns the "step" value captured for every range sub-query,
+// in the same order as snapshot's rangeQ.
+func (c *perfDetailsCapture) snapshotSteps() []int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]int64(nil), c.rangeStep...)
 }
 
 // runPerfDetailsCapture drives the handler over a 10-day (single-chunk) window
@@ -50,6 +60,7 @@ func runPerfDetailsCapture(t *testing.T) *perfDetailsCapture {
 		var payload struct {
 			Query         string `json:"query"`
 			MaxDataPoints int64  `json:"max_data_points"`
+			Step          int64  `json:"step"`
 		}
 		_ = json.Unmarshal(body, &payload)
 
@@ -58,6 +69,7 @@ func runPerfDetailsCapture(t *testing.T) *perfDetailsCapture {
 		case constants.EndpointPromQuery:
 			capture.rangeQ = append(capture.rangeQ, payload.Query)
 			capture.rangeMDP = append(capture.rangeMDP, payload.MaxDataPoints)
+			capture.rangeStep = append(capture.rangeStep, payload.Step)
 		case constants.EndpointPromQueryInstant:
 			capture.instantQ = append(capture.instantQ, payload.Query)
 		}
@@ -84,19 +96,46 @@ func runPerfDetailsCapture(t *testing.T) *perfDetailsCapture {
 }
 
 // ENG-1823: step and selector must move together. Every range sub-query asks
-// the server to size its selector from the step it chose.
+// the server to size its selector from the step it chose. Two builders
+// (availability, error_percent) carry two $__rate_interval occurrences each,
+// so a strings.Contains check alone could hide a regression in one selector
+// behind the other's surviving occurrence — count total occurrences instead.
 func TestPerfDetails_AllRangeQueriesUseRateInterval(t *testing.T) {
 	rangeQ, _, _ := runPerfDetailsCapture(t).snapshot()
 
 	if len(rangeQ) != 6 {
 		t.Fatalf("expected 6 range sub-queries, got %d", len(rangeQ))
 	}
+
+	// apdex 1, response_times 1, availability 2, throughput 1, error_rate 1,
+	// error_percent 2 = 8 total across the six queries.
+	const wantTotalRateIntervals = 8
+	total := 0
 	for _, q := range rangeQ {
-		if !strings.Contains(q, "$__rate_interval") {
-			t.Errorf("range query has no $__rate_interval; a widened step would outgrow its selector:\n%s", q)
-		}
+		total += strings.Count(q, "$__rate_interval")
 		if m := hardcodedSelector.FindString(q); m != "" {
 			t.Errorf("range query carries a hardcoded selector %s; it must be sized from the step:\n%s", m, q)
+		}
+	}
+	if total != wantTotalRateIntervals {
+		t.Errorf("$__rate_interval occurrences across all range queries = %d, want %d", total, wantTotalRateIntervals)
+	}
+}
+
+// ENG-1823: PromResolution{Step: ...} would send an absolute step against a
+// hardcoded selector and go unnoticed by a max_data_points-only check. Assert
+// no range sub-query sends a "step" value.
+func TestPerfDetails_RangeQueriesSendNoStep(t *testing.T) {
+	capture := runPerfDetailsCapture(t)
+	rangeQ, _, _ := capture.snapshot()
+	steps := capture.snapshotSteps()
+
+	if len(steps) != len(rangeQ) {
+		t.Fatalf("captured %d queries but %d step values", len(rangeQ), len(steps))
+	}
+	for i, step := range steps {
+		if step != 0 {
+			t.Errorf("range query %d sent step = %d, want 0 (absent):\n%s", i, step, rangeQ[i])
 		}
 	}
 }

--- a/internal/apm/service_performance_details_resolution_test.go
+++ b/internal/apm/service_performance_details_resolution_test.go
@@ -103,9 +103,10 @@ func TestPerfDetails_AllRangeQueriesUseRateInterval(t *testing.T) {
 		t.Fatalf("expected 6 range sub-queries, got %d", len(rangeQ))
 	}
 
-	// apdex 1, response_times 1, availability 2, throughput 1, error_rate 1,
-	// error_percent 2 = 8 total across the six queries.
-	const wantTotalRateIntervals = 8
+	// response_times 1, availability 2, throughput 1, error_rate 1,
+	// error_percent 2 = 7. Apdex is a bare gauge and carries none: VM sizes a
+	// bare selector's lookback from the step, so it needs no selector.
+	const wantTotalRateIntervals = 7
 	total := 0
 	for _, q := range rangeQ {
 		total += strings.Count(q, "$__rate_interval")
@@ -132,29 +133,6 @@ func TestPerfDetails_RangeQueriesSendNoStep(t *testing.T) {
 		if step != 0 {
 			t.Errorf("range query %d sent step = %d, want 0 (absent):\n%s", i, step, rangeQ[i])
 		}
-	}
-}
-
-// Apdex is a bare gauge: without a rollup wrapper a widened step reads almost
-// nothing, regardless of what the selector says.
-func TestPerfDetails_ApdexIsWrappedInRollup(t *testing.T) {
-	rangeQ, _, _ := runPerfDetailsCapture(t).snapshot()
-
-	var apdex string
-	for _, q := range rangeQ {
-		if strings.Contains(q, "trace_service_apdex_score") {
-			apdex = q
-			break
-		}
-	}
-	if apdex == "" {
-		t.Fatal("no apdex sub-query was sent")
-	}
-	if !strings.Contains(apdex, "avg_over_time(") {
-		t.Errorf("apdex is still a bare selector; a widened step drops most of its points:\n%s", apdex)
-	}
-	if !strings.Contains(apdex, "$__rate_interval") {
-		t.Errorf("apdex rollup window is not sized from the step:\n%s", apdex)
 	}
 }
 

--- a/internal/apm/service_performance_details_resolution_test.go
+++ b/internal/apm/service_performance_details_resolution_test.go
@@ -17,10 +17,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// hardcodedSelector matches any literal PromQL duration selector, including
-// compound (e.g. [1h30m]) and fractional (e.g. [1.5h]) durations — a
-// regression to a different hardcoded duration would slip past a check for
-// "[5m]" alone.
+// Matches any literal duration selector, incl. compound ([1h30m]) and
+// fractional ([1.5h]) — a check for "[5m]" alone would miss those.
 var hardcodedSelector = regexp.MustCompile(`\[[\d.]+[a-z]+(\d+[a-z]+)*\]`)
 
 // perfDetailsCapture records the PromQL and resolution of every sub-query the
@@ -95,11 +93,9 @@ func runPerfDetailsCapture(t *testing.T) *perfDetailsCapture {
 	return capture
 }
 
-// ENG-1823: step and selector must move together. Every range sub-query asks
-// the server to size its selector from the step it chose. Two builders
-// (availability, error_percent) carry two $__rate_interval occurrences each,
-// so a strings.Contains check alone could hide a regression in one selector
-// behind the other's surviving occurrence — count total occurrences instead.
+// Counting occurrences, not Contains: availability and error_percent carry
+// two selectors each, so one regressing could hide behind the other's
+// surviving occurrence.
 func TestPerfDetails_AllRangeQueriesUseRateInterval(t *testing.T) {
 	rangeQ, _, _ := runPerfDetailsCapture(t).snapshot()
 
@@ -122,9 +118,8 @@ func TestPerfDetails_AllRangeQueriesUseRateInterval(t *testing.T) {
 	}
 }
 
-// ENG-1823: PromResolution{Step: ...} would send an absolute step against a
-// hardcoded selector and go unnoticed by a max_data_points-only check. Assert
-// no range sub-query sends a "step" value.
+// A Step would be absolute, outgrowing a hardcoded selector, and would go
+// unnoticed by a max_data_points-only check.
 func TestPerfDetails_RangeQueriesSendNoStep(t *testing.T) {
 	capture := runPerfDetailsCapture(t)
 	rangeQ, _, _ := capture.snapshot()
@@ -179,8 +174,8 @@ func TestPerfDetails_TopKQueriesKeepChunkWidthSelector(t *testing.T) {
 	}
 }
 
-// ENG-1823 / ENG-1826: 50,401 points per series over 35 days becomes ~200.
-// Safe only because Task 2 made every selector track the step.
+// 50,401 points per series over 35 days becomes ~200. Safe only because
+// every range selector is sized from the resulting step.
 func TestPerfDetails_RangeQueriesSendPointBudget(t *testing.T) {
 	rangeQ, _, rangeMDP := runPerfDetailsCapture(t).snapshot()
 

--- a/internal/apm/service_performance_details_resolution_test.go
+++ b/internal/apm/service_performance_details_resolution_test.go
@@ -139,3 +139,65 @@ func TestPerfDetails_TopKQueriesKeepChunkWidthSelector(t *testing.T) {
 		}
 	}
 }
+
+// ENG-1823 / ENG-1826: 50,401 points per series over 35 days becomes ~200.
+// Safe only because Task 2 made every selector track the step.
+func TestPerfDetails_RangeQueriesSendPointBudget(t *testing.T) {
+	rangeQ, _, rangeMDP := runPerfDetailsCapture(t).snapshot()
+
+	if len(rangeMDP) != len(rangeQ) {
+		t.Fatalf("captured %d queries but %d budgets", len(rangeQ), len(rangeMDP))
+	}
+	if len(rangeMDP) != 6 {
+		t.Fatalf("expected 6 range sub-queries, got %d", len(rangeMDP))
+	}
+	for i, mdp := range rangeMDP {
+		if mdp != perfDetailsMaxDataPoints {
+			t.Errorf("range query %d sent max_data_points = %d, want %d:\n%s",
+				i, mdp, perfDetailsMaxDataPoints, rangeQ[i])
+		}
+	}
+}
+
+// The instant endpoint has no step, so a budget there is meaningless. Sending
+// one would also be the first step toward widening a chunk-width selector.
+func TestPerfDetails_InstantQueriesSendNoPointBudget(t *testing.T) {
+	var mu sync.Mutex
+	instantCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if r.URL.Path == constants.EndpointPromQueryInstant {
+			var raw map[string]any
+			_ = json.Unmarshal(body, &raw)
+			mu.Lock()
+			instantCount++
+			mu.Unlock()
+			// t.Errorf is goroutine-safe; t.Fatalf is not. Never Fatalf here.
+			if _, ok := raw["max_data_points"]; ok {
+				t.Errorf("instant sub-query carried max_data_points: %s", body)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+	now := time.Now().UTC()
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: now.Add(-10 * 24 * time.Hour).Format(time.RFC3339),
+		EndTimeISO:   now.Format(time.RFC3339),
+		Env:          "prod",
+	}
+	if _, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if instantCount != 3 {
+		t.Fatalf("expected 3 instant sub-queries, got %d", instantCount)
+	}
+}

--- a/internal/apm/service_performance_details_resolution_test.go
+++ b/internal/apm/service_performance_details_resolution_test.go
@@ -1,0 +1,135 @@
+package apm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"last9-mcp/internal/constants"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// perfDetailsCapture records the PromQL and resolution of every sub-query the
+// handler sends, split by endpoint.
+type perfDetailsCapture struct {
+	mu       sync.Mutex
+	rangeQ   []string
+	instantQ []string
+	rangeMDP []int64
+}
+
+func (c *perfDetailsCapture) snapshot() ([]string, []string, []int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.rangeQ...),
+		append([]string(nil), c.instantQ...),
+		append([]int64(nil), c.rangeMDP...)
+}
+
+// runPerfDetailsCapture drives the handler over a 10-day (single-chunk) window
+// and returns every sub-query it sent.
+func runPerfDetailsCapture(t *testing.T) *perfDetailsCapture {
+	t.Helper()
+	capture := &perfDetailsCapture{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload struct {
+			Query         string `json:"query"`
+			MaxDataPoints int64  `json:"max_data_points"`
+		}
+		_ = json.Unmarshal(body, &payload)
+
+		capture.mu.Lock()
+		switch r.URL.Path {
+		case constants.EndpointPromQuery:
+			capture.rangeQ = append(capture.rangeQ, payload.Query)
+			capture.rangeMDP = append(capture.rangeMDP, payload.MaxDataPoints)
+		case constants.EndpointPromQueryInstant:
+			capture.instantQ = append(capture.instantQ, payload.Query)
+		}
+		capture.mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(server.Close)
+
+	handler := NewServicePerformanceDetailsHandler(server.Client(), perfDetailsTestConfig(server.URL))
+	now := time.Now().UTC()
+	args := ServicePerformanceDetailsArgs{
+		ServiceName:  "svc",
+		StartTimeISO: now.Add(-10 * 24 * time.Hour).Format(time.RFC3339),
+		EndTimeISO:   now.Format(time.RFC3339),
+		Env:          "prod",
+	}
+
+	if _, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args); err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	return capture
+}
+
+// ENG-1823: step and selector must move together. Every range sub-query asks
+// the server to size its selector from the step it chose.
+func TestPerfDetails_AllRangeQueriesUseRateInterval(t *testing.T) {
+	rangeQ, _, _ := runPerfDetailsCapture(t).snapshot()
+
+	if len(rangeQ) != 6 {
+		t.Fatalf("expected 6 range sub-queries, got %d", len(rangeQ))
+	}
+	for _, q := range rangeQ {
+		if !strings.Contains(q, "$__rate_interval") {
+			t.Errorf("range query has no $__rate_interval; a widened step would outgrow its selector:\n%s", q)
+		}
+		if strings.Contains(q, "[5m]") {
+			t.Errorf("range query still carries the hardcoded [5m] selector:\n%s", q)
+		}
+	}
+}
+
+// Apdex is a bare gauge: without a rollup wrapper a widened step reads almost
+// nothing, regardless of what the selector says.
+func TestPerfDetails_ApdexIsWrappedInRollup(t *testing.T) {
+	rangeQ, _, _ := runPerfDetailsCapture(t).snapshot()
+
+	var apdex string
+	for _, q := range rangeQ {
+		if strings.Contains(q, "trace_service_apdex_score") {
+			apdex = q
+			break
+		}
+	}
+	if apdex == "" {
+		t.Fatal("no apdex sub-query was sent")
+	}
+	if !strings.Contains(apdex, "avg_over_time(") {
+		t.Errorf("apdex is still a bare selector; a widened step drops most of its points:\n%s", apdex)
+	}
+	if !strings.Contains(apdex, "$__rate_interval") {
+		t.Errorf("apdex rollup window is not sized from the step:\n%s", apdex)
+	}
+}
+
+// The three top-k sub-queries are instant queries whose selector IS the chunk
+// width. $__rate_interval is meaningless there and the server does not
+// substitute it on the instant endpoint.
+func TestPerfDetails_TopKQueriesKeepChunkWidthSelector(t *testing.T) {
+	_, instantQ, _ := runPerfDetailsCapture(t).snapshot()
+
+	if len(instantQ) != 3 {
+		t.Fatalf("expected 3 instant sub-queries, got %d", len(instantQ))
+	}
+	for _, q := range instantQ {
+		if strings.Contains(q, "$__rate_interval") {
+			t.Errorf("instant query carries $__rate_interval; the instant endpoint does not substitute it:\n%s", q)
+		}
+	}
+}

--- a/internal/apm/service_performance_details_resolution_test.go
+++ b/internal/apm/service_performance_details_resolution_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"sync"
 	"testing"
@@ -15,6 +16,11 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// hardcodedSelector matches any literal PromQL duration selector (e.g.
+// [5m], [1h]) — a regression to a different hardcoded duration would slip
+// past a check for "[5m]" alone.
+var hardcodedSelector = regexp.MustCompile(`\[\d+[smhdwy]\]`)
 
 // perfDetailsCapture records the PromQL and resolution of every sub-query the
 // handler sends, split by endpoint.
@@ -89,8 +95,8 @@ func TestPerfDetails_AllRangeQueriesUseRateInterval(t *testing.T) {
 		if !strings.Contains(q, "$__rate_interval") {
 			t.Errorf("range query has no $__rate_interval; a widened step would outgrow its selector:\n%s", q)
 		}
-		if strings.Contains(q, "[5m]") {
-			t.Errorf("range query still carries the hardcoded [5m] selector:\n%s", q)
+		if m := hardcodedSelector.FindString(q); m != "" {
+			t.Errorf("range query carries a hardcoded selector %s; it must be sized from the step:\n%s", m, q)
 		}
 	}
 }

--- a/internal/apm/service_performance_details_window_test.go
+++ b/internal/apm/service_performance_details_window_test.go
@@ -693,7 +693,7 @@ func TestServicePerformanceDetails_366DaysPlus1Second_Rejected(t *testing.T) {
 
 // --- gap 3: PromQL query-string construction correctness ---
 
-func TestServicePerformanceDetails_QueryStrings_SingleChunkUses5mInnerSelector(t *testing.T) {
+func TestServicePerformanceDetails_QueryStrings_SingleChunkUsesRateInterval(t *testing.T) {
 	var mu sync.Mutex
 	var queries []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -732,8 +732,8 @@ func TestServicePerformanceDetails_QueryStrings_SingleChunkUses5mInnerSelector(t
 			continue
 		}
 		throughputQueries++
-		if !strings.Contains(q, "[5m]") {
-			t.Errorf("expected throughput query to use the fixed 5m inner selector, got: %s", q)
+		if !strings.Contains(q, "$__rate_interval") {
+			t.Errorf("expected throughput query to size its selector from the step, got: %s", q)
 		}
 		if strings.Contains(q, "[240h]") {
 			t.Errorf("throughput query still uses the full outer window as inner selector: %s", q)
@@ -744,7 +744,7 @@ func TestServicePerformanceDetails_QueryStrings_SingleChunkUses5mInnerSelector(t
 	}
 }
 
-func TestServicePerformanceDetails_QueryStrings_ChunkedUsesFixed5mRangeAndChunkWidthTopK(t *testing.T) {
+func TestServicePerformanceDetails_QueryStrings_ChunkedUsesRateIntervalAndChunkWidthTopK(t *testing.T) {
 	now := time.Now().UTC()
 	start := now.Add(-90 * 24 * time.Hour).Unix() // 90 days -> 3 chunks (35+35+20)
 	end := now.Unix()
@@ -798,8 +798,8 @@ func TestServicePerformanceDetails_QueryStrings_ChunkedUsesFixed5mRangeAndChunkW
 		t.Fatalf("expected 3 throughput range queries (one per chunk), got %d", len(rangeQueries))
 	}
 	for _, q := range rangeQueries {
-		if !strings.Contains(q, "[5m]") {
-			t.Errorf("expected chunked range query to still use the fixed 5m inner selector, got: %s", q)
+		if !strings.Contains(q, "$__rate_interval") {
+			t.Errorf("expected chunked range query to size its selector from the step, got: %s", q)
 		}
 	}
 

--- a/internal/apm/service_performance_details_window_test.go
+++ b/internal/apm/service_performance_details_window_test.go
@@ -746,7 +746,7 @@ func TestServicePerformanceDetails_QueryStrings_SingleChunkUsesRateInterval(t *t
 
 func TestServicePerformanceDetails_QueryStrings_ChunkedUsesRateIntervalAndChunkWidthTopK(t *testing.T) {
 	now := time.Now().UTC()
-	start := now.Add(-90 * 24 * time.Hour).Unix() // 90 days -> 3 chunks (35+35+20)
+	start := now.Add(-90 * 24 * time.Hour).Unix() // 90 days -> 3 equal-width chunks of 30 days
 	end := now.Unix()
 	wantChunks := splitIntoPerfDetailsChunks(start, end)
 	if len(wantChunks) != 3 {
@@ -759,12 +759,14 @@ func TestServicePerformanceDetails_QueryStrings_ChunkedUsesRateIntervalAndChunkW
 
 	var mu sync.Mutex
 	var rangeQueries []string
+	var rangeBudgets []int64
 	var topRTEntries []string // "<timestamp>|<query>"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		var payload struct {
-			Query     string `json:"query"`
-			Timestamp int64  `json:"timestamp"`
+			Query         string `json:"query"`
+			Timestamp     int64  `json:"timestamp"`
+			MaxDataPoints int64  `json:"max_data_points"`
 		}
 		_ = json.Unmarshal(body, &payload)
 
@@ -772,6 +774,7 @@ func TestServicePerformanceDetails_QueryStrings_ChunkedUsesRateIntervalAndChunkW
 		switch {
 		case r.URL.Path == constants.EndpointPromQuery && strings.Contains(payload.Query, "sum by (http_status_code)(rate("):
 			rangeQueries = append(rangeQueries, payload.Query)
+			rangeBudgets = append(rangeBudgets, payload.MaxDataPoints)
 		case r.URL.Path == constants.EndpointPromQueryInstant && strings.Contains(payload.Query, "trace_endpoint_duration"):
 			topRTEntries = append(topRTEntries, fmt.Sprintf("%d|%s", payload.Timestamp, payload.Query))
 		}
@@ -800,6 +803,20 @@ func TestServicePerformanceDetails_QueryStrings_ChunkedUsesRateIntervalAndChunkW
 	for _, q := range rangeQueries {
 		if !strings.Contains(q, "$__rate_interval") {
 			t.Errorf("expected chunked range query to size its selector from the step, got: %s", q)
+		}
+	}
+
+	// The budget is per chunk, not per merged series: mergeChunkedSeries
+	// concatenates, so this window returns ~200*3 points, not ~200. Deliberate
+	// - the payload is still bounded and each chunk keeps one grid - but it is
+	// the documented contract, so pin it here rather than leaving it implied by
+	// the single-chunk test.
+	if len(rangeBudgets) != len(rangeQueries) {
+		t.Fatalf("captured %d queries but %d budgets", len(rangeQueries), len(rangeBudgets))
+	}
+	for i, b := range rangeBudgets {
+		if b != perfDetailsMaxDataPoints {
+			t.Errorf("chunk %d sent max_data_points = %d, want %d (full budget per chunk)", i, b, perfDetailsMaxDataPoints)
 		}
 	}
 
@@ -834,7 +851,7 @@ func TestServicePerformanceDetails_QueryStrings_ChunkedUsesRateIntervalAndChunkW
 
 func TestServicePerformanceDetails_MultiChunkTopKMergeAtHandlerLevel(t *testing.T) {
 	now := time.Now().UTC()
-	start := now.Add(-90 * 24 * time.Hour).Unix() // 90 days -> 3 chunks (35+35+20)
+	start := now.Add(-90 * 24 * time.Hour).Unix() // 90 days -> 3 equal-width chunks of 30 days
 	end := now.Unix()
 	wantChunks := splitIntoPerfDetailsChunks(start, end)
 	if len(wantChunks) != 3 {

--- a/internal/change_events/change_events.go
+++ b/internal/change_events/change_events.go
@@ -73,7 +73,7 @@ func NewGetChangeEventsHandler(client *http.Client, cfg models.Config) func(cont
 		promql := buildChangeEventsPromQL(args.ServiceName, args.Env, args.EventName)
 
 		// Make range query to get change events over time
-		resp, err := utils.MakePromRangeAPIQuery(ctx, client, promql, startTimeParam, endTimeParam, cfg)
+		resp, err := utils.MakePromRangeAPIQuery(ctx, client, promql, startTimeParam, endTimeParam, cfg, utils.PromResolution{})
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to query change events: %w", err)
 		}

--- a/internal/change_events/change_events_time_test.go
+++ b/internal/change_events/change_events_time_test.go
@@ -56,6 +56,7 @@ func TestGetChangeEventsHandler_ExplicitRangePrecedence(t *testing.T) {
 		Window    int64 `json:"window"`
 	}
 	captured := make([]promReq, 0, 2)
+	var capturedRaw []map[string]interface{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -64,6 +65,10 @@ func TestGetChangeEventsHandler_ExplicitRangePrecedence(t *testing.T) {
 		var reqBody promReq
 		_ = json.Unmarshal(body, &reqBody)
 		captured = append(captured, reqBody)
+
+		var raw map[string]interface{}
+		_ = json.Unmarshal(body, &raw)
+		capturedRaw = append(capturedRaw, raw)
 
 		w.Header().Set(constants.HeaderContentType, constants.HeaderContentTypeJSON)
 		switch r.URL.Path {
@@ -107,6 +112,18 @@ func TestGetChangeEventsHandler_ExplicitRangePrecedence(t *testing.T) {
 		}
 		if req.Window != 3600 {
 			t.Fatalf("window = %d, want %d", req.Window, int64(3600))
+		}
+	}
+
+	// get_change_events must keep using the zero-value legacy helper: this
+	// query has no range-vector selector at all, so a widened step here
+	// would silently drop events.
+	for _, raw := range capturedRaw {
+		if _, ok := raw["step"]; ok {
+			t.Fatalf("range query body must not send \"step\", got: %v", raw)
+		}
+		if _, ok := raw["max_data_points"]; ok {
+			t.Fatalf("range query body must not send \"max_data_points\", got: %v", raw)
 		}
 	}
 }

--- a/internal/change_events/change_events_time_test.go
+++ b/internal/change_events/change_events_time_test.go
@@ -56,7 +56,6 @@ func TestGetChangeEventsHandler_ExplicitRangePrecedence(t *testing.T) {
 		Window    int64 `json:"window"`
 	}
 	captured := make([]promReq, 0, 2)
-	var capturedRaw []map[string]interface{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -65,10 +64,6 @@ func TestGetChangeEventsHandler_ExplicitRangePrecedence(t *testing.T) {
 		var reqBody promReq
 		_ = json.Unmarshal(body, &reqBody)
 		captured = append(captured, reqBody)
-
-		var raw map[string]interface{}
-		_ = json.Unmarshal(body, &raw)
-		capturedRaw = append(capturedRaw, raw)
 
 		w.Header().Set(constants.HeaderContentType, constants.HeaderContentTypeJSON)
 		switch r.URL.Path {
@@ -112,18 +107,6 @@ func TestGetChangeEventsHandler_ExplicitRangePrecedence(t *testing.T) {
 		}
 		if req.Window != 3600 {
 			t.Fatalf("window = %d, want %d", req.Window, int64(3600))
-		}
-	}
-
-	// get_change_events must keep using the zero-value legacy helper: this
-	// query has no range-vector selector at all, so a widened step here
-	// would silently drop events.
-	for _, raw := range capturedRaw {
-		if _, ok := raw["step"]; ok {
-			t.Fatalf("range query body must not send \"step\", got: %v", raw)
-		}
-		if _, ok := raw["max_data_points"]; ok {
-			t.Fatalf("range query body must not send \"max_data_points\", got: %v", raw)
 		}
 	}
 }

--- a/internal/prompts/descriptions/get_service_performance_details.md
+++ b/internal/prompts/descriptions/get_service_performance_details.md
@@ -10,7 +10,7 @@ Many metric fields use PromQL timeseries format: `[{"metric":{...},"values":[[ti
 
 Windows over 35 days are split into 35-day-or-narrower chunks queried and merged separately (the backend hard-caps a single query's range at 35 days); the requested window is hard-capped at 366 days total. On a wider (chunked) window, any sub-query failure is recorded in `partial_errors` and the rest of the data is still returned. On a plain (<=35 day) window, a non-2xx upstream response is likewise recorded in `partial_errors`; a read/parse failure on the response fails the whole call.
 
-Counter-style fields (throughput, error rate) carry explicit zero values for intervals with no traffic, so a low-traffic service shows zeros rather than missing points. Each series is capped at about 200 points per chunk, so a wide window comes back as wide buckets rather than a dense per-minute grid — expect most buckets on a wide window to carry data. Quantile-style fields (response times) only cover intervals that actually had samples, so they can span far less than the requested window.
+Counter-style fields (throughput, error rate) carry explicit zero values for intervals with no traffic, so a low-traffic service shows zeros rather than missing points. Each series is capped at about 200 points per chunk, so a wide window returns wide buckets, not a dense per-minute grid — expect most buckets to carry data. Quantile-style fields (response times) only cover intervals that actually had samples, so they can span far less than the requested window.
 
 Parameters:
 - `service_name`: (Required) Service to query.

--- a/internal/prompts/descriptions/get_service_performance_details.md
+++ b/internal/prompts/descriptions/get_service_performance_details.md
@@ -10,7 +10,7 @@ Many metric fields use PromQL timeseries format: `[{"metric":{...},"values":[[ti
 
 Windows over 35 days are split into 35-day-or-narrower chunks queried and merged separately (the backend hard-caps a single query's range at 35 days); the requested window is hard-capped at 366 days total. On a wider (chunked) window, any sub-query failure is recorded in `partial_errors` and the rest of the data is still returned. On a plain (<=35 day) window, a non-2xx upstream response is likewise recorded in `partial_errors`; a read/parse failure on the response fails the whole call.
 
-On a wide window, counter-style fields (throughput, error rate) are returned on a dense time grid with explicit zero values for intervals that had no traffic — a low-traffic service shows long runs of zeros rather than missing points, and a low proportion of non-zero points is normal, not an error. Quantile-style fields (response times) only cover intervals that actually had samples, so they can span far less than the requested window.
+Counter-style fields (throughput, error rate) carry explicit zero values for intervals with no traffic, so a low-traffic service shows zeros rather than missing points. Each series is capped at about 200 points per chunk, so a wide window comes back as wide buckets rather than a dense per-minute grid — expect most buckets on a wide window to carry data. Quantile-style fields (response times) only cover intervals that actually had samples, so they can span far less than the requested window.
 
 Parameters:
 - `service_name`: (Required) Service to query.

--- a/internal/utils/promql_request_test.go
+++ b/internal/utils/promql_request_test.go
@@ -146,3 +146,100 @@ func TestMakePromLabelsAPIQuery_AnchorsOnEndTime(t *testing.T) {
 
 	assertRightAnchored(t, decodeBody(t, captured))
 }
+
+// ENG-1823: the resolution fields are opt-in. get_change_events (bare
+// selector) and promql_range_query (arbitrary caller PromQL) keep calling the
+// legacy function, and a widened step against their selectors would
+// spot-sample instead of aggregate. Absence on the default path is the
+// contract that protects them.
+func TestMakePromRangeAPIQuery_OmitsResolutionFieldsByDefault(t *testing.T) {
+	var captured []byte
+	srv := newCapturingServer(t, &captured)
+	defer srv.Close()
+
+	cfg := stubTokenManagerCfg(t, srv.URL)
+	resp, err := MakePromRangeAPIQuery(
+		context.Background(), srv.Client(), "up", testStartUnix, testEndUnix, cfg,
+	)
+	if err != nil {
+		t.Fatalf("MakePromRangeAPIQuery: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body := decodeBody(t, captured)
+	if _, ok := body["step"]; ok {
+		t.Error("step present on the default path; callers with hardcoded selectors rely on its absence")
+	}
+	if _, ok := body["max_data_points"]; ok {
+		t.Error("max_data_points present on the default path; a widened step would outgrow their selectors")
+	}
+}
+
+func TestMakePromRangeAPIQueryWithResolution_SendsBudgetAndStep(t *testing.T) {
+	var captured []byte
+	srv := newCapturingServer(t, &captured)
+	defer srv.Close()
+
+	cfg := stubTokenManagerCfg(t, srv.URL)
+	resp, err := MakePromRangeAPIQueryWithResolution(
+		context.Background(), srv.Client(), "up", testStartUnix, testEndUnix, cfg,
+		PromResolution{Step: 30, MaxDataPoints: 200},
+	)
+	if err != nil {
+		t.Fatalf("MakePromRangeAPIQueryWithResolution: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body := decodeBody(t, captured)
+
+	mdp, ok := body["max_data_points"].(float64)
+	if !ok {
+		t.Fatalf("max_data_points missing or wrong type: %v", body["max_data_points"])
+	}
+	if int64(mdp) != 200 {
+		t.Errorf("max_data_points = %d, want 200", int64(mdp))
+	}
+
+	step, ok := body["step"].(float64)
+	if !ok {
+		t.Fatalf("step missing or wrong type: %v", body["step"])
+	}
+	if int64(step) != 30 {
+		t.Errorf("step = %d, want 30", int64(step))
+	}
+
+	// Resolution must not disturb the right-anchored window contract.
+	assertRightAnchored(t, body)
+}
+
+// A zero PromResolution must be byte-identical to the legacy call, so the two
+// untouched callers cannot drift.
+func TestMakePromRangeAPIQueryWithResolution_ZeroValueMatchesLegacyBody(t *testing.T) {
+	var legacyBody, zeroBody []byte
+
+	legacySrv := newCapturingServer(t, &legacyBody)
+	defer legacySrv.Close()
+	legacyResp, err := MakePromRangeAPIQuery(
+		context.Background(), legacySrv.Client(), "up", testStartUnix, testEndUnix,
+		stubTokenManagerCfg(t, legacySrv.URL),
+	)
+	if err != nil {
+		t.Fatalf("legacy call: %v", err)
+	}
+	legacyResp.Body.Close()
+
+	zeroSrv := newCapturingServer(t, &zeroBody)
+	defer zeroSrv.Close()
+	zeroResp, err := MakePromRangeAPIQueryWithResolution(
+		context.Background(), zeroSrv.Client(), "up", testStartUnix, testEndUnix,
+		stubTokenManagerCfg(t, zeroSrv.URL), PromResolution{},
+	)
+	if err != nil {
+		t.Fatalf("zero-resolution call: %v", err)
+	}
+	zeroResp.Body.Close()
+
+	if !bytes.Equal(legacyBody, zeroBody) {
+		t.Errorf("bodies differ:\n legacy = %s\n zero   = %s", legacyBody, zeroBody)
+	}
+}

--- a/internal/utils/promql_request_test.go
+++ b/internal/utils/promql_request_test.go
@@ -102,6 +102,7 @@ func TestMakePromRangeAPIQuery_AnchorsOnEndTime(t *testing.T) {
 	cfg := stubTokenManagerCfg(t, srv.URL)
 	resp, err := MakePromRangeAPIQuery(
 		context.Background(), srv.Client(), "up", testStartUnix, testEndUnix, cfg,
+		PromResolution{},
 	)
 	if err != nil {
 		t.Fatalf("MakePromRangeAPIQuery: %v", err)
@@ -147,11 +148,8 @@ func TestMakePromLabelsAPIQuery_AnchorsOnEndTime(t *testing.T) {
 	assertRightAnchored(t, decodeBody(t, captured))
 }
 
-// ENG-1823: the resolution fields are opt-in. get_change_events (bare
-// selector) and promql_range_query (arbitrary caller PromQL) keep calling the
-// legacy function, and a widened step against their selectors would
-// spot-sample instead of aggregate. Absence on the default path is the
-// contract that protects them.
+// The resolution fields are opt-in — a zero PromResolution must put neither
+// on the wire, which is what callers with fixed selectors rely on.
 func TestMakePromRangeAPIQuery_OmitsResolutionFieldsByDefault(t *testing.T) {
 	var captured []byte
 	srv := newCapturingServer(t, &captured)
@@ -160,6 +158,7 @@ func TestMakePromRangeAPIQuery_OmitsResolutionFieldsByDefault(t *testing.T) {
 	cfg := stubTokenManagerCfg(t, srv.URL)
 	resp, err := MakePromRangeAPIQuery(
 		context.Background(), srv.Client(), "up", testStartUnix, testEndUnix, cfg,
+		PromResolution{},
 	)
 	if err != nil {
 		t.Fatalf("MakePromRangeAPIQuery: %v", err)
@@ -175,18 +174,18 @@ func TestMakePromRangeAPIQuery_OmitsResolutionFieldsByDefault(t *testing.T) {
 	}
 }
 
-func TestMakePromRangeAPIQueryWithResolution_SendsBudgetAndStep(t *testing.T) {
+func TestMakePromRangeAPIQuery_SendsBudgetAndStep(t *testing.T) {
 	var captured []byte
 	srv := newCapturingServer(t, &captured)
 	defer srv.Close()
 
 	cfg := stubTokenManagerCfg(t, srv.URL)
-	resp, err := MakePromRangeAPIQueryWithResolution(
+	resp, err := MakePromRangeAPIQuery(
 		context.Background(), srv.Client(), "up", testStartUnix, testEndUnix, cfg,
 		PromResolution{Step: 30, MaxDataPoints: 200},
 	)
 	if err != nil {
-		t.Fatalf("MakePromRangeAPIQueryWithResolution: %v", err)
+		t.Fatalf("MakePromRangeAPIQuery: %v", err)
 	}
 	defer resp.Body.Close()
 
@@ -210,36 +209,4 @@ func TestMakePromRangeAPIQueryWithResolution_SendsBudgetAndStep(t *testing.T) {
 
 	// Resolution must not disturb the right-anchored window contract.
 	assertRightAnchored(t, body)
-}
-
-// A zero PromResolution must be byte-identical to the legacy call, so the two
-// untouched callers cannot drift.
-func TestMakePromRangeAPIQueryWithResolution_ZeroValueMatchesLegacyBody(t *testing.T) {
-	var legacyBody, zeroBody []byte
-
-	legacySrv := newCapturingServer(t, &legacyBody)
-	defer legacySrv.Close()
-	legacyResp, err := MakePromRangeAPIQuery(
-		context.Background(), legacySrv.Client(), "up", testStartUnix, testEndUnix,
-		stubTokenManagerCfg(t, legacySrv.URL),
-	)
-	if err != nil {
-		t.Fatalf("legacy call: %v", err)
-	}
-	legacyResp.Body.Close()
-
-	zeroSrv := newCapturingServer(t, &zeroBody)
-	defer zeroSrv.Close()
-	zeroResp, err := MakePromRangeAPIQueryWithResolution(
-		context.Background(), zeroSrv.Client(), "up", testStartUnix, testEndUnix,
-		stubTokenManagerCfg(t, zeroSrv.URL), PromResolution{},
-	)
-	if err != nil {
-		t.Fatalf("zero-resolution call: %v", err)
-	}
-	zeroResp.Body.Close()
-
-	if !bytes.Equal(legacyBody, zeroBody) {
-		t.Errorf("bodies differ:\n legacy = %s\n zero   = %s", legacyBody, zeroBody)
-	}
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -154,6 +154,11 @@ func MakePromInstantAPIQuery(ctx context.Context, client *http.Client, promql st
 	return client.Do(req)
 }
 
+// PromResolution is an opt-in resolution hint; the zero value sends neither
+// field and leaves the step to the backend. Set one or the other: Step pins an
+// absolute step, MaxDataPoints caps points per series and lets the backend
+// size the step (a cap, not a target — it only binds once the default step
+// would exceed it). Sending both is untested.
 type PromResolution struct {
 	Step          int64
 	MaxDataPoints int64

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -157,9 +157,11 @@ func MakePromInstantAPIQuery(ctx context.Context, client *http.Client, promql st
 // PromResolution bounds a range query's output resolution. The zero value
 // sends neither field, leaving the server's defaults untouched.
 //
-// Only set MaxDataPoints on a query that asks for its selector via
-// $__rate_interval: the server sizes both from the same budget, so they move
-// together. A widened step against a hardcoded selector spot-samples.
+// Set neither field on a query with a hardcoded or absent range selector: a
+// widened budget and an absolute Step both leave the step outgrowing the
+// selector, which spot-samples instead of aggregating. Only set them on a
+// query that asks for its selector via $__rate_interval, which the server
+// sizes from the same step.
 type PromResolution struct {
 	Step          int64
 	MaxDataPoints int64

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -154,26 +154,15 @@ func MakePromInstantAPIQuery(ctx context.Context, client *http.Client, promql st
 	return client.Do(req)
 }
 
-// PromResolution bounds a range query's output resolution. The zero value
-// sends neither field, leaving the server's defaults untouched.
-//
-// Set neither field on a query with a hardcoded or absent range selector: a
-// widened budget and an absolute Step both leave the step outgrowing the
-// selector, which spot-samples instead of aggregating. Only set them on a
-// query that asks for its selector via $__rate_interval, which the server
-// sizes from the same step.
+// PromResolution bounds a range query's output resolution. Set either field
+// only on a query whose selector is $__rate_interval: against a hardcoded
+// selector the step outgrows it and the query spot-samples.
 type PromResolution struct {
 	Step          int64
 	MaxDataPoints int64
 }
 
-func MakePromRangeAPIQuery(ctx context.Context, client *http.Client, promql string, startTimeParam, endTimeParam int64, cfg models.Config) (*http.Response, error) {
-	return MakePromRangeAPIQueryWithResolution(
-		ctx, client, promql, startTimeParam, endTimeParam, cfg, PromResolution{},
-	)
-}
-
-func MakePromRangeAPIQueryWithResolution(ctx context.Context, client *http.Client, promql string, startTimeParam, endTimeParam int64, cfg models.Config, res PromResolution) (*http.Response, error) {
+func MakePromRangeAPIQuery(ctx context.Context, client *http.Client, promql string, startTimeParam, endTimeParam int64, cfg models.Config, res PromResolution) (*http.Response, error) {
 	// The Last9 PromQL HTTP endpoint treats `timestamp` as the END of the
 	// query window and runs Prometheus over [timestamp - window, timestamp]
 	// (this is also how MakePromInstantAPIQuery above uses endTimeParam as

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -154,26 +154,47 @@ func MakePromInstantAPIQuery(ctx context.Context, client *http.Client, promql st
 	return client.Do(req)
 }
 
+// PromResolution bounds a range query's output resolution. The zero value
+// sends neither field, leaving the server's defaults untouched.
+//
+// Only set MaxDataPoints on a query that asks for its selector via
+// $__rate_interval: the server sizes both from the same budget, so they move
+// together. A widened step against a hardcoded selector spot-samples.
+type PromResolution struct {
+	Step          int64
+	MaxDataPoints int64
+}
+
 func MakePromRangeAPIQuery(ctx context.Context, client *http.Client, promql string, startTimeParam, endTimeParam int64, cfg models.Config) (*http.Response, error) {
+	return MakePromRangeAPIQueryWithResolution(
+		ctx, client, promql, startTimeParam, endTimeParam, cfg, PromResolution{},
+	)
+}
+
+func MakePromRangeAPIQueryWithResolution(ctx context.Context, client *http.Client, promql string, startTimeParam, endTimeParam int64, cfg models.Config, res PromResolution) (*http.Response, error) {
 	// The Last9 PromQL HTTP endpoint treats `timestamp` as the END of the
 	// query window and runs Prometheus over [timestamp - window, timestamp]
 	// (this is also how MakePromInstantAPIQuery above uses endTimeParam as
 	// `timestamp`). Anchoring on startTimeParam shifts every range query
 	// backwards by exactly one window length.
 	promRangeParam := struct {
-		Query     string `json:"query"`
-		Timestamp int64  `json:"timestamp"`
-		Window    int64  `json:"window"`
-		ReadURL   string `json:"read_url"`
-		Username  string `json:"username"`
-		Password  string `json:"password"`
+		Query         string `json:"query"`
+		Timestamp     int64  `json:"timestamp"`
+		Window        int64  `json:"window"`
+		ReadURL       string `json:"read_url"`
+		Username      string `json:"username"`
+		Password      string `json:"password"`
+		Step          int64  `json:"step,omitempty"`
+		MaxDataPoints int64  `json:"max_data_points,omitempty"`
 	}{
-		Query:     promql,
-		Timestamp: endTimeParam,
-		Window:    endTimeParam - startTimeParam,
-		ReadURL:   cfg.PrometheusReadURL,
-		Username:  cfg.PrometheusUsername,
-		Password:  cfg.PrometheusPassword,
+		Query:         promql,
+		Timestamp:     endTimeParam,
+		Window:        endTimeParam - startTimeParam,
+		ReadURL:       cfg.PrometheusReadURL,
+		Username:      cfg.PrometheusUsername,
+		Password:      cfg.PrometheusPassword,
+		Step:          res.Step,
+		MaxDataPoints: res.MaxDataPoints,
 	}
 
 	bodyBytes, err := json.Marshal(promRangeParam)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -154,9 +154,6 @@ func MakePromInstantAPIQuery(ctx context.Context, client *http.Client, promql st
 	return client.Do(req)
 }
 
-// PromResolution bounds a range query's output resolution. Set either field
-// only on a query whose selector is $__rate_interval: against a hardcoded
-// selector the step outgrows it and the query spot-samples.
 type PromResolution struct {
 	Step          int64
 	MaxDataPoints int64


### PR DESCRIPTION
Makes `get_service_performance_details` ask for a bounded number of points per series, and sizes each range selector from the step the server picks, so a wide window aggregates rather than spot-samples on the four `rate()`-based series.

## The problem

The 6 range sub-queries ran at a fixed 60s step with a hardcoded `[5m]` selector. Over 35 days that is 50,401 evaluation timestamps per series — a multi-megabyte response describing what a few hundred points describe just as well.

Coverage was not the issue: a 5m selector ticking every 60s sweeps the whole window with overlap. The issue is resolution. On a series with intermittent traffic most of those 50,401 points are empty, so the payload is enormous and the result reads as sparse.

## Why the step alone is not the lever

Step and range selector are independent in PromQL, and the backend never reconciles them. Widen the step past the selector and you get the same point count with the opposite correctness: clean-looking numbers computed from a fraction of the window, with nothing in the response indicating data was skipped.

The two halves are therefore not separable, and the commits land in that order — no intermediate commit has a widened step against a narrow selector.

## Note on the apdex revert (eda272f)

That commit's message says dropping the rollup wrapper leaves "identical coverage." That reasoning is wrong: `default_rollup(x[4h])` reads one sample from the bucket, `avg_over_time(x[4h])` reads all of them. Point density is the same; aggregation fidelity is not.

The revert itself stands — this is a resolution change, and preserving apdex's existing last-value semantics is the correct scope. The consequence, now stated in the changelog, is that apdex and response times get *sparser* on a wide window rather than aggregating it. The other half of that commit's reasoning — that VictoriaMetrics sizes a bare selector from the step — is correct and load-bearing.

## Testing

Unit tests assert on the outgoing request body: 5 of the 6 range queries carry `$__rate_interval` and none carries a literal duration selector; the budget reaches every range query and no top-k query; a zero resolution puts neither field on the wire. Apdex deliberately carries no selector, per the revert note above. Each builder is pinned to its own expected occurrence count rather than to a total, so a selector moving between queries is attributed rather than cancelling out.

The point budget is per chunk, not per merged series, so a window past 35 days returns proportionally more than ~200 points. Deliberate — the payload stays bounded — and now pinned by an assertion in the chunked test rather than implied by the single-chunk one.

Verified end-to-end at 1h / 3h / 24h / 7d / 35d / 90d — narrow windows unchanged, wider windows capped, the 90-day path still chunking and merging in order, no partial errors at any width. The 35-day case previously returned `422 Too many samples queried`.

The two backend behaviours this rests on were measured directly rather than assumed:

- `max_data_points` is a cap, not a target. A 1h window returns 61 points at a 60s step with and without the budget — identical. The step never drops below 60s (a 15m window gives 16 points at 60s). The cap only binds past 200 × 60s ≈ 3h20m: 109s step at 6h, 435s at 24h, 15196s at 35d.

The budget is applied **per chunk**, and `mergeChunkedSeries` concatenates, so a window wider than 35 days returns roughly 200 × chunk count points rather than ~200 total (90 days → 3 equal 30-day chunks → ~600 points). That is deliberate: the payload stays bounded, and equal-width chunks keep every chunk on one grid, which is what the boundary dedup in `mergeChunkedSeries` depends on. The changelog, the tool description and the chunked test now all state it as a per-chunk cap.
- `$__rate_interval` substitutes as `max(step + scrape, 4 × scrape)`. Measured widths: 240s at a 60s step (1h and 15m), 495s at a 435s step (24h), ~15270s at a 15196s step (35d). It is never narrower than the step, and never narrower than the scrape interval — the second floor is what keeps `rate()` on a narrow window from returning empty. `rate()` returned data at every width tested.

On a low-traffic series over 35 days, output goes from 50,401 points to 199, and the fraction of returned points that carry data rises from roughly a seventh to about two thirds. The same window is read either way; the buckets are simply wide enough to be worth plotting.

Closes ENG-1823. Also resolves ENG-1826.
