### PR TITLE
feat(dashboards): validate_dashboard MCP tool (ENG-1914)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `validate_dashboard`: read-only lint + execute + classify for a saved dashboard id or inline `dashboard_definition` over a ≤24h window. Returns `dashboard_validation/v1` (same contract as the supervisor skill). Dry run — never creates/updates dashboards. Day-1 empty results are `valid_no_data` without diagnose probes.
 - `get_alert_groups`: lists configured Compass alert groups with team, tier, metadata labels, and rule counts — including groups with zero rules and groups that are not currently firing. `get_alert_config` rule rows now also print team, tier, and labels when those fields are set.
 - `last9://reference/investigation`: an MCP resource documenting the profile-first investigation flow.
 - `get_service_profile` returns a per-service telemetry profile — signal presence, language/runtime, deployment envs, log `signal_shape`, and a recommended ingest fix — as a short brief followed by raw JSON. Call it before a service-scoped investigation to skip trace tools when traces are absent and to parse severity from the log body when `severity_set` is `none` or `partial`.

--- a/dump_test.go
+++ b/dump_test.go
@@ -33,8 +33,8 @@ func TestDumpTools(t *testing.T) {
 	// All registered tools must be covered — the whole point of dump-tools.
 	// A loose floor would let a regression silently drop tools. Tighten this
 	// when the committed snapshot + CI equality gate supersedes it.
-	if len(out.Tools) < 38 {
-		t.Fatalf("expected at least 38 tools, got %d", len(out.Tools))
+	if len(out.Tools) < 39 {
+		t.Fatalf("expected at least 39 tools, got %d", len(out.Tools))
 	}
 	if !sort.SliceIsSorted(out.Tools, func(i, j int) bool { return out.Tools[i].Name < out.Tools[j].Name }) {
 		t.Fatal("tools are not sorted by name (output must be deterministic for snapshot diffing)")
@@ -332,7 +332,7 @@ func TestDumpToolsInvestigate(t *testing.T) {
 			t.Errorf("investigate dump missing %q", want)
 		}
 	}
-	for _, deny := range []string{"get_alerts", "get_alert_groups", "list_dashboards", "create_dashboard", "add_drop_rule", "list_dashboard_snapshots"} {
+	for _, deny := range []string{"get_alerts", "get_alert_groups", "list_dashboards", "create_dashboard", "add_drop_rule", "list_dashboard_snapshots", "validate_dashboard"} {
 		if byName[deny] {
 			t.Errorf("investigate dump should exclude %q", deny)
 		}

--- a/internal/dashboards/validate_dashboard.go
+++ b/internal/dashboards/validate_dashboard.go
@@ -1,0 +1,491 @@
+package dashboards
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"last9-mcp/internal/models"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const validateDashboardMaxWindow = 24 * time.Hour
+
+var noQueryVizTypes = map[string]struct{}{
+	"section":  {},
+	"markdown": {},
+}
+
+// ValidateDashboardArgs is the MCP input for validate_dashboard.
+type ValidateDashboardArgs struct {
+	DashboardID         *string                `json:"dashboard_id,omitempty"`
+	DashboardDefinition map[string]any         `json:"dashboard_definition,omitempty"`
+	StartTimeISO        string                 `json:"start_time_iso"`
+	EndTimeISO          string                 `json:"end_time_iso"`
+	Variables           map[string]any         `json:"variables,omitempty"`
+}
+
+// GetValidateDashboardInputSchema returns the MCP-facing schema so nested
+// dashboard_definition / variables are JSON objects (not byte arrays).
+func GetValidateDashboardInputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"dashboard_id": map[string]any{
+				"type":        "string",
+				"description": "Saved dashboard UUID. Mutually exclusive with dashboard_definition.",
+			},
+			"dashboard_definition": map[string]any{
+				"type":        "object",
+				"description": "Inline dashboard object (name, panels[].queries[], variables). Mutually exclusive with dashboard_id. Dry run — nothing is persisted.",
+			},
+			"start_time_iso": map[string]any{
+				"type":        "string",
+				"description": "Window start, RFC3339 (required).",
+			},
+			"end_time_iso": map[string]any{
+				"type":        "string",
+				"description": "Window end, RFC3339 (required). Window must be <= 24h.",
+			},
+			"variables": map[string]any{
+				"type":        "object",
+				"description": "Optional variable values overriding dashboard defaults (scalars only).",
+			},
+		},
+		"required": []string{"start_time_iso", "end_time_iso"},
+	}
+}
+
+type validatedDashboardArgs struct {
+	dashboardID *string
+	definition  map[string]any
+	window      map[string]string
+	variables   map[string]any
+}
+
+func parseValidateISO(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, fmt.Errorf("empty timestamp")
+	}
+	if t, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t.UTC(), nil
+	}
+	for _, layout := range []string{
+		"2006-01-02T15:04:05.999999999",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05",
+	} {
+		if t, err := time.ParseInLocation(layout, value, time.UTC); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid timestamp")
+}
+
+func validateDashboardInput(args ValidateDashboardArgs) (*validatedDashboardArgs, []string) {
+	var errors []string
+	hasID := args.DashboardID != nil && strings.TrimSpace(*args.DashboardID) != ""
+	hasDefinition := args.DashboardDefinition != nil
+	if hasID == hasDefinition {
+		errors = append(errors, "provide exactly one of dashboard_id or dashboard_definition")
+	}
+
+	start, startErr := parseValidateISO(args.StartTimeISO)
+	if startErr != nil {
+		errors = append(errors, "start_time_iso is required (RFC3339)")
+	}
+	end, endErr := parseValidateISO(args.EndTimeISO)
+	if endErr != nil {
+		errors = append(errors, "end_time_iso is required (RFC3339)")
+	}
+	if startErr == nil && endErr == nil {
+		if !end.After(start) {
+			errors = append(errors, "end_time_iso must be after start_time_iso")
+		} else if end.Sub(start) > validateDashboardMaxWindow {
+			errors = append(errors, "window must be 24 hours or less")
+		}
+	}
+
+	callerVars := args.Variables
+	if callerVars == nil {
+		callerVars = map[string]any{}
+	}
+	for key, value := range callerVars {
+		switch value.(type) {
+		case map[string]any, []any:
+			errors = append(errors, fmt.Sprintf("variables[%q] must be a scalar", key))
+		}
+	}
+
+	if len(errors) > 0 {
+		return nil, errors
+	}
+	out := &validatedDashboardArgs{
+		window: map[string]string{
+			"start": args.StartTimeISO,
+			"end":   args.EndTimeISO,
+		},
+		variables: callerVars,
+	}
+	if hasID {
+		id := strings.TrimSpace(*args.DashboardID)
+		out.dashboardID = &id
+	} else {
+		out.definition = args.DashboardDefinition
+	}
+	return out, nil
+}
+
+// NewValidateDashboardHandler returns the MCP tool handler for validate_dashboard.
+func NewValidateDashboardHandler(client *http.Client, cfg models.Config) func(context.Context, *mcp.CallToolRequest, ValidateDashboardArgs) (*mcp.CallToolResult, any, error) {
+	return func(ctx context.Context, _ *mcp.CallToolRequest, args ValidateDashboardArgs) (*mcp.CallToolResult, any, error) {
+		parsed, errs := validateDashboardInput(args)
+		if len(errs) > 0 {
+			return nil, nil, fmt.Errorf("%s", strings.Join(errs, "; "))
+		}
+
+		exec := &validateExecutor{client: client, cfg: cfg}
+		result := runValidateDashboard(ctx, exec, parsed)
+		body, err := json.Marshal(result)
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshal report: %w", err)
+		}
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: string(body)}},
+		}, nil, nil
+	}
+}
+
+func runValidateDashboard(ctx context.Context, exec *validateExecutor, parsed *validatedDashboardArgs) map[string]any {
+	var dashboard map[string]any
+	var source string
+	if parsed.dashboardID != nil {
+		fetched, fetchErr := exec.fetchDashboard(ctx, *parsed.dashboardID)
+		if fetchErr != "" {
+			return map[string]any{
+				"success": false,
+				"error":   "dashboard_fetch_failed",
+				"detail":  fetchErr,
+			}
+		}
+		dashboard = fetched
+		source = "saved"
+	} else {
+		dashboard = parsed.definition
+		source = "inline"
+	}
+
+	defaults := dashboardDefaults(dashboard)
+	window := parsed.window
+
+	dashboardRef := "<inline>"
+	if id, ok := dashboard["id"].(string); ok && id != "" {
+		dashboardRef = id
+	} else if parsed.dashboardID != nil {
+		dashboardRef = *parsed.dashboardID
+	}
+
+	rawPanels := dashboard["panels"]
+	var panels []any
+	switch p := rawPanels.(type) {
+	case nil:
+		panels = []any{}
+	case []any:
+		panels = p
+	case []map[string]any:
+		panels = make([]any, len(p))
+		for i, m := range p {
+			panels[i] = m
+		}
+	default:
+		return map[string]any{
+			"success": false,
+			"error":   "invalid_input",
+			"detail":  []string{"dashboard.panels must be a list"},
+		}
+	}
+
+	panelRecords := make([]map[string]any, 0, len(panels))
+	for _, raw := range panels {
+		panel, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panelRecords = append(panelRecords, panelFailureRecord(panel, fmt.Errorf("%v", r)))
+				}
+			}()
+			panelRecords = append(panelRecords, validatePanel(ctx, panel, exec, parsed.variables, defaults, window, dashboardRef))
+		}()
+	}
+
+	summary := summarize(panelRecords)
+	defaultsStr := map[string]string{}
+	for k, v := range defaults {
+		defaultsStr[k] = stringifyScalar(v)
+	}
+
+	var dashID any
+	if id, ok := dashboard["id"]; ok && id != nil && id != "" {
+		dashID = id
+	} else if parsed.dashboardID != nil {
+		dashID = *parsed.dashboardID
+	} else {
+		dashID = nil
+	}
+
+	out := map[string]any{
+		"success":        true,
+		"schema_version": schemaVersion,
+		"dashboard": map[string]any{
+			"source": source,
+			"id":     dashID,
+			"name":   dashboard["name"],
+		},
+		"window": window,
+		"variables": map[string]any{
+			"caller":             parsed.variables,
+			"dashboard_defaults": defaultsStr,
+		},
+		"summary":   summary,
+		"panels":    panelRecords,
+		"timestamp": time.Now().UTC().Format("2006-01-02T15:04:05Z"),
+	}
+
+	// Round-trip through JSON so validateReport sees []any shapes consistently.
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		return map[string]any{"success": false, "error": "internal_error", "detail": err.Error()}
+	}
+	var check map[string]any
+	if err := json.Unmarshal(encoded, &check); err != nil {
+		return map[string]any{"success": false, "error": "internal_error", "detail": err.Error()}
+	}
+	if violations := validateReport(check); len(violations) > 0 {
+		return map[string]any{
+			"success": false,
+			"error":   "internal_invalid_report",
+			"detail":  violations,
+		}
+	}
+	return check
+}
+
+func panelVizType(panel map[string]any) string {
+	viz, ok := panel["visualization"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	t, _ := viz["type"].(string)
+	return t
+}
+
+func failureTarget(index int, err error) map[string]any {
+	note := fmt.Sprintf("validator error: %T: %s", err, err.Error())
+	if len(note) > 200 {
+		note = note[:200]
+	}
+	return map[string]any{
+		"target_index": index,
+		"query_type":   "unknown",
+		"status":       "execution_error",
+		"note":         note,
+		"lint":         []any{},
+		"execution":    nil,
+		"evidence":     nil,
+		"diagnosis":    nil,
+	}
+}
+
+func panelFailureRecord(panel map[string]any, err error) map[string]any {
+	name, _ := panel["name"].(string)
+	return map[string]any{
+		"panel_id":           panel["id"],
+		"name":               name,
+		"visualization_type": panelVizType(panel),
+		"classification":     "query",
+		"targets":            []map[string]any{failureTarget(0, err)},
+	}
+}
+
+func detectQueryType(query map[string]any) string {
+	if qt, ok := query["query_type"].(string); ok {
+		if isQueryType(qt) {
+			return qt
+		}
+		if qt != "" {
+			return "unknown"
+		}
+	}
+	if telemetry, _ := query["telemetry"].(string); telemetry == "metrics" {
+		return "promql"
+	}
+	return "unknown"
+}
+
+func validatePanel(
+	ctx context.Context,
+	panel map[string]any,
+	exec *validateExecutor,
+	callerVars, defaults map[string]any,
+	window map[string]string,
+	dashboardRef string,
+) map[string]any {
+	_ = dashboardRef
+	vizType := panelVizType(panel)
+	record := map[string]any{
+		"panel_id":           panel["id"],
+		"name":               panel["name"],
+		"visualization_type": nilIfEmpty(vizType),
+		"classification":     "query",
+		"targets":            []map[string]any{},
+	}
+
+	queries := asAnySlice(panel["queries"])
+	_, isCSV := panel["csv"]
+	if _, noQuery := noQueryVizTypes[vizType]; noQuery || isCSV || len(queries) == 0 {
+		record["classification"] = "no_query"
+		reason := "no_queries_defined"
+		if isCSV {
+			reason = "csv_panel"
+		} else if _, ok := noQueryVizTypes[vizType]; ok {
+			reason = vizType + "_panel"
+		}
+		record["reason"] = reason
+		return record
+	}
+
+	targets := make([]map[string]any, 0, len(queries))
+	for index, raw := range queries {
+		query, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					targets = append(targets, failureTarget(index, fmt.Errorf("%v", r)))
+				}
+			}()
+			targets = append(targets, validateTarget(ctx, query, index, vizType, exec, callerVars, defaults, window))
+		}()
+	}
+	if len(targets) == 0 {
+		record["classification"] = "no_query"
+		record["reason"] = "no_queries_defined"
+	} else {
+		record["targets"] = targets
+	}
+	return record
+}
+
+func validateTarget(
+	ctx context.Context,
+	query map[string]any,
+	index int,
+	vizType string,
+	exec *validateExecutor,
+	callerVars, defaults map[string]any,
+	window map[string]string,
+) map[string]any {
+	queryType := detectQueryType(query)
+	expr := query["expr"]
+	target := map[string]any{
+		"target_index": index,
+		"query_name":   query["name"],
+		"query_type":   queryType,
+		"telemetry":    query["telemetry"],
+		"lint":         []any{},
+		"execution":    nil,
+		"evidence":     nil,
+		"diagnosis":    nil,
+	}
+
+	var resolved any
+	var used map[string]map[string]any
+	var unresolved []string
+
+	if queryType == "log_json" || queryType == "trace_json" {
+		pipeline := parsePipeline(expr)
+		if pipeline != nil {
+			resolved, used, unresolved = interpolatePipeline(pipeline, callerVars, defaults)
+		} else {
+			resolved, used, unresolved = interpolatePipeline(expr, callerVars, defaults)
+		}
+	} else {
+		exprStr, _ := expr.(string)
+		var s string
+		s, used, unresolved = interpolate(exprStr, callerVars, defaults)
+		resolved = s
+	}
+	if len(used) > 0 {
+		target["variables_used"] = used
+	}
+	if len(unresolved) > 0 {
+		target["status"] = "unresolved_variable"
+		target["unresolved_variables"] = unresolved
+		return target
+	}
+
+	findings := lintTarget(queryType, resolved, vizType)
+	lintAny := make([]any, len(findings))
+	for i, f := range findings {
+		lintAny[i] = f
+	}
+	target["lint"] = lintAny
+	if hasBlockingError(findings) {
+		target["status"] = "invalid_query"
+		return target
+	}
+
+	var outcome executionOutcome
+	switch queryType {
+	case "promql":
+		exprStr, _ := resolved.(string)
+		outcome = exec.runPromQL(ctx, exprStr, window, vizType)
+	case "log_json":
+		indexName, _ := query["index_name"].(string)
+		outcome = exec.runLogJSON(ctx, resolved, window, indexName)
+	default:
+		target["status"] = "unsupported_execution"
+		target["note"] = queryType + " execution is not supported; lint-only"
+		return target
+	}
+
+	target["execution"] = map[string]any{
+		"tool":        outcome.tool,
+		"duration_ms": outcome.durationMs,
+		"error":       nilIfEmpty(outcome.errorText),
+	}
+	if outcome.status != "executed" {
+		target["status"] = outcome.status
+		return target
+	}
+
+	target["evidence"] = boundedEvidence(outcome.payload)
+	if hasData(outcome.payload) {
+		target["status"] = "valid_with_data"
+	} else {
+		// Day-1: no diagnose probes (ENG-1915 / U6).
+		target["status"] = "valid_no_data"
+		target["diagnosis"] = nil
+	}
+	return target
+}
+
+func nilIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/dashboards/validate_dashboard.go
+++ b/internal/dashboards/validate_dashboard.go
@@ -149,19 +149,27 @@ func NewValidateDashboardHandler(client *http.Client, cfg models.Config) func(co
 	return func(ctx context.Context, _ *mcp.CallToolRequest, args ValidateDashboardArgs) (*mcp.CallToolResult, any, error) {
 		parsed, errs := validateDashboardInput(args)
 		if len(errs) > 0 {
-			return nil, nil, fmt.Errorf("%s", strings.Join(errs, "; "))
+			return jsonToolResult(map[string]any{
+				"success": false,
+				"error":   "invalid_input",
+				"detail":  errs,
+			})
 		}
 
 		exec := &validateExecutor{client: client, cfg: cfg}
 		result := runValidateDashboard(ctx, exec, parsed)
-		body, err := json.Marshal(result)
-		if err != nil {
-			return nil, nil, fmt.Errorf("marshal report: %w", err)
-		}
-		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: string(body)}},
-		}, nil, nil
+		return jsonToolResult(result)
 	}
+}
+
+func jsonToolResult(v any) (*mcp.CallToolResult, any, error) {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal report: %w", err)
+	}
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{&mcp.TextContent{Text: string(body)}},
+	}, nil, nil
 }
 
 func runValidateDashboard(ctx context.Context, exec *validateExecutor, parsed *validatedDashboardArgs) map[string]any {

--- a/internal/dashboards/validate_dashboard_execute.go
+++ b/internal/dashboards/validate_dashboard_execute.go
@@ -114,7 +114,7 @@ func (e *validateExecutor) runPromQL(ctx context.Context, expr string, window ma
 		return executionOutcome{status: "source_unavailable", tool: tool, errorText: "received nil response", durationMs: duration}
 	}
 	defer httpResp.Body.Close()
-	rawBody, err := io.ReadAll(io.LimitReader(httpResp.Body, maxAPISuccessBodyBytes+1))
+	rawBody, err := readCappedResponseBody(httpResp.Body)
 	if err != nil {
 		return executionOutcome{status: "source_unavailable", tool: tool, errorText: clipError(err.Error()), durationMs: duration}
 	}
@@ -148,7 +148,7 @@ func (e *validateExecutor) runLogJSON(ctx context.Context, pipeline any, window 
 		return executionOutcome{status: "source_unavailable", tool: tool, errorText: "received nil response", durationMs: duration}
 	}
 	defer httpResp.Body.Close()
-	rawBody, err := io.ReadAll(io.LimitReader(httpResp.Body, maxAPISuccessBodyBytes+1))
+	rawBody, err := readCappedResponseBody(httpResp.Body)
 	if err != nil {
 		return executionOutcome{status: "source_unavailable", tool: tool, errorText: clipError(err.Error()), durationMs: duration}
 	}
@@ -156,6 +156,19 @@ func (e *validateExecutor) runLogJSON(ctx context.Context, pipeline any, window 
 		return outcomeFromHTTPError(tool, string(rawBody), httpResp.StatusCode, duration)
 	}
 	return outcomeFromResult(tool, rawBody, "", duration)
+}
+
+// readCappedResponseBody mirrors doJSONRequest's success-body cap so truncated
+// JSON is never classified as an empty successful execute.
+func readCappedResponseBody(r io.Reader) ([]byte, error) {
+	rawBody, err := io.ReadAll(io.LimitReader(r, maxAPISuccessBodyBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(rawBody)) > maxAPISuccessBodyBytes {
+		return nil, fmt.Errorf("response body exceeds %d bytes", maxAPISuccessBodyBytes)
+	}
+	return rawBody, nil
 }
 
 func outcomeFromHTTPError(tool, body string, statusCode, durationMs int) executionOutcome {

--- a/internal/dashboards/validate_dashboard_execute.go
+++ b/internal/dashboards/validate_dashboard_execute.go
@@ -1,0 +1,365 @@
+package dashboards
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"last9-mcp/internal/constants"
+	"last9-mcp/internal/models"
+	"last9-mcp/internal/utils"
+)
+
+// Execution + classification helpers for validate_dashboard.
+// Port of agents/supervisor/skills/dashboard_validation/executor.py (day-1: no probes).
+
+const (
+	logsExecutionLimit = 100
+	headSampleN        = 3
+	errorClipLimit     = 500
+)
+
+var instantVizTypes = map[string]struct{}{
+	"stat":  {},
+	"gauge": {},
+	"table": {},
+}
+
+var syntaxErrorMarkers = []string{
+	"parse error",
+	"invalid expression",
+	"unexpected token",
+	"bad_data",
+	"invalid parameter",
+}
+
+type executionOutcome struct {
+	status     string // executed | invalid_query | execution_error | source_unavailable
+	tool       string
+	payload    any
+	errorText  string
+	durationMs int
+}
+
+type validateExecutor struct {
+	client *http.Client
+	cfg    models.Config
+}
+
+func (e *validateExecutor) fetchDashboard(ctx context.Context, dashboardID string) (map[string]any, string) {
+	region, err := resolveRegion(e.cfg, "")
+	if err != nil {
+		return nil, err.Error()
+	}
+	path := fmt.Sprintf(constants.EndpointDashboardByID, url.PathEscape(dashboardID))
+	u := e.cfg.APIBaseURL + path + "?" + url.Values{"region": {region}}.Encode()
+
+	started := time.Now()
+	body, _, err := doJSONRequest(ctx, e.client, e.cfg, http.MethodGet, u, nil)
+	_ = started
+	if err != nil {
+		return nil, clipError(err.Error())
+	}
+	var payload any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, "get_dashboard returned a non-object payload"
+	}
+	obj, ok := payload.(map[string]any)
+	if !ok {
+		return nil, "get_dashboard returned a non-object payload"
+	}
+	dashboard, _ := obj["dashboard"].(map[string]any)
+	if dashboard == nil {
+		dashboard = obj
+	}
+	if dashboard == nil {
+		return nil, "get_dashboard payload has no dashboard object"
+	}
+	return dashboard, ""
+}
+
+func (e *validateExecutor) runPromQL(ctx context.Context, expr string, window map[string]string, vizType string) executionOutcome {
+	end, err := parseValidateISO(window["end"])
+	if err != nil {
+		return executionOutcome{status: "execution_error", tool: "prometheus_range_query", errorText: err.Error()}
+	}
+	endUnix := end.Unix()
+
+	var tool string
+	var httpResp *http.Response
+	var callErr error
+	started := time.Now()
+
+	if _, ok := instantVizTypes[strings.ToLower(vizType)]; ok {
+		tool = "prometheus_instant_query"
+		httpResp, callErr = utils.MakePromInstantAPIQuery(ctx, e.client, expr, endUnix, e.cfg)
+	} else {
+		tool = "prometheus_range_query"
+		start, err := parseValidateISO(window["start"])
+		if err != nil {
+			return executionOutcome{status: "execution_error", tool: tool, errorText: err.Error()}
+		}
+		httpResp, callErr = utils.MakePromRangeAPIQuery(ctx, e.client, expr, start.Unix(), endUnix, e.cfg, utils.PromResolution{})
+	}
+	duration := int(time.Since(started).Milliseconds())
+	if callErr != nil {
+		return executionOutcome{status: "source_unavailable", tool: tool, errorText: clipError(callErr.Error()), durationMs: duration}
+	}
+	if httpResp == nil {
+		return executionOutcome{status: "source_unavailable", tool: tool, errorText: "received nil response", durationMs: duration}
+	}
+	defer httpResp.Body.Close()
+	rawBody, err := io.ReadAll(io.LimitReader(httpResp.Body, maxAPISuccessBodyBytes+1))
+	if err != nil {
+		return executionOutcome{status: "source_unavailable", tool: tool, errorText: clipError(err.Error()), durationMs: duration}
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return outcomeFromHTTPError(tool, string(rawBody), httpResp.StatusCode, duration)
+	}
+	return outcomeFromResult(tool, rawBody, "", duration)
+}
+
+func (e *validateExecutor) runLogJSON(ctx context.Context, pipeline any, window map[string]string, index string) executionOutcome {
+	tool := "get_logs"
+	start, err := parseValidateISO(window["start"])
+	if err != nil {
+		return executionOutcome{status: "execution_error", tool: tool, errorText: err.Error()}
+	}
+	end, err := parseValidateISO(window["end"])
+	if err != nil {
+		return executionOutcome{status: "execution_error", tool: tool, errorText: err.Error()}
+	}
+	started := time.Now()
+	httpResp, callErr := utils.MakeLogsJSONQueryAPI(
+		ctx, e.client, e.cfg, pipeline,
+		start.UnixMilli(), end.UnixMilli(),
+		logsExecutionLimit, index,
+	)
+	duration := int(time.Since(started).Milliseconds())
+	if callErr != nil {
+		return executionOutcome{status: "source_unavailable", tool: tool, errorText: clipError(callErr.Error()), durationMs: duration}
+	}
+	if httpResp == nil {
+		return executionOutcome{status: "source_unavailable", tool: tool, errorText: "received nil response", durationMs: duration}
+	}
+	defer httpResp.Body.Close()
+	rawBody, err := io.ReadAll(io.LimitReader(httpResp.Body, maxAPISuccessBodyBytes+1))
+	if err != nil {
+		return executionOutcome{status: "source_unavailable", tool: tool, errorText: clipError(err.Error()), durationMs: duration}
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		return outcomeFromHTTPError(tool, string(rawBody), httpResp.StatusCode, duration)
+	}
+	return outcomeFromResult(tool, rawBody, "", duration)
+}
+
+func outcomeFromHTTPError(tool, body string, statusCode, durationMs int) executionOutcome {
+	errText := clipError(fmt.Sprintf("HTTP %d: %s", statusCode, body))
+	lowered := strings.ToLower(errText)
+	status := "execution_error"
+	for _, marker := range syntaxErrorMarkers {
+		if strings.Contains(lowered, marker) {
+			status = "invalid_query"
+			break
+		}
+	}
+	return executionOutcome{status: status, tool: tool, errorText: errText, durationMs: durationMs}
+}
+
+func outcomeFromResult(tool string, raw []byte, transportErr string, durationMs int) executionOutcome {
+	if transportErr != "" {
+		return executionOutcome{status: "source_unavailable", tool: tool, errorText: transportErr, durationMs: durationMs}
+	}
+	payload := parseJSONPayload(raw)
+	if errText := errorTextFromPayload(payload, string(raw)); errText != "" {
+		lowered := strings.ToLower(errText)
+		status := "execution_error"
+		for _, marker := range syntaxErrorMarkers {
+			if strings.Contains(lowered, marker) {
+				status = "invalid_query"
+				break
+			}
+		}
+		return executionOutcome{status: status, tool: tool, errorText: errText, durationMs: durationMs}
+	}
+	return executionOutcome{status: "executed", tool: tool, payload: payload, durationMs: durationMs}
+}
+
+func parseJSONPayload(raw []byte) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var payload any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil
+	}
+	return payload
+}
+
+func errorTextFromPayload(payload any, raw string) string {
+	if obj, ok := payload.(map[string]any); ok {
+		if isTruthy(obj["is_error"]) || isTruthy(obj["isError"]) {
+			if v := obj["error"]; v != nil {
+				return fmt.Sprint(v)
+			}
+			if v := obj["message"]; v != nil {
+				return fmt.Sprint(v)
+			}
+			return "tool error"
+		}
+		if err := obj["error"]; err != nil && err != "" {
+			return fmt.Sprint(err)
+		}
+		if status, _ := obj["status"].(string); status == "error" {
+			if v := obj["errorType"]; v != nil {
+				return fmt.Sprint(v)
+			}
+			if v := obj["message"]; v != nil {
+				return fmt.Sprint(v)
+			}
+			return "backend error"
+		}
+		if okVal, isBool := obj["ok"].(bool); isBool && !okVal {
+			if v := obj["detail"]; v != nil {
+				return fmt.Sprint(v)
+			}
+			return "tool error"
+		}
+	}
+	trimmed := strings.TrimSpace(raw)
+	if strings.HasPrefix(strings.ToLower(trimmed), "error") {
+		return clipError(trimmed)
+	}
+	return ""
+}
+
+func isTruthy(v any) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		return t != "" && t != "false" && t != "0"
+	case float64:
+		return t != 0
+	case nil:
+		return false
+	default:
+		return t != nil
+	}
+}
+
+func extractResultRows(payload any) []any {
+	if payload == nil {
+		return nil
+	}
+	if list, ok := payload.([]any); ok {
+		return list
+	}
+	obj, ok := payload.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if data, ok := obj["data"].(map[string]any); ok {
+		if result, ok := data["result"].([]any); ok {
+			return result
+		}
+	}
+	for _, key := range []string{"result", "logs", "entries", "rows"} {
+		if list, ok := obj[key].([]any); ok {
+			return list
+		}
+	}
+	return nil
+}
+
+func hasData(payload any) bool {
+	rows := extractResultRows(payload)
+	return len(rows) > 0
+}
+
+func boundedEvidence(payload any) map[string]any {
+	rows := extractResultRows(payload)
+	if rows == nil {
+		return map[string]any{
+			"sample_count": 0,
+			"total_count":  0,
+			"truncated":    false,
+			"samples":      []any{},
+			"note":         "unrecognized payload shape; treated as empty",
+		}
+	}
+	total := len(rows)
+	alreadyTruncated := false
+	if obj, ok := payload.(map[string]any); ok && isTruthy(obj["truncated"]) {
+		alreadyTruncated = true
+		switch t := obj["total_entries"].(type) {
+		case float64:
+			total = int(t)
+		case int:
+			total = t
+		case map[string]any:
+			max := total
+			for _, v := range t {
+				if n := asInt(v); n > max {
+					max = n
+				}
+			}
+			total = max
+		}
+	}
+	n := headSampleN
+	if n > len(rows) {
+		n = len(rows)
+	}
+	samples := compactSamples(rows[:n])
+	return map[string]any{
+		"sample_count": len(samples),
+		"total_count":  total,
+		"truncated":    alreadyTruncated || total > len(samples),
+		"samples":      samples,
+	}
+}
+
+func compactSamples(samples []any) []any {
+	out := make([]any, 0, len(samples))
+	for _, item := range samples {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			out = append(out, map[string]any{"row": clipError(fmt.Sprint(item))})
+			continue
+		}
+		compact := map[string]any{}
+		if metric, ok := obj["metric"].(map[string]any); ok {
+			compact["labels"] = metric
+		}
+		if values, ok := obj["values"].([]any); ok {
+			compact["points"] = len(values)
+			if len(values) > 0 {
+				compact["last_value"] = values[len(values)-1]
+			} else {
+				compact["last_value"] = nil
+			}
+		}
+		if value, ok := obj["value"]; ok {
+			compact["value"] = value
+		}
+		if len(compact) == 0 {
+			b, _ := json.Marshal(obj)
+			compact = map[string]any{"row": clipError(string(b))}
+		}
+		out = append(out, compact)
+	}
+	return out
+}
+
+func clipError(text string) string {
+	if len(text) <= errorClipLimit {
+		return text
+	}
+	return text[:errorClipLimit] + "…"
+}

--- a/internal/dashboards/validate_dashboard_lint.go
+++ b/internal/dashboards/validate_dashboard_lint.go
@@ -1,0 +1,255 @@
+package dashboards
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// Pure query lint — no I/O.
+// Port of agents/supervisor/skills/dashboard_validation/lint.py.
+
+const (
+	severityError   = "error"
+	severityWarning = "warning"
+	timesliceGroupbyCol = "__ts__"
+)
+
+var (
+	logqlRangeSelectorRe = regexp.MustCompile(`\[\d+(?:ms|[smhdwy])\]`)
+	promqlDanglingOpRe   = regexp.MustCompile(`[+\-*/%^]\s*$|^\s*[+*/%^]`)
+	timeseriesVizTypes   = map[string]struct{}{
+		"timeseries": {},
+		"line":       {},
+		"bar":        {},
+		"chart":      {},
+	}
+)
+
+func lintFinding(rule, severity, message string) map[string]any {
+	return map[string]any{"rule": rule, "severity": severity, "message": message}
+}
+
+func hasBlockingError(findings []map[string]any) bool {
+	for _, f := range findings {
+		if f["severity"] == severityError {
+			return true
+		}
+	}
+	return false
+}
+
+func balanced(expr string) bool {
+	pairs := map[byte]byte{')': '(', '}': '{', ']': '['}
+	var stack []byte
+	var quote byte
+	escaped := false
+	for i := 0; i < len(expr); i++ {
+		ch := expr[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		if ch == '\'' || ch == '"' || ch == '`' {
+			quote = ch
+			continue
+		}
+		if ch == '(' || ch == '{' || ch == '[' {
+			stack = append(stack, ch)
+		} else if ch == ')' || ch == '}' || ch == ']' {
+			if len(stack) == 0 || stack[len(stack)-1] != pairs[ch] {
+				return false
+			}
+			stack = stack[:len(stack)-1]
+		}
+	}
+	return len(stack) == 0 && quote == 0
+}
+
+func lintPromQL(expr string) []map[string]any {
+	if strings.TrimSpace(expr) == "" {
+		return []map[string]any{lintFinding("promql_empty", severityError, "PromQL expression is empty")}
+	}
+	var findings []map[string]any
+	if !balanced(expr) {
+		findings = append(findings, lintFinding(
+			"promql_unbalanced",
+			severityError,
+			"unbalanced parentheses/braces/brackets or unterminated quote",
+		))
+	}
+	if promqlDanglingOpRe.MatchString(strings.TrimSpace(expr)) {
+		findings = append(findings, lintFinding("promql_dangling_operator", severityError, "dangling binary operator"))
+	}
+	return findings
+}
+
+func parsePipeline(expr any) []any {
+	switch e := expr.(type) {
+	case []any:
+		return e
+	case []map[string]any:
+		out := make([]any, len(e))
+		for i, m := range e {
+			out[i] = m
+		}
+		return out
+	case string:
+		if strings.TrimSpace(e) == "" {
+			return nil
+		}
+		var parsed any
+		if err := json.Unmarshal([]byte(e), &parsed); err != nil {
+			return nil
+		}
+		if list, ok := parsed.([]any); ok {
+			return list
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func aggregateStages(pipeline []any) []map[string]any {
+	var out []map[string]any
+	for _, stage := range pipeline {
+		m, ok := stage.(map[string]any)
+		if !ok {
+			continue
+		}
+		t, _ := m["type"].(string)
+		if t == "aggregate" || t == "aggregation" {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func stageHasTimeslice(stage map[string]any) bool {
+	if isTruthy(stage["window"]) {
+		return true
+	}
+	groupby := stage["groupby"]
+	if groupby == nil {
+		groupby = stage["group_by"]
+	}
+	for _, col := range asAnySlice(groupby) {
+		var name string
+		switch c := col.(type) {
+		case map[string]any:
+			name, _ = c["column"].(string)
+		case string:
+			name = c
+		}
+		if name == timesliceGroupbyCol {
+			return true
+		}
+	}
+	return false
+}
+
+func lintPipeline(expr any, queryType, vizType string) []map[string]any {
+	pipeline := parsePipeline(expr)
+	if pipeline == nil {
+		return []map[string]any{lintFinding(
+			queryType+"_invalid_pipeline",
+			severityError,
+			"pipeline expr is not a JSON array of stages",
+		)}
+	}
+	if len(pipeline) == 0 {
+		return []map[string]any{lintFinding(
+			queryType+"_empty_pipeline",
+			severityError,
+			"pipeline has no stages",
+		)}
+	}
+
+	var findings []map[string]any
+	aggregates := aggregateStages(pipeline)
+	viz := strings.ToLower(vizType)
+	isTable := viz == "table"
+
+	if len(aggregates) == 0 && isTable {
+		findings = append(findings, lintFinding(
+			queryType+"_table_requires_aggregation",
+			severityError,
+			"table panels require an aggregation stage in the pipeline",
+		))
+	}
+
+	if _, ok := timeseriesVizTypes[viz]; ok {
+		if len(aggregates) == 0 {
+			findings = append(findings, lintFinding(
+				queryType+"_timeseries_requires_aggregation",
+				severityError,
+				viz+" visualization requires an aggregation stage",
+			))
+		} else {
+			hasSlice := false
+			for _, stage := range aggregates {
+				if stageHasTimeslice(stage) {
+					hasSlice = true
+					break
+				}
+			}
+			if !hasSlice {
+				findings = append(findings, lintFinding(
+					queryType+"_timeseries_requires_timeslice",
+					severityError,
+					viz+" visualization requires a time-sliced aggregate "+
+						"(aggregate stage with a window)",
+				))
+			}
+		}
+	}
+	return findings
+}
+
+func lintLogQL(expr string) []map[string]any {
+	if strings.TrimSpace(expr) == "" {
+		return []map[string]any{lintFinding("log_ql_empty", severityError, "LogQL expression is empty")}
+	}
+	var findings []map[string]any
+	if !logqlRangeSelectorRe.MatchString(expr) {
+		findings = append(findings, lintFinding(
+			"log_ql_missing_range_selector",
+			severityError,
+			"LogQL query must include a range selector like [5m]",
+		))
+	}
+	if !balanced(expr) {
+		findings = append(findings, lintFinding("log_ql_unbalanced", severityError, "unbalanced brackets or quote"))
+	}
+	return findings
+}
+
+func lintTarget(queryType string, expr any, vizType string) []map[string]any {
+	switch queryType {
+	case "promql":
+		s, _ := expr.(string)
+		return lintPromQL(s)
+	case "log_json", "trace_json":
+		return lintPipeline(expr, queryType, vizType)
+	case "log_ql":
+		s, _ := expr.(string)
+		return lintLogQL(s)
+	default:
+		return []map[string]any{lintFinding(
+			"unknown_query_type",
+			severityWarning,
+			"no lint rules for query_type '"+queryType+"'",
+		)}
+	}
+}

--- a/internal/dashboards/validate_dashboard_report.go
+++ b/internal/dashboards/validate_dashboard_report.go
@@ -1,0 +1,258 @@
+package dashboards
+
+import "strconv"
+
+// Report schema constants + fail-closed self-validation (dashboard_validation/v1).
+// Port of agents/supervisor/skills/dashboard_validation/report.py.
+
+const schemaVersion = "dashboard_validation/v1"
+
+var targetStatuses = map[string]struct{}{
+	"valid_with_data":       {},
+	"valid_no_data":         {},
+	"invalid_query":         {},
+	"execution_error":       {},
+	"source_unavailable":    {},
+	"unsupported_execution": {},
+	"unresolved_variable":   {},
+}
+
+var panelClassifications = map[string]struct{}{
+	"query":    {},
+	"no_query": {},
+}
+
+var diagnosisKinds = map[string]struct{}{
+	"metric_absent":            {},
+	"label_value_absent":       {},
+	"log_attribute_unpopulated": {},
+	"window_empty":             {},
+	"unknown":                  {},
+}
+
+var queryTypes = map[string]struct{}{
+	"promql":     {},
+	"log_json":   {},
+	"log_ql":     {},
+	"trace_json": {},
+	"trace_ql":   {},
+	"unknown":    {},
+}
+
+func isQueryType(s string) bool {
+	_, ok := queryTypes[s]
+	return ok
+}
+
+// validateReport returns schema violations (empty means valid). Fail-closed:
+// unknown statuses/kinds, missing evidence on diagnoses, or count drift.
+func validateReport(report map[string]any) []string {
+	var errors []string
+	if report == nil {
+		return []string{"report must be a dict"}
+	}
+	if report["schema_version"] != schemaVersion {
+		errors = append(errors, "schema_version must be "+schemaVersion)
+	}
+	for _, key := range []string{"dashboard", "window", "summary", "panels"} {
+		if _, ok := report[key]; !ok {
+			errors = append(errors, "missing key: "+key)
+		}
+	}
+	if len(errors) > 0 {
+		return errors
+	}
+
+	panels, ok := report["panels"].([]any)
+	if !ok {
+		// Also accept []map from internal assembly before marshal round-trip.
+		if typed, ok := report["panels"].([]map[string]any); ok {
+			panels = make([]any, len(typed))
+			for i, p := range typed {
+				panels[i] = p
+			}
+		} else {
+			return []string{"panels must be a list"}
+		}
+	}
+
+	targetCount := 0
+	byStatus := map[string]int{}
+	for i, raw := range panels {
+		panel, ok := raw.(map[string]any)
+		if !ok {
+			errors = append(errors, "panels["+strconv.Itoa(i)+"] must be a dict")
+			continue
+		}
+		classification, _ := panel["classification"].(string)
+		if _, ok := panelClassifications[classification]; !ok {
+			errors = append(errors, "panels["+strconv.Itoa(i)+"].classification invalid: "+classification)
+		}
+		targets := asAnySlice(panel["targets"])
+		if classification == "no_query" && len(targets) > 0 {
+			errors = append(errors, "panels["+strconv.Itoa(i)+"] is no_query but has targets")
+		}
+		for j, traw := range targets {
+			targetCount++
+			where := "panels[" + strconv.Itoa(i) + "].targets[" + strconv.Itoa(j) + "]"
+			target, ok := traw.(map[string]any)
+			if !ok {
+				errors = append(errors, where+" must be a dict")
+				continue
+			}
+			status, _ := target["status"].(string)
+			if _, ok := targetStatuses[status]; !ok {
+				errors = append(errors, where+".status invalid: "+status)
+				continue
+			}
+			byStatus[status]++
+			qt, _ := target["query_type"].(string)
+			if !isQueryType(qt) {
+				errors = append(errors, where+".query_type invalid: "+qt)
+			}
+			if status == "valid_with_data" || status == "valid_no_data" {
+				if _, ok := target["evidence"].(map[string]any); !ok {
+					errors = append(errors, where+".evidence required for status "+status)
+				}
+			}
+			if diagnosis := target["diagnosis"]; diagnosis != nil {
+				errors = append(errors, validateDiagnosis(diagnosis, where)...)
+			}
+		}
+	}
+
+	summary, _ := report["summary"].(map[string]any)
+	if summary == nil {
+		errors = append(errors, "summary must be a dict")
+		return errors
+	}
+	targetsTotal := asInt(summary["targets_total"])
+	if targetsTotal != targetCount {
+		errors = append(errors, "summary.targets_total="+strconv.Itoa(targetsTotal)+" but counted "+strconv.Itoa(targetCount))
+	}
+	declared := map[string]int{}
+	if raw, ok := summary["by_status"].(map[string]any); ok {
+		for k, v := range raw {
+			declared[k] = asInt(v)
+		}
+	} else if typed, ok := summary["by_status"].(map[string]int); ok {
+		declared = typed
+	}
+	for status, count := range byStatus {
+		if declared[status] != count {
+			errors = append(errors, "summary.by_status["+status+"]="+strconv.Itoa(declared[status])+" but counted "+strconv.Itoa(count))
+		}
+	}
+	for status, count := range declared {
+		if count > 0 {
+			if _, ok := byStatus[status]; !ok {
+				errors = append(errors, "summary.by_status["+status+"]="+strconv.Itoa(count)+" but no such targets")
+			}
+		}
+	}
+	return errors
+}
+
+func validateDiagnosis(diagnosis any, where string) []string {
+	d, ok := diagnosis.(map[string]any)
+	if !ok {
+		return []string{where + ".diagnosis must be a dict"}
+	}
+	possibilities := asAnySlice(d["possibilities"])
+	if len(possibilities) == 0 {
+		return []string{where + ".diagnosis.possibilities must be a non-empty list"}
+	}
+	var errors []string
+	for k, raw := range possibilities {
+		poss, ok := raw.(map[string]any)
+		if !ok {
+			errors = append(errors, where+".diagnosis.possibilities["+strconv.Itoa(k)+"].kind invalid: <non-object>")
+			continue
+		}
+		kind, _ := poss["kind"].(string)
+		if _, ok := diagnosisKinds[kind]; !ok {
+			errors = append(errors, where+".diagnosis.possibilities["+strconv.Itoa(k)+"].kind invalid: "+kind)
+			continue
+		}
+		if kind != "unknown" {
+			evidence := asAnySlice(poss["evidence"])
+			if len(evidence) == 0 {
+				errors = append(errors, where+".diagnosis.possibilities["+strconv.Itoa(k)+"] kind="+kind+" lacks probe evidence")
+			}
+		}
+	}
+	return errors
+}
+
+// summarize builds the summary block from assembled panel records.
+func summarize(panels []map[string]any) map[string]any {
+	byStatus := map[string]int{}
+	targetsTotal := 0
+	panelsNoQuery := 0
+	for _, panel := range panels {
+		if panel["classification"] == "no_query" {
+			panelsNoQuery++
+		}
+		for _, traw := range asAnySlice(panel["targets"]) {
+			targetsTotal++
+			target, _ := traw.(map[string]any)
+			status, _ := target["status"].(string)
+			if status == "" {
+				status = "execution_error"
+			}
+			byStatus[status]++
+		}
+	}
+
+	overall := "pass"
+	for _, s := range []string{"invalid_query", "execution_error", "source_unavailable"} {
+		if byStatus[s] > 0 {
+			overall = "fail"
+			break
+		}
+	}
+	if overall == "pass" {
+		for _, s := range []string{"unsupported_execution", "unresolved_variable"} {
+			if byStatus[s] > 0 {
+				overall = "partial"
+				break
+			}
+		}
+	}
+
+	return map[string]any{
+		"panels_total":    len(panels),
+		"panels_no_query": panelsNoQuery,
+		"targets_total":   targetsTotal,
+		"by_status":       byStatus,
+		"overall":         overall,
+	}
+}
+
+func asAnySlice(v any) []any {
+	switch t := v.(type) {
+	case []any:
+		return t
+	case []map[string]any:
+		out := make([]any, len(t))
+		for i, m := range t {
+			out[i] = m
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func asInt(v any) int {
+	switch t := v.(type) {
+	case int:
+		return t
+	case int64:
+		return int(t)
+	case float64:
+		return int(t)
+	default:
+		return 0
+	}
+}

--- a/internal/dashboards/validate_dashboard_test.go
+++ b/internal/dashboards/validate_dashboard_test.go
@@ -432,7 +432,6 @@ func TestValidateDashboard_LogJSONExecute(t *testing.T) {
 						map[string]any{
 							"query_type": "log_json",
 							"expr":       string(pipelineJSON),
-							"index_name": "logs",
 						},
 					},
 				},
@@ -445,7 +444,7 @@ func TestValidateDashboard_LogJSONExecute(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !sawLogsPOST {
-		t.Fatalf("expected logs query_range POST, methods=%v", methods)
+		t.Fatalf("expected logs query_range POST, methods=%v report=%s", methods, result.Content[0].(*mcp.TextContent).Text)
 	}
 	for _, m := range methods {
 		if strings.HasPrefix(m, "PUT ") || strings.HasPrefix(m, "DELETE ") {

--- a/internal/dashboards/validate_dashboard_test.go
+++ b/internal/dashboards/validate_dashboard_test.go
@@ -86,14 +86,21 @@ func TestValidateDashboardHandler_InvalidInputNoHTTP(t *testing.T) {
 
 	handler := NewValidateDashboardHandler(srv.Client(), testDashboardConfig(srv.URL))
 	id := "dash-1"
-	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ValidateDashboardArgs{
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ValidateDashboardArgs{
 		DashboardID:         &id,
 		DashboardDefinition: map[string]any{},
 		StartTimeISO:        "2026-09-10T08:00:00Z",
 		EndTimeISO:          "2026-09-10T09:00:00Z",
 	})
-	if err == nil {
-		t.Fatal("expected error")
+	if err != nil {
+		t.Fatalf("expected structured envelope, got err: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report["success"] != false || report["error"] != "invalid_input" {
+		t.Fatalf("report=%v", report)
 	}
 }
 
@@ -383,5 +390,78 @@ func TestValidateDashboard_NonListPanelsFailClosed(t *testing.T) {
 	_ = json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &report)
 	if report["success"] != false || report["error"] != "invalid_input" {
 		t.Fatalf("%v", report)
+	}
+}
+
+func TestValidateDashboard_LogJSONExecute(t *testing.T) {
+	var sawLogsPOST bool
+	var methods []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method+" "+r.URL.Path)
+		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/logs/") {
+			sawLogsPOST = true
+			body, _ := io.ReadAll(r.Body)
+			var payload map[string]any
+			_ = json.Unmarshal(body, &payload)
+			if _, ok := payload["pipeline"]; !ok {
+				t.Errorf("expected pipeline in body, got %s", body)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"logs":[{"Body":"hello"}]}`))
+			return
+		}
+		t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cfg := testDashboardConfig(srv.URL)
+	handler := NewValidateDashboardHandler(srv.Client(), cfg)
+	pipeline := []any{
+		map[string]any{"type": "filter", "query": map[string]any{"$and": []any{}}},
+		map[string]any{"type": "aggregate", "window": "1m", "groupby": []any{map[string]any{"column": "__ts__"}}},
+	}
+	pipelineJSON, _ := json.Marshal(pipeline)
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ValidateDashboardArgs{
+		DashboardDefinition: map[string]any{
+			"panels": []any{
+				map[string]any{
+					"id":            "p1",
+					"visualization": map[string]any{"type": "timeseries"},
+					"queries": []any{
+						map[string]any{
+							"query_type": "log_json",
+							"expr":       string(pipelineJSON),
+							"index_name": "logs",
+						},
+					},
+				},
+			},
+		},
+		StartTimeISO: "2026-09-10T08:00:00Z",
+		EndTimeISO:   "2026-09-10T09:00:00Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sawLogsPOST {
+		t.Fatalf("expected logs query_range POST, methods=%v", methods)
+	}
+	for _, m := range methods {
+		if strings.HasPrefix(m, "PUT ") || strings.HasPrefix(m, "DELETE ") {
+			t.Fatalf("unexpected mutating method: %s", m)
+		}
+		if strings.Contains(m, "/dashboards") {
+			t.Fatalf("inline must not hit dashboard CRUD: %s", m)
+		}
+	}
+	var report map[string]any
+	_ = json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &report)
+	if report["success"] != true {
+		t.Fatalf("%v", report)
+	}
+	status := report["panels"].([]any)[0].(map[string]any)["targets"].([]any)[0].(map[string]any)["status"]
+	if status != "valid_with_data" {
+		t.Fatalf("status=%v report=%v", status, report)
 	}
 }

--- a/internal/dashboards/validate_dashboard_test.go
+++ b/internal/dashboards/validate_dashboard_test.go
@@ -1,0 +1,387 @@
+package dashboards
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestValidateDashboardInput_XORAndWindow(t *testing.T) {
+	id := "dash-1"
+	cases := []struct {
+		name    string
+		args    ValidateDashboardArgs
+		wantErr string
+	}{
+		{
+			name: "both",
+			args: ValidateDashboardArgs{
+				DashboardID:         &id,
+				DashboardDefinition: map[string]any{},
+				StartTimeISO:        "2026-09-10T08:00:00Z",
+				EndTimeISO:          "2026-09-10T09:00:00Z",
+			},
+			wantErr: "exactly one",
+		},
+		{
+			name: "neither",
+			args: ValidateDashboardArgs{
+				StartTimeISO: "2026-09-10T08:00:00Z",
+				EndTimeISO:   "2026-09-10T09:00:00Z",
+			},
+			wantErr: "exactly one",
+		},
+		{
+			name: "window too large",
+			args: ValidateDashboardArgs{
+				DashboardID:  &id,
+				StartTimeISO: "2026-09-01T08:00:00Z",
+				EndTimeISO:   "2026-09-10T09:00:00Z",
+			},
+			wantErr: "24 hours",
+		},
+		{
+			name: "end before start",
+			args: ValidateDashboardArgs{
+				DashboardID:  &id,
+				StartTimeISO: "2026-09-10T09:00:00Z",
+				EndTimeISO:   "2026-09-10T08:00:00Z",
+			},
+			wantErr: "after start",
+		},
+		{
+			name: "missing start",
+			args: ValidateDashboardArgs{
+				DashboardID: &id,
+				EndTimeISO:  "2026-09-10T09:00:00Z",
+			},
+			wantErr: "start_time_iso",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, errs := validateDashboardInput(tc.args)
+			if len(errs) == 0 {
+				t.Fatal("expected errors")
+			}
+			joined := strings.Join(errs, "; ")
+			if !strings.Contains(joined, tc.wantErr) {
+				t.Fatalf("got %q, want substring %q", joined, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateDashboardHandler_InvalidInputNoHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not be called")
+	}))
+	defer srv.Close()
+
+	handler := NewValidateDashboardHandler(srv.Client(), testDashboardConfig(srv.URL))
+	id := "dash-1"
+	_, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ValidateDashboardArgs{
+		DashboardID:         &id,
+		DashboardDefinition: map[string]any{},
+		StartTimeISO:        "2026-09-10T08:00:00Z",
+		EndTimeISO:          "2026-09-10T09:00:00Z",
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSummarizeOverall(t *testing.T) {
+	pass := summarize([]map[string]any{
+		{"classification": "query", "targets": []map[string]any{
+			{"status": "valid_with_data"},
+		}},
+	})
+	if pass["overall"] != "pass" {
+		t.Fatalf("overall=%v", pass["overall"])
+	}
+
+	partial := summarize([]map[string]any{
+		{"classification": "query", "targets": []map[string]any{
+			{"status": "unsupported_execution"},
+		}},
+	})
+	if partial["overall"] != "partial" {
+		t.Fatalf("overall=%v", partial["overall"])
+	}
+
+	fail := summarize([]map[string]any{
+		{"classification": "query", "targets": []map[string]any{
+			{"status": "invalid_query"},
+			{"status": "unsupported_execution"},
+		}},
+	})
+	if fail["overall"] != "fail" {
+		t.Fatalf("overall=%v", fail["overall"])
+	}
+}
+
+func TestInterpolateBuiltinAndUnresolved(t *testing.T) {
+	out, used, unresolved := interpolate(
+		`rate(http_requests_total{job="$job"}[$__rate_interval])`,
+		map[string]any{},
+		map[string]any{},
+	)
+	if !strings.Contains(out, "5m") {
+		t.Fatalf("builtin not resolved: %s", out)
+	}
+	if used["__rate_interval"]["source"] != "builtin_default" {
+		t.Fatalf("used=%v", used)
+	}
+	if len(unresolved) != 1 || unresolved[0] != "job" {
+		t.Fatalf("unresolved=%v", unresolved)
+	}
+}
+
+func TestLintPromQLAndLogJSONTimeseries(t *testing.T) {
+	if !hasBlockingError(lintPromQL("")) {
+		t.Fatal("empty promql should block")
+	}
+	if !hasBlockingError(lintPromQL("up +")) {
+		t.Fatal("dangling op should block")
+	}
+	pipeline := []any{
+		map[string]any{"type": "filter", "query": map[string]any{}},
+	}
+	findings := lintPipeline(pipeline, "log_json", "timeseries")
+	if !hasBlockingError(findings) {
+		t.Fatal("timeseries without aggregate should block")
+	}
+}
+
+func TestValidateDashboard_InlinePromWithData(t *testing.T) {
+	var methods []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		methods = append(methods, r.Method+" "+r.URL.Path)
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected write-ish method %s", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up"},"value":[1,"1"]}]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := testDashboardConfig(srv.URL)
+	cfg.PrometheusReadURL = "http://prom.example"
+	handler := NewValidateDashboardHandler(srv.Client(), cfg)
+
+	args := ValidateDashboardArgs{
+		DashboardDefinition: map[string]any{
+			"name": "Inline",
+			"panels": []any{
+				map[string]any{
+					"id":   "p1",
+					"name": "Up",
+					"visualization": map[string]any{
+						"type": "stat",
+					},
+					"queries": []any{
+						map[string]any{
+							"name":       "A",
+							"query_type": "promql",
+							"telemetry":  "metrics",
+							"expr":       "up",
+						},
+					},
+				},
+			},
+		},
+		StartTimeISO: "2026-09-10T08:00:00Z",
+		EndTimeISO:   "2026-09-10T09:00:00Z",
+	}
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := result.Content[0].(*mcp.TextContent).Text
+	var report map[string]any
+	if err := json.Unmarshal([]byte(text), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report["success"] != true {
+		t.Fatalf("report=%s", text)
+	}
+	if report["schema_version"] != schemaVersion {
+		t.Fatalf("schema=%v", report["schema_version"])
+	}
+	summary := report["summary"].(map[string]any)
+	if summary["overall"] != "pass" {
+		t.Fatalf("overall=%v by_status=%v", summary["overall"], summary["by_status"])
+	}
+	for _, m := range methods {
+		if strings.HasPrefix(m, "PUT") || strings.HasPrefix(m, "DELETE") || strings.Contains(m, "/dashboards") && !strings.Contains(m, "query") {
+			t.Fatalf("unexpected mutating/dashboard path: %s", m)
+		}
+	}
+}
+
+func TestValidateDashboard_InlineEmptySeries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := testDashboardConfig(srv.URL)
+	cfg.PrometheusReadURL = "http://prom.example"
+	handler := NewValidateDashboardHandler(srv.Client(), cfg)
+
+	args := ValidateDashboardArgs{
+		DashboardDefinition: map[string]any{
+			"name": "Empty",
+			"panels": []any{
+				map[string]any{
+					"id":            "p1",
+					"visualization": map[string]any{"type": "timeseries"},
+					"queries": []any{
+						map[string]any{"query_type": "promql", "expr": "up"},
+					},
+				},
+			},
+		},
+		StartTimeISO: "2026-09-10T08:00:00Z",
+		EndTimeISO:   "2026-09-10T09:00:00Z",
+	}
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report map[string]any
+	_ = json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &report)
+	panels := report["panels"].([]any)
+	targets := panels[0].(map[string]any)["targets"].([]any)
+	status := targets[0].(map[string]any)["status"]
+	if status != "valid_no_data" {
+		t.Fatalf("status=%v report=%v", status, report)
+	}
+	if targets[0].(map[string]any)["diagnosis"] != nil {
+		t.Fatal("day-1 diagnosis should be null")
+	}
+}
+
+func TestValidateDashboard_LintBlocksExecution(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("lint should block HTTP")
+	}))
+	defer srv.Close()
+
+	handler := NewValidateDashboardHandler(srv.Client(), testDashboardConfig(srv.URL))
+	args := ValidateDashboardArgs{
+		DashboardDefinition: map[string]any{
+			"panels": []any{
+				map[string]any{
+					"queries": []any{
+						map[string]any{"query_type": "promql", "expr": ""},
+					},
+				},
+			},
+		},
+		StartTimeISO: "2026-09-10T08:00:00Z",
+		EndTimeISO:   "2026-09-10T09:00:00Z",
+	}
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report map[string]any
+	_ = json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &report)
+	status := report["panels"].([]any)[0].(map[string]any)["targets"].([]any)[0].(map[string]any)["status"]
+	if status != "invalid_query" {
+		t.Fatalf("status=%v", status)
+	}
+}
+
+func TestValidateDashboard_SavedDashboardUnwrap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/dashboards/") {
+			_, _ = w.Write([]byte(`{"dashboard":{"id":"dash-1","name":"Saved","panels":[{"id":"p1","visualization":{"type":"stat"},"queries":[{"query_type":"promql","expr":"up"}]}]}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"result":[{"metric":{},"value":[1,"1"]}]}}`))
+	}))
+	defer srv.Close()
+
+	cfg := testDashboardConfig(srv.URL)
+	cfg.PrometheusReadURL = "http://prom.example"
+	handler := NewValidateDashboardHandler(srv.Client(), cfg)
+	id := "dash-1"
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ValidateDashboardArgs{
+		DashboardID:  &id,
+		StartTimeISO: "2026-09-10T08:00:00Z",
+		EndTimeISO:   "2026-09-10T09:00:00Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report map[string]any
+	_ = json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &report)
+	if report["success"] != true {
+		t.Fatalf("%v", report)
+	}
+	dash := report["dashboard"].(map[string]any)
+	if dash["source"] != "saved" || dash["id"] != "dash-1" {
+		t.Fatalf("dashboard=%v", dash)
+	}
+}
+
+func TestValidateDashboard_UnsupportedLogQL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("log_ql should not execute")
+	}))
+	defer srv.Close()
+
+	handler := NewValidateDashboardHandler(srv.Client(), testDashboardConfig(srv.URL))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ValidateDashboardArgs{
+		DashboardDefinition: map[string]any{
+			"panels": []any{
+				map[string]any{
+					"queries": []any{
+						map[string]any{"query_type": "log_ql", "expr": `{app="x"}[5m]`},
+					},
+				},
+			},
+		},
+		StartTimeISO: "2026-09-10T08:00:00Z",
+		EndTimeISO:   "2026-09-10T09:00:00Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report map[string]any
+	_ = json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &report)
+	if report["summary"].(map[string]any)["overall"] != "partial" {
+		t.Fatalf("%v", report["summary"])
+	}
+}
+
+func TestValidateDashboard_NonListPanelsFailClosed(t *testing.T) {
+	handler := NewValidateDashboardHandler(http.DefaultClient, testDashboardConfig("http://127.0.0.1:9"))
+	result, _, err := handler(context.Background(), &mcp.CallToolRequest{}, ValidateDashboardArgs{
+		DashboardDefinition: map[string]any{
+			"panels": map[string]any{"bad": true},
+		},
+		StartTimeISO: "2026-09-10T08:00:00Z",
+		EndTimeISO:   "2026-09-10T09:00:00Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report map[string]any
+	_ = json.Unmarshal([]byte(result.Content[0].(*mcp.TextContent).Text), &report)
+	if report["success"] != false || report["error"] != "invalid_input" {
+		t.Fatalf("%v", report)
+	}
+}

--- a/internal/dashboards/validate_dashboard_variables.go
+++ b/internal/dashboards/validate_dashboard_variables.go
@@ -1,0 +1,186 @@
+package dashboards
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// Pure dashboard-variable interpolation.
+// Port of agents/supervisor/skills/dashboard_validation/variables.py.
+
+// Bare form requires a leading letter/underscore so label_replace capture
+// groups like "$1" are left alone.
+var varRefRe = regexp.MustCompile(
+	`\$\{(?P<braced>[a-zA-Z_]\w*)\}` +
+		`|\$(?P<bare>[a-zA-Z_]\w*)` +
+		`|\[\[(?P<bracketed>[a-zA-Z_]\w*)\]\]` +
+		`|\{\{(?P<mustache>[a-zA-Z_]\w*)\}\}`,
+)
+
+// Grafana built-in variables commonly present in imported dashboards.
+var builtinDefaults = map[string]string{
+	"__rate_interval": "5m",
+	"__interval":      "1m",
+	"__interval_ms":   "60000",
+	"__range":         "1h",
+	"__range_s":       "3600",
+	"__range_ms":      "3600000",
+}
+
+func matchVarName(m []string) string {
+	// Subexp names: braced, bare, bracketed, mustache at indices 1..4
+	for i := 1; i < len(m); i++ {
+		if m[i] != "" {
+			return m[i]
+		}
+	}
+	return ""
+}
+
+// dashboardDefaults extracts default values from the dashboard's variables block.
+func dashboardDefaults(dashboard map[string]any) map[string]any {
+	defaults := map[string]any{}
+	rawVars := dashboard["variables"]
+	vars, ok := rawVars.([]any)
+	if !ok {
+		if typed, ok := rawVars.([]map[string]any); ok {
+			vars = make([]any, len(typed))
+			for i, v := range typed {
+				vars[i] = v
+			}
+		} else {
+			return defaults
+		}
+	}
+	for _, raw := range vars {
+		v, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		target, _ := v["target"].(string)
+		if target == "" {
+			target, _ = v["name"].(string)
+		}
+		if target == "" {
+			continue
+		}
+		var chosen any
+		if current := asAnySlice(v["current_values"]); len(current) > 0 {
+			chosen = current[0]
+		} else if values := asAnySlice(v["values"]); len(values) > 0 {
+			chosen = values[0]
+		}
+		if chosen != nil {
+			defaults[target] = chosen
+		}
+	}
+	return defaults
+}
+
+// interpolate returns (interpolatedExpr, used, unresolvedNames).
+// used maps variable name -> {"value": ..., "source": "caller"|"dashboard_default"|"builtin_default"}.
+func interpolate(expr string, callerVars, defaults map[string]any) (string, map[string]map[string]any, []string) {
+	used := map[string]map[string]any{}
+	var unresolved []string
+
+	resolve := func(name string) (string, bool) {
+		var value any
+		var source string
+		if v, ok := callerVars[name]; ok {
+			value, source = v, "caller"
+		} else if v, ok := defaults[name]; ok {
+			value, source = v, "dashboard_default"
+		} else if v, ok := builtinDefaults[name]; ok {
+			value, source = v, "builtin_default"
+		} else {
+			return "", false
+		}
+		used[name] = map[string]any{"value": value, "source": source}
+		return stringifyScalar(value), true
+	}
+
+	out := varRefRe.ReplaceAllStringFunc(expr, func(match string) string {
+		sub := varRefRe.FindStringSubmatch(match)
+		name := matchVarName(sub)
+		resolved, ok := resolve(name)
+		if !ok {
+			for _, u := range unresolved {
+				if u == name {
+					return match
+				}
+			}
+			unresolved = append(unresolved, name)
+			return match
+		}
+		return resolved
+	})
+	return out, used, unresolved
+}
+
+// interpolatePipeline interpolates every string inside a pipeline structure.
+func interpolatePipeline(pipeline any, callerVars, defaults map[string]any) (any, map[string]map[string]any, []string) {
+	used := map[string]map[string]any{}
+	var unresolved []string
+
+	var walk func(any) any
+	walk = func(node any) any {
+		switch n := node.(type) {
+		case string:
+			out, u, unres := interpolate(n, callerVars, defaults)
+			for k, v := range u {
+				used[k] = v
+			}
+			for _, name := range unres {
+				found := false
+				for _, existing := range unresolved {
+					if existing == name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					unresolved = append(unresolved, name)
+				}
+			}
+			return out
+		case []any:
+			out := make([]any, len(n))
+			for i, x := range n {
+				out[i] = walk(x)
+			}
+			return out
+		case map[string]any:
+			out := make(map[string]any, len(n))
+			for k, v := range n {
+				out[k] = walk(v)
+			}
+			return out
+		default:
+			return node
+		}
+	}
+	return walk(pipeline), used, unresolved
+}
+
+func stringifyScalar(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		if t == float64(int64(t)) {
+			return strconv.FormatInt(int64(t), 10)
+		}
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(t)
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case bool:
+		return strconv.FormatBool(t)
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(t)
+	}
+}

--- a/internal/prompts/descriptions/validate_dashboard.md
+++ b/internal/prompts/descriptions/validate_dashboard.md
@@ -1,3 +1,5 @@
 Read-only validation of a Last9 dashboard: lints and executes every panel query in a bounded time window and classifies each result (data / no data / invalid / error). Accepts exactly one of dashboard_id (saved dashboard) or dashboard_definition (unsaved inline definition — a true dry run, nothing is persisted). Window must be ≤ 24h. Never mutates anything.
 
+Panel and target execution is sequential; large dashboards may be slow or hit client timeouts.
+
 Day-1 note: empty results classify as valid_no_data with diagnosis null; evidence-backed empty-result probes are a follow-up.

--- a/internal/prompts/descriptions/validate_dashboard.md
+++ b/internal/prompts/descriptions/validate_dashboard.md
@@ -1,0 +1,3 @@
+Read-only validation of a Last9 dashboard: lints and executes every panel query in a bounded time window and classifies each result (data / no data / invalid / error). Accepts exactly one of dashboard_id (saved dashboard) or dashboard_definition (unsaved inline definition — a true dry run, nothing is persisted). Window must be ≤ 24h. Never mutates anything.
+
+Day-1 note: empty results classify as valid_no_data with diagnosis null; evidence-backed empty-result probes are a follow-up.

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -122,6 +122,9 @@ var ListDashboardsDescription string
 //go:embed descriptions/get_dashboard.md
 var GetDashboardDescription string
 
+//go:embed descriptions/validate_dashboard.md
+var ValidateDashboardDescription string
+
 //go:embed descriptions/create_dashboard.md
 var CreateDashboardDescription string
 

--- a/internal/toolsets/toolsets.go
+++ b/internal/toolsets/toolsets.go
@@ -61,6 +61,7 @@ var named = map[string][]string{
 	"dashboards": {
 		"list_dashboards",
 		"get_dashboard",
+		"validate_dashboard",
 		"create_dashboard",
 		"update_dashboard",
 		"delete_dashboard",

--- a/internal/toolsets/toolsets_test.go
+++ b/internal/toolsets/toolsets_test.go
@@ -69,10 +69,23 @@ func TestParseInvestigate(t *testing.T) {
 			t.Errorf("investigate missing %q", want)
 		}
 	}
-	for _, deny := range []string{"get_alerts", "get_alert_groups", "list_dashboards", "create_dashboard", "add_drop_rule", "list_dashboard_snapshots"} {
+	for _, deny := range []string{"get_alerts", "get_alert_groups", "list_dashboards", "create_dashboard", "add_drop_rule", "list_dashboard_snapshots", "validate_dashboard"} {
 		if set.Allows(deny) {
 			t.Errorf("investigate should exclude %q", deny)
 		}
+	}
+}
+
+func TestParseDashboardsIncludesValidate(t *testing.T) {
+	set, err := Parse("dashboards")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !set.Allows("validate_dashboard") || !set.Allows("get_dashboard") {
+		t.Fatal("dashboards toolset missing validate_dashboard or get_dashboard")
+	}
+	if set.Allows("get_logs") {
+		t.Fatal("dashboards should not include get_logs")
 	}
 }
 

--- a/tools.go
+++ b/tools.go
@@ -295,6 +295,12 @@ func registerAllTools(server *last9mcp.Last9MCPServer, cfg models.Config) error 
 	}, dashboards.NewGetDashboardHandler(client, cfg)))
 
 	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
+		Name:        "validate_dashboard",
+		Description: prompts.ValidateDashboardDescription,
+		InputSchema: dashboards.GetValidateDashboardInputSchema(),
+	}, dashboards.NewValidateDashboardHandler(client, cfg)))
+
+	reg(registerIfAllowed(server, cfg.AllowedTools, &mcp.Tool{
 		Name:        "create_dashboard",
 		Description: prompts.CreateDashboardDescription,
 		InputSchema: dashboards.GetCreateDashboardInputSchema(),

--- a/tools_test.go
+++ b/tools_test.go
@@ -152,7 +152,10 @@ func TestRegisterAllTools_ExposesDashboardObjectSchemas(t *testing.T) {
 		t.Fatalf("update_dashboard InputSchema mismatch:\ngot  %v\nwant %v", got, want)
 	}
 
-	for _, name := range []string{"list_dashboard_snapshots", "get_dashboard_snapshot", "delete_dashboard_snapshot"} {
+	for _, name := range []string{"list_dashboard_snapshots", "get_dashboard_snapshot", "delete_dashboard_snapshot", "validate_dashboard"} {
 		_ = toolByName(t, list.Tools, name)
+	}
+	if got, want := schemaAsMap(t, toolByName(t, list.Tools, "validate_dashboard").InputSchema), schemaAsMap(t, dashboards.GetValidateDashboardInputSchema()); !reflect.DeepEqual(got, want) {
+		t.Fatalf("validate_dashboard InputSchema mismatch:\ngot  %v\nwant %v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- Add read-only MCP tool `validate_dashboard` in the `dashboards` toolset: lint + execute + classify for a saved id or inline definition over a ≤24h window.
- Returns `dashboard_validation/v1` in-process against Levitate (no supervisor / mithai). Dry run — never mutates dashboards.
- Day-1: empty execute → `valid_no_data` with `diagnosis: null` (diagnose probes = ENG-1915 / U6 follow-up).

## Test plan
- [x] `go test ./internal/dashboards/ ./internal/toolsets/ . -run 'TestValidate|TestSummarize|TestInterpolate|TestLint|TestParse|TestDump|TestRegisterAllTools'`
- [x] Tool present for `dashboards` / `all`; absent from `investigate` / `logs`
- [ ] Optional live: HTTP MCP `tools/call validate_dashboard` against a known dashboard / inline `up`

Linear: [ENG-1914](https://linear.app/last9/issue/ENG-1914) · parent [ENG-1804](https://linear.app/last9/issue/ENG-1804)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/last9/codesmith/last9-mcp-server/pr/275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791627708&installation_model_id=433497&pr_number=275&repository=last9%2Flast9-mcp-server&return_to=https%3A%2F%2Fgithub.com%2Flast9%2Flast9-mcp-server%2Fpull%2F275&signature=792f07cd92685602ba02c4a2b56a86534970fad40a0dacfdbb227980f73abcba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->